### PR TITLE
[#1806] Drop the orphaned engine-backed immediate migration lane

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -28,8 +28,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `zcash_client_sqlite::pool_migration`, both on librustzcash main; the family pin
   targets a plain main rev — boundary-anchor proving (#2710) and owner-keyed
   note locking (#2716) are both merged, nothing unmerged remains):
-  21 of the 24 `zcashlc_migration_*` entry points (the residual-locking pair
-  and the run-count estimate ride their own entries below) plus the
+  21 of the 30 `zcashlc_migration_*` entry points (the residual-locking pair,
+  the run-count estimate, the per-transaction statuses, the four Keystone
+  batch-signing members, and the debug fast-reschedule ride their own entries
+  below) plus the
   `zcashlc_ironwood_activation_height` helper, with their `#[repr(C)]` return
   types and `zcashlc_free_migration_*` destructors. Each call opens the wallet database and
   the account-keyed migration store (a second connection into the same file) from

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -448,8 +448,7 @@ fn reconcile_mined(ctx: &mut CallCtx) -> anyhow::Result<Option<MigrationState>> 
 
 /// Computes a fresh preview plan against the account's live balance and caches it under a fresh
 /// [`migration_plan_cache::PlanHandle`] (a later commit echoes the handle back and signs exactly
-/// this plan, not an independently re-randomized one). `immediate` records that the preview came
-/// through the immediate lane, so the commit rewrites the transfer schedule to "all due at once".
+/// this plan, not an independently re-randomized one).
 ///
 /// Returns the plan alongside the tip at plan time (the "now" reference the schedule encoders
 /// stamp into `FfiTransferProposal::anchor_height` and measure durations from) and the handle
@@ -459,16 +458,11 @@ fn reconcile_mined(ctx: &mut CallCtx) -> anyhow::Result<Option<MigrationState>> 
 /// dust floor) — the "ask rust whether anything remains" answer after a completed run.
 fn plan_and_cache(
     ctx: &mut CallCtx,
-    immediate: bool,
 ) -> anyhow::Result<Option<(MigrationPlan, BlockHeight, migration_plan_cache::PlanHandle)>> {
     match compute_plan(ctx)? {
         Some((plan, reference_height)) => {
-            let handle = migration_plan_cache::set(
-                ctx.db_path.clone(),
-                ctx.account_bytes,
-                plan.clone(),
-                immediate,
-            );
+            let handle =
+                migration_plan_cache::set(ctx.db_path.clone(), ctx.account_bytes, plan.clone());
             Ok(Some((plan, reference_height, handle)))
         }
         None => Ok(None),
@@ -700,9 +694,6 @@ fn encode_schedule_from_state(
 /// and is durable, so there is nothing left the handle could protect. `sign` picks the
 /// `commit_preparation` / `build_preparation_unsigned` variant. A terminal stored run (a
 /// completed or cancelled previous migration) is REPLACED — that is the sequential-runs path.
-/// When the cached preview came through the immediate lane, the committed transfers' scheduled
-/// heights are rewritten to the commit tip (everything due at once; preparation mining order
-/// still gates transfers via their dependencies).
 fn commit_or_resume(
     ctx: &mut CallCtx,
     usk: Option<zcash_keys::keys::UnifiedSpendingKey>,
@@ -2031,7 +2022,7 @@ pub unsafe extern "C" fn zcashlc_migration_prepare_note_split(
 ) -> *mut FfiNoteSplitProposal {
     let res = catch_panic(|| {
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let (values, fee, proposal_handle) = match plan_and_cache(&mut ctx, false)? {
+        let (values, fee, proposal_handle) = match plan_and_cache(&mut ctx)? {
             Some((plan, _, handle)) => {
                 let split = plan.denominations();
                 let values: Vec<i64> = split
@@ -2335,59 +2326,9 @@ pub unsafe extern "C" fn zcashlc_migration_propose_transfers(
 ) -> *mut FfiMigrationSchedule {
     let res = catch_panic(|| {
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        match plan_and_cache(&mut ctx, false)? {
+        match plan_and_cache(&mut ctx)? {
             Some((plan, reference_height, handle)) => {
                 encode_schedule_from_plan(&plan, reference_height, handle)
-            }
-            None => Ok(encode_empty_schedule()),
-        }
-    });
-    unwrap_exc_or_null(res)
-}
-
-/// Like `zcashlc_migration_propose_transfers`, but the previewed plan is marked IMMEDIATE: at
-/// commit time every transfer's scheduled height is rewritten to the commit tip, so the whole
-/// migration drains as fast as preparation mining allows instead of over the drawn ZIP 318
-/// spread. The returned preview reflects that (every transfer executable now).
-///
-/// # Safety
-/// See [`open`]. Free the returned pointer with [`zcashlc_free_migration_schedule`].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn zcashlc_migration_propose_immediate_transfers(
-    db_data: *const u8,
-    db_data_len: usize,
-    account_uuid_bytes: *const u8,
-    network_id: u32,
-) -> *mut FfiMigrationSchedule {
-    let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        match plan_and_cache(&mut ctx, true)? {
-            Some((plan, reference_height, handle)) => {
-                // Preview mirrors the commit-time rewrite: every transfer due at the tip.
-                let rows = schedule_rows(
-                    plan.denominations().crossing_values(),
-                    plan.schedule(),
-                    prep_tx_count(&plan),
-                )?;
-                let transfers = rows
-                    .into_iter()
-                    .map(|(id, amount, _, expiry)| {
-                        Ok(FfiTransferProposal {
-                            id: u32::from(id),
-                            amount: zat_to_i64(amount),
-                            anchor_height: i64::from(u32::from(reference_height)),
-                            next_executable_after_height: i64::from(u32::from(reference_height)),
-                            expiry_height: i64::from(u32::from(expiry)),
-                        })
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()?;
-                let (transfers, transfers_len) = ptr_from_vec(transfers);
-                Ok(Box::into_raw(Box::new(FfiMigrationSchedule {
-                    transfers,
-                    transfers_len,
-                    estimated_duration_hours: 0,
-                    proposal_handle: handle,
-                })))
             }
             None => Ok(encode_empty_schedule()),
         }
@@ -2665,7 +2606,7 @@ pub unsafe extern "C" fn zcashlc_migration_restart_step(
         }
         clear_invalid_marks(&mut ctx.wallet, &ctx.account_bytes)
             .map_err(|e| anyhow!("marks clear failed: {e}"))?;
-        match plan_and_cache(&mut ctx, false)? {
+        match plan_and_cache(&mut ctx)? {
             Some((plan, reference_height, handle)) => {
                 encode_schedule_from_plan(&plan, reference_height, handle)
             }
@@ -4494,7 +4435,7 @@ mod tests {
         }
         .expect("the fixture context opens");
 
-        let (plan, _reference_height, handle) = plan_and_cache(&mut ctx, false)
+        let (plan, _reference_height, handle) = plan_and_cache(&mut ctx)
             .expect("planning must succeed")
             .expect("the funded account has a real migration plan");
         assert_ne!(handle, 0, "a real cached plan must mint a non-zero handle");
@@ -4567,10 +4508,10 @@ mod tests {
         }
         .expect("the fixture context opens");
 
-        let (_plan1, _ref1, handle1) = plan_and_cache(&mut ctx, false)
+        let (_plan1, _ref1, handle1) = plan_and_cache(&mut ctx)
             .expect("the first planning call must succeed")
             .expect("the funded account has a real migration plan");
-        let (_plan2, _ref2, handle2) = plan_and_cache(&mut ctx, false)
+        let (_plan2, _ref2, handle2) = plan_and_cache(&mut ctx)
             .expect("the second planning call must succeed")
             .expect("the funded account still has a real migration plan (nothing was spent)");
         assert_ne!(

--- a/rust/src/migration_plan_cache.rs
+++ b/rust/src/migration_plan_cache.rs
@@ -22,11 +22,6 @@
 //! stable `MIGRATION_PLAN_STALE` error (mapped to `ZcashError.migrationPlanStale` in Swift) so
 //! the app re-proposes, rather than silently recomputing a fresh, differently-randomized plan the
 //! user never saw or approved.
-//!
-//! Each entry also records whether the plan was previewed through the IMMEDIATE lane
-//! (`zcashlc_migration_propose_immediate_transfers`), so the commit path knows to rewrite the
-//! committed transfers' scheduled heights to the commit height (everything due at once) instead
-//! of keeping the drawn ZIP 318 spread.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -70,12 +65,10 @@ impl std::fmt::Display for PlanLookupError {
 
 impl std::error::Error for PlanLookupError {}
 
-/// A cached preview: the plan, the handle identifying it, and whether it was previewed through
-/// the immediate lane.
+/// A cached preview: the plan and the handle identifying it.
 #[derive(Clone)]
 pub(crate) struct CachedPlan {
     pub plan: MigrationPlan,
-    pub immediate: bool,
     handle: PlanHandle,
 }
 
@@ -90,26 +83,17 @@ fn store() -> &'static Mutex<HashMap<Key, CachedPlan>> {
 /// (each propose call replaces any prior unconsumed proposal), and returns the fresh handle that
 /// now identifies it. Any handle previously issued for the key is thereby invalidated:
 /// committing with it fails with [`PlanLookupError::Superseded`].
-pub(crate) fn set(
-    db_path: PathBuf,
-    account: [u8; 16],
-    plan: MigrationPlan,
-    immediate: bool,
-) -> PlanHandle {
+pub(crate) fn set(db_path: PathBuf, account: [u8; 16], plan: MigrationPlan) -> PlanHandle {
     let handle = loop {
         let candidate = OsRng.next_u64();
         if candidate != 0 {
             break candidate;
         }
     };
-    store().lock().unwrap_or_else(|e| e.into_inner()).insert(
-        (db_path, account),
-        CachedPlan {
-            plan,
-            immediate,
-            handle,
-        },
-    );
+    store()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert((db_path, account), CachedPlan { plan, handle });
     handle
 }
 


### PR DESCRIPTION
Removes dead scaffolding the send-max redesign left behind, and a doc comment that promised behaviour this line does not have.

Closes zcash/zcash-swift-wallet-sdk#1894.<br>Resolves zcash/zcash-swift-wallet-sdk#1894

## What was left behind

`zcashlc_migration_propose_immediate_transfers` has had no caller since the immediate lane became an ordinary send-max sweep — `proposeSendMaxTransfer(orchardOnly: true)` followed by `recordImmediateMigration`. The welding member that reached the extern went with that change and the Swift surface never grew a replacement, so the only path that passed `immediate: true` to `plan_and_cache` was itself unreachable.

The flag it set was never read. `CachedPlan.immediate` was written and never consulted (the compiler said so on every build: `` field `immediate` is never read ``), while `commit_or_resume` documented that "when the cached preview came through the immediate lane, the committed transfers' scheduled heights are rewritten to the commit tip". No code performs that rewrite on this line — the block that does exists only on `feature/ironwood-support`, which the send-max redesign superseded.

## Why remove it rather than leave it

Dead code that still compiles still gets maintained. Merging maint/v2.8.x turned up that this extern passed gross funding notes to `schedule_rows`, overstating every previewed transfer by one fee buffer — a real bug, found and fixed in a function no caller reaches. Deleting it removes the surface that invites that.

So the extern, the `plan_and_cache` parameter, the `CachedPlan` field and the false promise all go. No behaviour changes: the immediate lane that actually ships is the send-max one, untouched.

## Also here

The entry-point census in `rust/CHANGELOG.md` had drifted independently — the bullet describes 21 `zcashlc_migration_*` entry points out of a stated total of 24, but the real total is 30 once the per-transaction statuses read, the four Keystone batch-signing members and the debug fast-reschedule are counted. Corrected while adjacent.

No CHANGELOG entry for the removal itself: the extern arrived after 2.8.0-rc.1 and never appeared in a release — which is the answer to "does this need a note?".

`cargo test` 111/111, `swift test --filter OfflineTests` 691/691, fmt and clippy clean.

---

Opened with Claude Code assistance.

Resolves COR-1883