### PR TITLE
Replace the XCFramework slice instead of merging into it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,11 @@ clean-rust: ## Clean the Cargo build artifacts (target/)
 ffi-macos: require-macos ## Build the macOS FFI and assemble the XCFramework
 	$(MAKE) -C $(BUILD_SUPPORT) macos
 	cd $(BUILD_SUPPORT) && mkdir -p products/libzcashlc.xcframework
+	# Clear the slice first: `cp -R src dst` copies *into* dst when it already
+	# exists, which would nest the framework a level down and leave the previous
+	# build's framework — the one Info.plist names — in place, so the Swift build
+	# would compile against a stale zcashlc.h.
+	cd $(BUILD_SUPPORT) && rm -rf products/libzcashlc.xcframework/macos-arm64_x86_64
 	cd $(BUILD_SUPPORT) && cp -R products/macos/frameworks \
 		products/libzcashlc.xcframework/macos-arm64_x86_64
 	cd $(BUILD_SUPPORT) && cp Info.plist products/libzcashlc.xcframework
@@ -209,6 +214,10 @@ verify-ffi: ## Check the XCFramework exists and show its contents
 .PHONY: configure-local-ffi
 configure-local-ffi: verify-ffi ## Point Package.swift at the locally built FFI
 	mkdir -p LocalPackages
+	# Replace rather than merge: `cp -R` into an existing xcframework leaves the
+	# previous build's slices behind, so a slice that is no longer produced keeps
+	# shadowing the current one.
+	rm -rf LocalPackages/$(notdir $(XCFRAMEWORK))
 	cp -R $(XCFRAMEWORK) LocalPackages/
 	cp $(BUILD_SUPPORT)/LocalPackages-Package.swift LocalPackages/Package.swift
 	@echo "LocalPackages created; Package.swift will use the local FFI"


### PR DESCRIPTION
Closes #1943.
Resolves MOB-1648

`cp -R src dst` copies *into* `dst` when `dst` already exists. Both `ffi-macos` and `configure-local-ffi` copied onto a destination left over from the previous build, so instead of replacing the macOS slice they nested the new framework a level deeper (`macos-arm64_x86_64/frameworks/libzcashlc.framework`) and left the previous build's `macos-arm64_x86_64/libzcashlc.framework` in place — the directory the XCFramework's `Info.plist` names, and therefore the one the Swift build links.

The effect is that after any Rust change, `make ffi-macos && make configure-local-ffi && make check` compiles Swift against the *previous* `zcashlc.h`. A newly added FFI function is absent from the header, so the failure surfaces as `cannot find type 'Ffi…' in scope` at the Swift call sites, pointing away from the actual cause. A changed signature is worse: it can compile against the old declaration and fail at runtime.

Both targets now clear the destination first, matching what the `xcframework` rule in `BuildSupport/Makefile` already does.

Release artifacts were never affected — `ffi-all` goes through that rule, which already did `rm -rf $@`.

Filed against `maint/v2.7.x` because the bug is present there verbatim and reaches the later lines by merging forward. It was found while merging `zcash_client_sqlite 0.22.0-rc.7` into `feature/ironwood-slipstream` (#1941), where the same fix is carried locally so that branch's `make check` could run; that copy becomes redundant once this merges forward.

## Test plan

Behaviour of the two recipes, before and after, isolated from the ~20-minute FFI build:

```
$ # stale slice in place, then the OLD recipe (cp -R with no rm -rf)
$ cp -R src/frameworks xcf/macos-arm64_x86_64
$ cat xcf/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
STALE header                        # <- what Info.plist names, and what Swift links
$ ls xcf/macos-arm64_x86_64/
frameworks  libzcashlc.framework    # <- new copy nested and ignored

$ # the NEW recipe
$ rm -rf xcf/macos-arm64_x86_64 && cp -R src/frameworks xcf/macos-arm64_x86_64
$ cat xcf/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
NEW header
$ ls xcf/macos-arm64_x86_64/
libzcashlc.framework                # <- one slice, current
```

- `make -n ffi-macos` / `make -n configure-local-ffi` confirm both recipes expand as intended, including `$(notdir $(XCFRAMEWORK))` → `LocalPackages/libzcashlc.xcframework` (the `rm -rf` targets only the framework, not the `Package.swift` written alongside it).
- End-to-end on the merge branch where this was found: `make ffi-macos && make configure-local-ffi && make check` goes from linking a stale header to a clean 795-test offline run.
- A full FFI build was **not** re-run on this branch — the change is confined to the packaging step and CI exercises `ffi-macos` on every PR.
- No CHANGELOG entry: local and CI build tooling only, with no consumer-visible or FFI-surface effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
