### PR TITLE
[#1932] Add host Rust build targets and make the aggregates compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,25 @@ test: test-offline ## Run the offline test suite
 .PHONY: check
 check: build test ## Build and run the offline tests
 
+# `build` links whatever FFI is already in place; these build the Rust from
+# source first, so the XCFramework matches the tree.
+.PHONY: build-all
+build-all: ffi-macos configure-local-ffi build ## Build the FFI from source, then the Swift package
+
+.PHONY: build-all-release
+build-all-release: ffi-macos configure-local-ffi build-release ## Build the FFI and the Swift package in release mode
+
+.PHONY: check-all
+check-all: build-all test ## Build everything from source and run the offline tests
+
 .PHONY: clean
 clean: ## Clean the SwiftPM build directory
 	$(SWIFT) package clean
 
+# reset-ffi last: it removes LocalPackages/, which would otherwise survive as a
+# stale copy that Package.swift keeps linking after everything else is gone.
 .PHONY: clean-all
-clean-all: clean clean-ffi ## Clean SwiftPM and FFI build artifacts
+clean-all: clean clean-ffi clean-rust reset-ffi ## Clean all artifacts and reset the FFI mode
 
 .PHONY: setup
 setup: ## Set up the development environment
@@ -143,6 +156,27 @@ format: ## Apply SwiftLint autocorrections
 swift-build: build ## Alias for `make build`
 
 # ---------------------------------------------------------------------------
+# Rust crate
+# ---------------------------------------------------------------------------
+#
+# Cargo.toml is at the repo root, so cargo runs from here. These build for the
+# host only; the ffi-* targets below cross-compile for Apple platforms.
+
+.PHONY: build-rust
+build-rust: ## Build the Rust crate for the host (debug)
+	$(CARGO) build
+
+.PHONY: build-rust-release
+build-rust-release: ## Build the Rust crate for the host (release)
+	$(CARGO) build --release
+
+# Removes target/ entirely, including the cross-compiled slices the ffi-*
+# targets build. clean-ffi preserves those on purpose.
+.PHONY: clean-rust
+clean-rust: ## Clean the Cargo build artifacts (target/)
+	$(CARGO) clean
+
+# ---------------------------------------------------------------------------
 # Rust FFI (BuildSupport/)
 # ---------------------------------------------------------------------------
 #
@@ -173,7 +207,7 @@ verify-ffi: ## Check the XCFramework exists and show its contents
 # Package.swift auto-detects LocalPackages/ and links the local FFI instead of
 # the released binary target.
 .PHONY: configure-local-ffi
-configure-local-ffi: ## Point Package.swift at the locally built FFI
+configure-local-ffi: verify-ffi ## Point Package.swift at the locally built FFI
 	mkdir -p LocalPackages
 	cp -R $(XCFRAMEWORK) LocalPackages/
 	cp $(BUILD_SUPPORT)/LocalPackages-Package.swift LocalPackages/Package.swift


### PR DESCRIPTION
Closes #1932.
Resolves MOB-1636

`Makefile` only. No Swift, Rust, or CI changes.

## What and why

The only way to compile the Rust was `ffi-macos` / `ffi-all`, which always
build release, always cross-compile to Apple triples, and then assemble an
XCFramework. There was no host build for the edit-typecheck-link loop, and no
way to clean the Cargo artifacts, since `clean-ffi` preserves `target/` on
purpose.

The aggregate targets also did not compose. Building from source took three
separate commands, and `clean-all` was the inverse of none of them: it left
both `target/` and `LocalPackages/` behind. Because `Package.swift` selects the
local FFI purely on the presence of `LocalPackages/Package.swift`, a stale
copied XCFramework survives a full clean and keeps being linked. That is not
hypothetical, see the test plan below.

## Targets

New:

| Target | Does |
|---|---|
| `build-rust` | `cargo build` (host, debug) |
| `build-rust-release` | `cargo build --release` (host) |
| `clean-rust` | `cargo clean` |
| `build-all` | `ffi-macos` then `configure-local-ffi` then `build` |
| `build-all-release` | same, but `build-release` |
| `check-all` | `build-all` then `test` |

`build-rust` / `build-rust-release` mirror the Android SDK's targets of the
same name. `Cargo.toml` is at the repo root here rather than in a crate
subdirectory, so cargo runs from the root with no directory to change into.

Changed:

- `clean-all` gains `clean-rust` and `reset-ffi`, making it the inverse of
  `build-all`.
- `configure-local-ffi` now depends on `verify-ffi`, so a missing XCFramework
  reports `Error: BuildSupport/products/libzcashlc.xcframework not found`
  instead of a bare `cp: No such file or directory`.

## Test plan

Ran on macOS with Xcode 16, Swift 6.2.3, cargo 1.97.1.

- `make build-rust` builds the crate for the host: 41s against a warm cache,
  producing `target/debug/libzcashlc.a`.
- `make build-rust-release` produces `target/release/libzcashlc.a` (56MB) in
  2m16s. The `[profile.release] lto = true` link pass dominates.
- `make clean-rust`, `make clean-all`, `make build-all`, `make
  build-all-release` and `make check-all` each verified with `make -n` to
  expand to the intended chain. `clean-all` expands to `swift package clean`,
  `make -C BuildSupport clean`, `cargo clean`, `./Scripts/reset-local-ffi.sh`
  in that order.
- `make help` lists every new target.
- `configure-local-ffi` guard confirmed by running it with
  `BuildSupport/products/` absent: it now fails on `verify-ffi` with the clear
  message rather than a `cp` error.
- The stale-FFI problem reproduced directly. With a `LocalPackages/` copy from
  an older commit still in place, `make build` fails with
  `ZcashRustBackend.swift:1352:15: error: cannot convert value of type 'Void'
  to expected condition type 'Bool'`, because the stale `zcashlc.h` declares
  `zcashlc_set_transaction_status` as returning `void`. `make build-all`
  rebuilds the FFI from source and resolves it; `make clean-all` now clears
  the stale copy rather than leaving it to be linked.

No manual testnet verification applies: this changes no runtime behaviour.

## CI impact

The one change CI touches is `configure-local-ffi` gaining a `verify-ffi`
dependency. `swift.yml` already runs `make verify-ffi` immediately before
`make configure-local-ffi`, and the XCFramework exists at that point, so the
added dependency is a no-op there.

## Note, not addressed here

`-all` now means three different things across the file: "including Rust"
(`build-all`, `check-all`, matching the Android SDK convention), "all
architectures" (`ffi-all`), and "including networked tests" (`test-all`). So
`check-all` runs the offline suite while `test-all` runs the networked one.
Worth reconciling, but renaming `test-all` is out of scope.
