### PR TITLE
D1+D2: sync gate drops its forward-looking clause; preparations prove-and-broadcast in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,31 +11,36 @@ Changes are relative to `2.8.0-rc.3`.
 ## Changed
 
 - The librustzcash family rides an interim git pin (the michal/pool-migration-public-next-due
-  branch head: the michal/pool-migration-compressed-spacing-floor branch head plus
-  `MigrationState`'s `next_due_broadcast`/`next_provable` exported as public read-only selection,
-  so this SDK's FFI can delegate its delivery-lane selection instead of reimplementing it) so a
-  wallet's own scheduled migration transactions carry their ZIP 318 classification
-  (`Overview.zip318Kind`) from the moment they are STORED at proving time, instead of only after
-  they mine and are scanned. This is what lets a wallet present its stored-but-unmined migration
-  transactions as labeled in-flight activity. The rev also carries librustzcash #2907 — the
-  engine's advance-path selection (prove/broadcast steps) picks transfers by scheduled height
-  instead of internal id — librustzcash #2910: a broadcast schedule whose slots were missed (for
-  example when the app was closed past several scheduled sends) is re-spread on resume instead of
-  coming due all at once — librustzcash #2927: the step that re-spread releases lands on scanned
-  chain data (and the re-spread fires only when more of the schedule is due behind it), so a
-  wallet driven in short foreground sessions can actually prove and broadcast the released step
-  instead of livelocking with its schedule re-pinned past the scan on every open — and the
-  compressed-schedule spacing floors (`AdvanceConfig::with_compressed_schedule_floors`): two
-  opt-in floors, under the re-spread trigger's overdue-shift tolerance and its release spacing,
-  for a consumer whose committed schedule is compressed below its own wall-clock privacy buffer —
-  this SDK's testnet. Mainnet passes the zero pair on every call, byte-identical to the engine's
-  behavior before the floors existed; the floors take effect on testnet only. It also carries
-  `MigrationState`'s public read-only next-due selection (`next_due_broadcast`/`next_provable`):
-  the engine's own delivery-lane choice, now exposed for a caller to read directly instead of
-  recomputing it client-side — pinned so this SDK's FFI can delegate to it instead of
-  reimplementing the selection. (This branch replaces that delivery-lane selection with the
-  engine's exported reads, so the drive and read lanes now agree by construction.) The pin
-  reverts to published crates at the first rc containing all of it.
+  branch head, rebased onto librustzcash main) so a wallet's own scheduled migration transactions
+  carry their ZIP 318 classification (`Overview.zip318Kind`) from the moment they are STORED at
+  proving time, instead of only after they mine and are scanned. This is what lets a wallet
+  present its stored-but-unmined migration transactions as labeled in-flight activity. The rev
+  also carries librustzcash #2907 — the engine's advance-path selection (prove/broadcast steps)
+  picks transfers by scheduled height instead of internal id — librustzcash #2910: a broadcast
+  schedule whose slots were missed (for example when the app was closed past several scheduled
+  sends) is re-spread on resume instead of coming due all at once — librustzcash #2927: the step
+  that re-spread releases lands on scanned chain data (and the re-spread fires only when more of
+  the schedule is due behind it), so a wallet driven in short foreground sessions can actually
+  prove and broadcast the released step instead of livelocking with its schedule re-pinned past
+  the scan on every open — librustzcash #2936: `advance_migration` returns the verified step
+  together with a next-wake outlook (this FFI marshals the step alone for now) — and the engine's
+  note-locking generation: a proved migration transaction's spent notes are reserved in the
+  wallet database, so an ordinary payment proposed mid-migration can no longer spend a note a
+  stored, proved transfer is already committed to. It also carries `MigrationState`'s public
+  read-only next-due selection (`next_due_broadcast`/`next_provable`): the engine's own
+  delivery-lane choice, now exposed for a caller to read directly instead of recomputing it
+  client-side — pinned so this SDK's FFI can delegate to it instead of reimplementing the
+  selection. (This branch replaces that delivery-lane selection with the engine's exported reads,
+  so the drive and read lanes now agree by construction.) The compressed-schedule spacing floors
+  (`AdvanceConfig::with_compressed_schedule_floors`) left the pinned lineage, and this SDK no
+  longer derives or passes them. The pin reverts to published crates at the first rc containing
+  all of it.
+- Restarting a migration (`restartCurrentMigrationStep`) now cancels the stored run through the
+  engine's own cancel: the run is recorded with the terminal `Cancelled` status (previously
+  `Failed`, which left a deliberate abandonment indistinguishable from a broken run) and every
+  note reservation its never-broadcast transactions held is released in the same store
+  transaction — so the fresh plan the restart previews sees the full balance immediately instead
+  of selecting around notes the abandoned run still holds until their locks expire.
 
 ## Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3610,7 +3610,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 [[package]]
 name = "pczt"
 version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "bech32",
  "bs58",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "arti-client",
  "base64",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "bech32",
  "bip32",
@@ -7979,8 +7979,9 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -7999,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8029,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8050,7 +8051,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "corez",
  "document-features",
@@ -8088,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "bip32",
  "bs58",
@@ -8181,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=5c94dcf38d6ce7233962749b85c3bb2729395fda#5c94dcf38d6ce7233962749b85c3bb2729395fda"
+source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,32 +163,30 @@ lto = true
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
-# INTERIM PIN (MOB-1466): the michal/pool-migration-public-next-due branch head (the
-# michal/pool-migration-compressed-spacing-floor branch head plus MigrationState's
-# next_due_broadcast/next_provable exported as public read-only selection, so this SDK's FFI
-# can delegate its delivery-lane selection instead of reimplementing it). Carries #2909
-# (migration transactions classified against ZIP 318 at store time — what the app's Activity
-# labels key on), #2907 (engine next_* selection ordered by height), #2910 (a missed broadcast
-# schedule is re-spread on resume), #2927 (the released overdue step lands on scanned chain
-# data, and the re-spread fires only for a due cluster — without this a short-session wallet
-# livelocks, its schedule re-pinned past the scan on every foreground), the
-# compressed-schedule spacing floors (AdvanceConfig::with_compressed_schedule_floors, opt-in
-# and default 0 = byte-identical — a re-spread on a compressed schedule otherwise leaves a
-# post-release sync window and the overdue trigger stops re-arming every drive), and
-# MigrationState's public read-only next-due selection (next_due_broadcast/next_provable — a
-# caller reads the engine's own delivery-lane choice instead of recomputing it client-side).
+# INTERIM PIN (MOB-1466): the michal/pool-migration-public-next-due branch head, rebased onto
+# librustzcash main. Main itself now carries #2909 (migration transactions classified against
+# ZIP 318 at store time — what the app's Activity labels key on), #2907 (engine next_*
+# selection ordered by height), #2910 (a missed broadcast schedule is re-spread on resume),
+# and #2936 (advance_migration returns satisfiability::Advance: the verified step plus the
+# next-wake outlook). On top of main the pin adds #2927 (the released overdue step lands on
+# scanned chain data, and the re-spread fires only for a due cluster — without this a
+# short-session wallet livelocks, its schedule re-pinned past the scan on every foreground)
+# and MigrationState's public read-only next-due selection (next_due_broadcast/next_provable —
+# a caller reads the engine's own delivery-lane choice instead of recomputing it client-side).
+# The compressed-schedule spacing floors (#2932) left this lineage when the stack was
+# restructured and are no longer carried.
 # Remove the pin (recomment the block) at the first published rc that contains all of it.
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "5c94dcf38d6ce7233962749b85c3bb2729395fda" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
 
 # Reinstate together with the voting dependencies above:
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }

--- a/Sources/ZcashLightClientKit/Migration/MigrationSyncGate.swift
+++ b/Sources/ZcashLightClientKit/Migration/MigrationSyncGate.swift
@@ -9,24 +9,26 @@ import Foundation
 /// The persisted, per-account gate that decides whether ordinary wallet sync must pause for the
 /// benefit of an in-flight migration.
 ///
-/// Three independent reasons block sync:
-/// 1. **Ready broadcast** — a PROVED, schedule-due, unexpired, valid transfer is servable RIGHT
-///    NOW: the one situation where the wallet should broadcast instead of starting a sync (ZIP
-///    318's broadcast-or-sync session split). Engine-derived (`migrationHasReadyBroadcast`) and
-///    passed in as `hasReadyBroadcast`. Deliberately NOT the broader "overdue" query
-///    (`migrationHasOverdueTransfers`): a due-but-unproved `Signed` row needs MORE syncing (its
-///    proof is produced at sync wake-ups), so it must never hold sync hostage.
-/// 2. **Privacy buffer** — for a fixed window after each broadcast, sync stays paused so the
+/// Two independent reasons block sync — both PAST/PRESENT-looking, never future:
+/// 1. **Privacy buffer** — for a fixed window after each broadcast, sync stays paused so the
 ///    broadcast is not correlated with a fresh sync. This is the `resumeAt` timestamp persisted here.
-/// 3. **Broadcast in flight** — from just before a migration submit hits the network until its
+/// 2. **Broadcast in flight** — from just before a migration submit hits the network until its
 ///    outcome is recorded, sync must not run: the engine's own in-flight sweep (inside
 ///    `migrationAdvanceStep`) would otherwise meet a transfer that is neither recorded broadcast
 ///    nor yet visible on chain. This is the `inFlightUntil` timestamp persisted here; a crash
 ///    between submit and record leaves the marker behind, and it self-expires
 ///    ``broadcastInFlightGuardDuration`` (120 s) after it was set.
 ///
-/// The gate owns the privacy-buffer and in-flight halves; the ready-broadcast half is supplied by
-/// the caller (and, for the reactive `blockedStream`, by an injected `readyBroadcastProvider`).
+/// A THIRD condition — "ready broadcast": block sync whenever a proved, schedule-due transfer was
+/// servable — lived here until 2026-08-05 and was REMOVED on danny + nuttycom's ruling (relayed by
+/// Lukas): sync is held only when a broadcast happened recently in the PAST (the buffer, and the
+/// submit-to-record marker), never because one is expected in the FUTURE. The forward-looking
+/// clause was also field-implicated in a live wedge: it blocked the very sync whose scanned
+/// progress the pending broadcast needed, freezing an awake session for 50+ minutes (FIND-5,
+/// campaign 7/8a receipts). The broadcast-or-sync session split itself is unaffected — an app
+/// open whose `next_step` answers `.broadcast` runs a no-sync delivery session (the consumer's
+/// visit classification), which is a statement about THAT session, not a hold on sync in general.
+///
 /// State is durably persisted to an atomically written JSON file, but every read in this process is
 /// served from an in-memory cache (see `cachedResumeAt`/`cachedInFlightUntil`) -- the file exists
 /// for durability across launches, not as the read path. The other in-memory mutable state is the
@@ -58,7 +60,6 @@ final class MigrationSyncGate: @unchecked Sendable {
     private let bufferDuration: TimeInterval
     private let tickInterval: TimeInterval
     private let now: @Sendable () -> Date
-    private let readyBroadcastProvider: @Sendable () async -> Bool
     private let logger: Logger
     private let blockedSubject: CurrentValueSubject<Bool, Never>
 
@@ -80,9 +81,8 @@ final class MigrationSyncGate: @unchecked Sendable {
     /// The in-memory cache of the persisted privacy-buffer expiry, guarded by `emissionLock`. Loaded
     /// once from the gate file at init; `markBroadcast()` is the only writer thereafter (persists to
     /// the file first, then updates this cache -- see `markBroadcast()` for why the file must win
-    /// that race). Every read in this process (`currentResumeAt()`, hence
-    /// `currentlyBlocked(hasReadyBroadcast:)` and `recompute()`) serves this cache rather than re-reading
-    /// the file.
+    /// that race). Every read in this process (`currentResumeAt()`, hence `currentlyBlocked()`
+    /// and `recompute()`) serves this cache rather than re-reading the file.
     ///
     /// A plain lock-guarded value suffices here, unlike `publish(_:generation:)`'s generation
     /// ordering: the writers (`markBroadcast()`, `markBroadcastInFlight()`,
@@ -149,9 +149,6 @@ final class MigrationSyncGate: @unchecked Sendable {
     ///   - tickInterval: how often the reactive stream re-evaluates (time passing alone can flip the
     ///     answer even with no data change). Injectable for tests.
     ///   - now: the clock. Injectable for tests.
-    ///   - readyBroadcastProvider: supplies the engine's "has a ready broadcast" answer (a proved,
-    ///     due, unexpired, valid transfer is servable right now) for the reactive stream; must
-    ///     degrade to `false` (never throw) on failure.
     ///   - logger: sink for the single warning emitted on a corrupt read or a failed write.
     init(
         directory: URL,
@@ -159,7 +156,6 @@ final class MigrationSyncGate: @unchecked Sendable {
         bufferDuration: TimeInterval,
         tickInterval: TimeInterval = 15,
         now: @escaping @Sendable () -> Date = { Date() },
-        readyBroadcastProvider: @escaping @Sendable () async -> Bool,
         logger: Logger
     ) {
         let url = directory.appendingPathComponent(Self.fileName(accountUUID: accountUUID))
@@ -167,7 +163,6 @@ final class MigrationSyncGate: @unchecked Sendable {
         self.bufferDuration = bufferDuration
         self.tickInterval = tickInterval
         self.now = now
-        self.readyBroadcastProvider = readyBroadcastProvider
         self.logger = logger
 
         do {
@@ -182,9 +177,9 @@ final class MigrationSyncGate: @unchecked Sendable {
         // its plausible window at this load (the A13 backwards-clock-step guard — see
         // `clampedInFlightUntil(_:now:)`), so a marker persisted before a clock step back expires
         // within `broadcastInFlightGuardDuration` of THIS launch rather than wedging sync for the
-        // whole displacement. Also seeds the synchronous subscribe-time value (buffer + in-flight
-        // only -- see `blockedStream`'s documented caveat: the first tick refines it with the real
-        // ready-broadcast signal) so subscribers get an immediate value.
+        // whole displacement. Also seeds the synchronous subscribe-time value, which is EXACT —
+        // the gate's inputs are entirely these two persisted instants — so subscribers get an
+        // immediate, correct value.
         let loadedAt = now()
         let initialInputs = Self.readGateInputs(fileURL: url, logger: logger)
         self.cachedResumeAt = initialInputs.resumeAt
@@ -192,7 +187,6 @@ final class MigrationSyncGate: @unchecked Sendable {
         self.cachedInFlightUntil = clampedInFlightUntil
         let initialBlocked = Self.isBlocked(
             now: loadedAt,
-            hasReadyBroadcast: false,
             resumeAt: initialInputs.resumeAt,
             inFlightUntil: clampedInFlightUntil
         )
@@ -223,7 +217,7 @@ final class MigrationSyncGate: @unchecked Sendable {
     /// instance's own init so the on-disk format has a single reader. The raw file values are
     /// returned UNCLAMPED — this static read has nowhere to persist a clamp, so an
     /// implausibly-far-future in-flight marker (a backwards clock-step artifact) is instead
-    /// neutralized at evaluation time by ``isBlocked(now:hasReadyBroadcast:resumeAt:inFlightUntil:)``'s
+    /// neutralized at evaluation time by ``isBlocked(now:resumeAt:inFlightUntil:)``'s
     /// plausible-window rule.
     static func persistedGateInputs(
         directory: URL,
@@ -245,10 +239,10 @@ final class MigrationSyncGate: @unchecked Sendable {
         inFlightUntil.map { min($0, now.addingTimeInterval(broadcastInFlightGuardDuration)) }
     }
 
-    /// The gate's core predicate: sync is blocked when a ready broadcast is waiting (a proved,
-    /// due, unexpired, valid transfer the wallet should serve instead of syncing), while the
-    /// privacy buffer has not yet elapsed, or while an unexpired in-flight broadcast marker
-    /// exists. Pure, so it is exhaustively table-testable.
+    /// The gate's core predicate: sync is blocked while the privacy buffer has not yet elapsed,
+    /// or while an unexpired in-flight broadcast marker exists — past/present conditions only
+    /// (see the type doc for the removed forward-looking third clause). Pure, so it is
+    /// exhaustively table-testable.
     ///
     /// The in-flight clause honors the marker only within its PLAUSIBLE window (`inFlightUntil`
     /// at most ``broadcastInFlightGuardDuration`` in the future — see
@@ -258,10 +252,7 @@ final class MigrationSyncGate: @unchecked Sendable {
     /// a fresh block forever. The marker is designed to be safe to leak, so failing open on clock
     /// weirdness matches its contract; the in-process cache paths additionally clamp (load +
     /// `currentInFlightUntil()`), which keeps the protective window instead.
-    static func isBlocked(now: Date, hasReadyBroadcast: Bool, resumeAt: Date?, inFlightUntil: Date?) -> Bool {
-        if hasReadyBroadcast {
-            return true
-        }
+    static func isBlocked(now: Date, resumeAt: Date?, inFlightUntil: Date?) -> Bool {
         if let inFlightUntil,
             now < inFlightUntil,
             inFlightUntil.timeIntervalSince(now) <= Self.broadcastInFlightGuardDuration {
@@ -380,12 +371,11 @@ final class MigrationSyncGate: @unchecked Sendable {
         return now() < inFlightUntil
     }
 
-    /// Whether sync is currently blocked, combining the supplied `hasReadyBroadcast` with the
-    /// persisted privacy buffer and in-flight broadcast marker. Never throws.
-    func currentlyBlocked(hasReadyBroadcast: Bool) -> Bool {
+    /// Whether sync is currently blocked by the persisted privacy buffer or the in-flight
+    /// broadcast marker. Never throws, never suspends — the gate's inputs are entirely local.
+    func currentlyBlocked() -> Bool {
         Self.isBlocked(
             now: now(),
-            hasReadyBroadcast: hasReadyBroadcast,
             resumeAt: currentResumeAt(),
             inFlightUntil: currentInFlightUntil()
         )
@@ -396,17 +386,10 @@ final class MigrationSyncGate: @unchecked Sendable {
     /// expiry, see `nextRecomputeDelay`) — and after every ``markBroadcast()``, and collapses
     /// consecutive duplicates.
     /// Internally synchronized: the ticker loop and every `markBroadcast()`-triggered recompute can
-    /// be in flight concurrently (both suspend awaiting the injected `readyBroadcastProvider`), but every
-    /// send is serialized and generation-ordered -- latest-wins, so a recompute that started earlier
+    /// be in flight concurrently, and every send is serialized and generation-ordered -- latest-wins, so a recompute that started earlier
     /// but finishes later after a fresher one already published is dropped rather than emitted as a
     /// stale overwrite. See `publish(_:generation:)`.
     ///
-    /// - Important: The synchronous subscribe-time seed reflects only the persisted privacy buffer
-    ///   and in-flight marker (see the `hasReadyBroadcast: false` seed in `init`) --
-    ///   ready-broadcast detection arrives with the first asynchronous recompute. On relaunch with
-    ///   a ready broadcast and no active buffer, the first emission can therefore briefly read
-    ///   `false` while a fresh `isBlocked`/`currentlyBlocked` call (which always consults the
-    ///   ready-broadcast answer) already reads `true`.
     /// - Important: Subscription-gated (finding 14): the periodic ticker only runs while at least one
     ///   subscriber is attached (`subscriberAttached()`/`subscriberDetached()`, via `handleEvents`
     ///   below), so a `blockedStream` with no subscribers costs nothing beyond the seed already
@@ -455,8 +438,7 @@ final class MigrationSyncGate: @unchecked Sendable {
     /// could leave a cleared gate unnoticed for a whole interval. On a foregrounded device that
     /// read as a dead half-minute between "gate expired" and "sync resumed", with the app doing
     /// nothing wrong. Each iteration now sleeps only until the SOONEST future boundary (plus a
-    /// small epsilon so the recompute lands strictly after the flip), capped at `tickInterval`;
-    /// ready-broadcast flips carry no deadline and keep the interval cadence as before.
+    /// small epsilon so the recompute lands strictly after the flip), capped at `tickInterval`.
     private func startTicking() {
         tickerTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -508,19 +490,17 @@ final class MigrationSyncGate: @unchecked Sendable {
     private func recompute() async {
         let generation = drawNextGeneration()
 
-        let hasReadyBroadcast = await readyBroadcastProvider()
         let blocked = Self.isBlocked(
             now: now(),
-            hasReadyBroadcast: hasReadyBroadcast,
             resumeAt: currentResumeAt(),
             inFlightUntil: currentInFlightUntil()
         )
         publish(blocked, generation: generation)
     }
 
-    /// Snapshots this recompute's generation, under `emissionLock`, at the moment it *starts* --
-    /// before the `readyBroadcastProvider` suspension point -- so `publish(_:generation:)` can later tell
-    /// whether a later-started recompute has already published.
+    /// Snapshots this recompute's generation, under `emissionLock`, at the moment it *starts*, so
+    /// `publish(_:generation:)` can later tell whether a later-started recompute has already
+    /// published.
     private func drawNextGeneration() -> UInt64 {
         emissionLock.lock()
         defer { emissionLock.unlock() }
@@ -543,7 +523,7 @@ final class MigrationSyncGate: @unchecked Sendable {
     ///
     /// - Warning: That safety is specific to the cancel path. A subscriber's synchronous
     ///   value-handling callback must never call back into `currentResumeAt()`,
-    ///   `currentlyBlocked(hasReadyBroadcast:)`, or `markBroadcast()` from inside its handler for this
+    ///   `currentlyBlocked()`, or `markBroadcast()` from inside its handler for this
     ///   emission: all three acquire `emissionLock`, which -- unlike `subscriptionLock` -- this
     ///   thread is already holding right here, and `NSLock` is non-recursive, so a same-thread
     ///   re-acquisition would deadlock. No shipped subscriber does this today (only cancellation

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
@@ -70,9 +70,9 @@ struct MigrationSpacingFloors: Equatable, Sendable {
 ///
 /// It composes three collaborators: the migration welding (the Rust engine surface), a fail-closed
 /// ``MigrationBroadcaster``, and a persisted ``MigrationSyncGate`` (the network-scaled
-/// post-broadcast privacy buffer, the in-flight broadcast marker, plus the ready-broadcast
-/// block). The engine owns all migration state, including
-/// the committed schedule; the SDK keeps no local copy of the proposal list.
+/// post-broadcast privacy buffer plus the in-flight broadcast marker — past/present holds only;
+/// see the gate's type doc for the removed forward-looking clause). The engine owns all migration
+/// state, including the committed schedule; the SDK keeps no local copy of the proposal list.
 actor OrchardMigration {
     /// The immutable configuration an ``OrchardMigration`` is built from.
     ///
@@ -318,14 +318,6 @@ actor OrchardMigration {
             directory: config.generalStorageURL,
             accountUUID: accountUUID,
             bufferDuration: OrchardMigration.privacySyncBufferDuration(for: config.network.networkType),
-            readyBroadcastProvider: {
-                // The gate's work-pending clause (D1): a PROVED, due, unexpired, valid transfer
-                // servable right now — never the broader overdue query, whose due-but-unproved
-                // `Signed` rows need MORE syncing rather than a broadcast session. Estimate-aware
-                // with the scanned tip asked FIRST (U8), degrading to "no ready broadcast" on any
-                // engine error so the reactive gate never crashes.
-                await OrchardMigration.gateReadyBroadcast(welding: welding, accountUUID: accountUUID, now: now)
-            },
             logger: logger
         )
     }
@@ -422,30 +414,10 @@ actor OrchardMigration {
     // same shared `MigrationTipEstimation` composition only for its gate/delivery due-ness
     // checks below.
 
-    /// The gate's estimate-aware work-pending clause (D1): whether a PROVED, schedule-due,
-    /// unexpired, valid transfer is servable RIGHT NOW — the one situation where the wallet
-    /// should broadcast instead of syncing. Never the broader overdue query: a due-but-unproved
-    /// `Signed` row needs MORE syncing, so it must never block sync.
-    ///
-    /// Asks at the SCANNED tip first (U8): the estimate may only ACCELERATE due-ness, so a `true`
-    /// scanned answer is final and the sample read is skipped entirely; only a `false` answer
-    /// pays for the projection and re-asks with the estimate. Any engine or estimator failure
-    /// degrades to `false`/`nil` (never blocks, never crashes the gate). Static (welding and
-    /// clock passed in) so the init-time `readyBroadcastProvider` closure can share it before
-    /// `self` exists.
-    private static func gateReadyBroadcast(
-        welding: ZcashRustBackendWelding,
-        accountUUID: AccountUUID,
-        now: @Sendable () -> Date
-    ) async -> Bool {
-        if (try? await welding.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: nil)) ?? false {
-            return true
-        }
-        guard let estimatedTip = await MigrationTipEstimation.gatingEstimatedTip(welding: welding, now: now()) else {
-            return false
-        }
-        return (try? await welding.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: estimatedTip)) ?? false
-    }
+    // (`gateReadyBroadcast` — the estimate-aware ready-broadcast probe that fed the sync gate's
+    // forward-looking clause — was deleted with that clause on 2026-08-05, danny + nuttycom's
+    // ruling; see `MigrationSyncGate`'s type doc. The `migrationHasReadyBroadcast` welding/FFI
+    // surface remains for any non-gating consumer.)
 
     // MARK: - Note splitting
 
@@ -634,22 +606,15 @@ actor OrchardMigration {
 
     /// Whether ordinary wallet sync should currently be paused for this migration.
     ///
-    /// `true` when a READY broadcast is waiting (a proved, schedule-due, unexpired, valid
-    /// transfer the wallet should serve instead of syncing — never a `Signed` or awaiting-proof
-    /// row, which needs MORE syncing), **or** the post-broadcast privacy buffer has not yet
-    /// elapsed, **or** an in-flight broadcast marker is live. The ready-broadcast query is
-    /// engine-backed and estimate-aware (scanned tip asked first — U8); if it throws, this
-    /// degrades to the persisted gate-file (privacy-buffer/in-flight) state rather than crashing
-    /// the app's sync gating.
+    /// `true` while the post-broadcast privacy buffer has not yet elapsed, **or** an in-flight
+    /// broadcast marker is live — past/present conditions only. (The forward-looking
+    /// ready-broadcast clause was removed 2026-08-05 — danny + nuttycom's ruling; see
+    /// `MigrationSyncGate`'s type doc.)
     ///
     /// - Note: The gate is per-account (by file name). An app running several migrating accounts must
     ///   consult each account's `OrchardMigration`; this instance answers only for its bound account.
-    /// - Note: Always consults the ready-broadcast query fresh (`await`s the engine), unlike
-    ///   ``syncBlockedStream``'s synchronous subscribe-time seed -- see that property's documented
-    ///   caveat about the two briefly disagreeing right after relaunch.
     func isSyncBlocked() async -> Bool {
-        let hasReadyBroadcast = await OrchardMigration.gateReadyBroadcast(welding: welding, accountUUID: accountUUID, now: now)
-        return syncGate.currentlyBlocked(hasReadyBroadcast: hasReadyBroadcast)
+        syncGate.currentlyBlocked()
     }
 
     /// A stream of ``isSyncBlocked()``: emits the current value on subscribe, re-evaluates every 15 s
@@ -662,13 +627,10 @@ actor OrchardMigration {
     /// dropped rather than emitted — subscribers only ever see values in latest-wins order, never a
     /// stale one overwriting a fresher one.
     ///
-    /// - Important: The value delivered synchronously on subscribe reflects only the persisted
-    ///   privacy buffer and in-flight marker, not ready broadcasts -- ready-broadcast detection
-    ///   needs the engine query, which is asynchronous. On relaunch with a ready broadcast and no
-    ///   active buffer, that first emission can therefore briefly read `false` while
-    ///   ``isSyncBlocked()`` already reads `true`; the stream corrects itself with its first
-    ///   asynchronous re-evaluation (the next tick, or sooner if a broadcast happens first). A
-    ///   subscriber that must be correct from its very first value should pair this stream with
+    /// - Important: The value delivered synchronously on subscribe is EXACT — the gate's inputs
+    ///   are entirely its two persisted instants (see ``MigrationSyncGate``), so the old caveat
+    ///   about a briefly-wrong first emission is gone with the ready-broadcast clause. A
+    ///   subscriber that wants a belt anyway may still pair this stream with
     ///   an initial ``isSyncBlocked()`` call rather than trusting the seed alone.
     nonisolated var syncBlockedStream: AnyPublisher<Bool, Never> {
         syncGate.blockedStream
@@ -691,9 +653,8 @@ actor OrchardMigration {
     /// delivery lane's "is there actionable work" query, counting an already-proved due
     /// transaction AND a due, dependency-satisfied `Signed` one the delivery call would drive
     /// through proving. An informational query for hosts (re-arm background execution, launch
-    /// reconciliation); deliberately NOT consulted by any sync-gate path, which asks the
-    /// narrower ready-broadcast predicate instead (a due-but-unproved row must never block
-    /// sync — see ``isSyncBlocked()``).
+    /// reconciliation) and for the app's est-aware dispatch; deliberately NOT consulted by any
+    /// sync-gate path — since 2026-08-05 NO work-pending query is (see ``isSyncBlocked()``).
     ///
     /// `useEstimatedTip` opts the check into the wall-clock chain-tip estimate: the estimate may
     /// only ACCELERATE due-ness (expiry stays scanned-tip), and an estimator failure degrades to
@@ -841,7 +802,7 @@ actor OrchardMigration {
     /// broadcast once to the resolved endpoint, and classify the outcome. On a success outcome the
     /// privacy buffer starts *before* the result is recorded — ``MigrationSyncGate/markBroadcast()``
     /// is a non-throwing local write, and a record failure after a real broadcast must never skip
-    /// the buffer; a record failure on that path throws
+    /// the buffer (TRANSFERS only — a preparation arms no buffer, D2, see the body); a record failure on that path throws
     /// ``ZcashError/migrationRecordFailedAfterBroadcast(_:)``. Non-success outcomes are recorded
     /// first and returned with the gate untouched (only success outcomes mark it, unchanged); a
     /// record throw on that path clears the in-flight marker first only for a DEFINITIVE
@@ -863,6 +824,18 @@ actor OrchardMigration {
     /// ``MigrationSyncGate/broadcastInFlightGuardDuration`` (120 s); while it lives, sync (and
     /// with it the reconciliation probe that must not observe a just-broadcast transfer) stays
     /// blocked.
+    /// Whether `id` names a note-PREPARATION of this account's run — the D2 discriminator for
+    /// the privacy-buffer exemption above. One statuses read per broadcast; a failed read
+    /// degrades to `false` (the conservative TRANSFER treatment: the buffer arms).
+    private func isPreparationTransaction(id: UInt32) async -> Bool {
+        let statuses = (try? await welding.migrationTransactionStatuses(for: accountUUID)) ?? []
+        return statuses.contains { status in
+            guard status.id == id else { return false }
+            if case .preparation = status.kind { return true }
+            return false
+        }
+    }
+
     private func broadcastAndRecord(
         prepared: PreparedMigrationTransfer,
         options: MigrationNetworkPrivacyOptions
@@ -896,7 +869,20 @@ actor OrchardMigration {
         if case MigrationTransferResult.success = result {
             // The broadcast landed (or a duplicate rejection proved an earlier one did): start the
             // privacy buffer first, so a record failure cannot skip it.
-            syncGate.markBroadcast()
+            //
+            // D2 (danny + nuttycom, 2026-08-05): the buffer is a TRANSFER separation — a
+            // note-PREPARATION is a fully shielded orchard→orchard send-to-self, ZIP-318-exempt,
+            // and the engine's own contract is "a preparation is broadcast as soon as it is
+            // proved". Arming the buffer after a prep broadcast held the very sync its next
+            // layer's mine-observation needed, doubling every split phase. A failed kind read
+            // degrades to the conservative transfer treatment (buffer arms). The in-flight
+            // marker above is UNTOUCHED either way — it guards submit-to-record correctness,
+            // not ZIP-318 pacing.
+            if await isPreparationTransaction(id: prepared.id) {
+                logger.debug("migration preparation \(prepared.id) broadcast — no privacy buffer armed (ZIP-318 exempt)")
+            } else {
+                syncGate.markBroadcast()
+            }
             do {
                 try await welding.migrationRecordTransferResult(transferId: prepared.id, result: result, for: accountUUID)
             } catch {

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
@@ -34,31 +34,6 @@ public struct MigrationNetworkPrivacyOptions: Equatable {
     }
 }
 
-/// Consumer spacing floors for a compressed migration schedule — threaded into the pinned
-/// engine's `AdvanceConfig::with_compressed_schedule_floors` via
-/// `zcashlc_migration_advance_step`'s two trailing `u32` parameters. Both fields at zero
-/// (``zero``) is the ZIP 318 verbatim behavior, byte-identical to the engine's behavior before
-/// these floors existed — what every mainnet caller passes. See
-/// ``OrchardMigration/spacingFloors(network:secondsPerBlock:)`` for how a compressed-schedule
-/// consumer (this SDK's testnet) derives nonzero values.
-///
-/// Internal: floors are derived policy, not a consumer-facing choice, so this never reaches the
-/// public `Synchronizer` surface.
-struct MigrationSpacingFloors: Equatable, Sendable {
-    /// The floor under the re-spread trigger's overdue-shift tolerance.
-    let toleranceFloor: UInt32
-    /// The floor under the re-spread release's spacing to the deferred rows behind it.
-    let releaseSpacingFloor: UInt32
-
-    /// Both floors at zero — no floor applied, byte-identical to the engine's behavior before
-    /// these floors existed. What every mainnet caller passes.
-    ///
-    /// Named `zero`, not `none`: a `static let none` on a non-Optional type shadows
-    /// `Optional.none` in optional contexts (`MigrationSpacingFloors?.none` silently means "this
-    /// value", not "no value") — a silent footgun for any future optional use of this type.
-    static let zero = MigrationSpacingFloors(toleranceFloor: 0, releaseSpacingFloor: 0)
-}
-
 /// The app-facing entry point for driving an Orchard -> Ironwood pool migration for one
 /// account.
 ///
@@ -166,53 +141,6 @@ actor OrchardMigration {
     /// network to scale by; real synchronizers forward their host's network-scaled value instead).
     static let privacySyncBufferDuration: TimeInterval = privacySyncBufferDuration(for: .mainnet)
 
-    /// The consumer spacing floors this SDK passes to the migration advance engine for `network`,
-    /// given a measured `secondsPerBlock`. Pure — no I/O, no clock, no wallet state.
-    ///
-    /// Mainnet ALWAYS answers ``MigrationSpacingFloors/zero`` — a hard requirement, not a derived
-    /// result: production mainnet callers must stay byte-identical to the floor-free engine, so
-    /// this branch never even reads `secondsPerBlock`.
-    ///
-    /// testnet/regtest derive nonzero floors because ZIP 318's schedule scale is compressed
-    /// there: a shortened test-network anchor bucket interval shrinks the schedule's own
-    /// overdue-tolerance and deferred-gap scale in proportion, while the wallet's wall-clock
-    /// privacy buffer (``privacySyncBufferDuration(for:)``) stays wall-clock-fixed — see
-    /// `AdvanceConfig::with_compressed_schedule_floors` in the pinned engine for the mechanism
-    /// this corrects. The buffer is a WALL-CLOCK quantity; converting it to a block count needs
-    /// `secondsPerBlock`: `bufferBlocks = ceil(privacyBuffer / secondsPerBlock)`.
-    ///
-    /// `toleranceFloor` is `bufferBlocks + 2`: the re-spread trigger must not be able to re-arm
-    /// inside less than one privacy buffer's worth of blocks, plus 2 blocks of slack for
-    /// estimation error in `secondsPerBlock`.
-    ///
-    /// A shift whose lag is at or below `toleranceFloor` is suppressed outright — the re-spread
-    /// trigger does not re-arm, so the backlog stays at its compressed drawn gaps for that drive.
-    /// Accepted: suppression only ever covers a lag up to roughly one buffer, and the next drive
-    /// whose lag clears the floor re-spreads with the full `releaseSpacingFloor` window below.
-    ///
-    /// `releaseSpacingFloor` is `2 * bufferBlocks + 2`: before the NEXT transfer may come due,
-    /// the just-released one needs its own post-broadcast sync buffer, then a sync session, then
-    /// the sync-to-send buffer ahead of the next send — two buffers' worth of blocks end to end,
-    /// not one, hence the doubling — plus the same 2-block estimation slack.
-    ///
-    /// `secondsPerBlock` should be the SDK's own measured seconds-per-block — the same value the
-    /// wall-clock chain-tip estimate rides (``ChainTipEstimator/secondsPerBlock()`` /
-    /// ``OrchardMigrationHost/estimatedSecondsPerBlock()``). Where a caller has no measurement in
-    /// reach, pass ``ChainTipEstimator/fallbackSecondsPerBlock`` (the nominal 75 s Zcash target
-    /// block spacing) instead.
-    static func spacingFloors(network: NetworkType, secondsPerBlock: Double) -> MigrationSpacingFloors {
-        switch network {
-        case .mainnet:
-            return MigrationSpacingFloors.zero
-        case .testnet, .regtest:
-            let bufferBlocks = UInt32((privacySyncBufferDuration(for: network) / secondsPerBlock).rounded(.up))
-            return MigrationSpacingFloors(
-                toleranceFloor: bufferBlocks + 2,
-                releaseSpacingFloor: 2 * bufferBlocks + 2
-            )
-        }
-    }
-
     /// The NU6.3 (Ironwood) activation height for `networkType`, or `nil` when NU6.3 is unset for
     /// that network. Stateless — no database access, and safe to call before constructing an
     /// ``OrchardMigration``.
@@ -233,11 +161,6 @@ actor OrchardMigration {
     private let broadcaster: any MigrationBroadcasting
     private let syncGate: MigrationSyncGate
     private let logger: Logger
-
-    /// This account's network — the sole input to ``OrchardMigration/spacingFloors(network:secondsPerBlock:)``.
-    /// Mainnet here is a hard requirement, not a default: every mainnet-built actor passes
-    /// ``MigrationSpacingFloors/zero`` on every advance step, unconditionally.
-    private let network: NetworkType
 
     /// The clock every estimate-consulting path on this actor reads (mirroring
     /// ``OrchardMigrationHost``'s injected `now`), so tests can drive the wall-clock tip
@@ -313,7 +236,6 @@ actor OrchardMigration {
         self.logger = logger
         self.broadcaster = sharedBroadcaster
         self.now = now
-        self.network = config.network.networkType
         self.syncGate = MigrationSyncGate(
             directory: config.generalStorageURL,
             accountUUID: accountUUID,
@@ -325,17 +247,14 @@ actor OrchardMigration {
     /// Injecting initializer for tests: supply the welding, broadcaster, sync gate (with its test
     /// clock/ticker), logger, and — for the actor's own estimate-consulting paths — a clock,
     /// directly. `now` defaults to the real clock so call sites that do not exercise the
-    /// estimate stay unchanged. `network` defaults to `.mainnet` — ``MigrationSpacingFloors/zero``
-    /// on every advance step — so call sites that do not exercise the spacing-floor derivation
-    /// stay unchanged; a test exercising testnet's nonzero floors passes `.testnet` explicitly.
+    /// estimate stay unchanged.
     init(
         welding: ZcashRustBackendWelding,
         accountUUID: AccountUUID,
         broadcaster: any MigrationBroadcasting,
         syncGate: MigrationSyncGate,
         logger: Logger,
-        now: @escaping @Sendable () -> Date = { Date() },
-        network: NetworkType = .mainnet
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.welding = welding
         self.accountUUID = accountUUID
@@ -343,7 +262,6 @@ actor OrchardMigration {
         self.syncGate = syncGate
         self.logger = logger
         self.now = now
-        self.network = network
     }
 
     // MARK: - State
@@ -352,25 +270,9 @@ actor OrchardMigration {
     /// and wall-clock estimated target. `nil` means no run is stored; a
     /// terminal (complete or cancelled) run reports ``MigrationAdvanceStep/complete``. See
     /// ``MigrationAdvanceStep`` for the step semantics and the discharge mapping.
-    ///
-    /// Also derives this account's ``MigrationSpacingFloors`` (see
-    /// ``OrchardMigration/spacingFloors(network:secondsPerBlock:)``) from the SAME chain-tip
-    /// projection that produces `estimatedTip`, so the floor derivation costs no extra sample
-    /// read. A failed projection degrades `secondsPerBlock` to
-    /// ``ChainTipEstimator/fallbackSecondsPerBlock`` exactly as it degrades `estimatedTip` to
-    /// `nil` — inlined here (rather than going through ``MigrationTipEstimation/gatingEstimatedTip(welding:now:)``)
-    /// only so both values come from the one read.
     func advanceStep() async throws -> MigrationAdvanceStep? {
-        let projection = try? await MigrationTipEstimation.project(welding: welding, now: now())
-        let spacingFloors = OrchardMigration.spacingFloors(
-            network: network,
-            secondsPerBlock: projection?.secondsPerBlock ?? ChainTipEstimator.fallbackSecondsPerBlock
-        )
-        return try await welding.migrationAdvanceStep(
-            for: accountUUID,
-            estimatedTip: projection?.estimatedTip,
-            spacingFloors: spacingFloors
-        )
+        let estimatedTip = await MigrationTipEstimation.gatingEstimatedTip(welding: welding, now: now())
+        return try await welding.migrationAdvanceStep(for: accountUUID, estimatedTip: estimatedTip)
     }
 
     /// Live migration progress, or `nil` when no snapshot is reportable: present only while an

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigrationHost.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigrationHost.swift
@@ -270,12 +270,11 @@ actor OrchardMigrationHost {
 
         let evaluatedAt = now()
 
-        // Pass 1 — no estimate: gate files, live gate views, and the SCANNED-tip ready-broadcast
-        // answer. Any block here makes the estimate unnecessary (it can only accelerate).
+        // Gate files + live gate views only — past/present holds (privacy buffer, in-flight
+        // marker). The per-account ready-broadcast probe (and the whole estimate-aware second
+        // pass it needed) was deleted with the gate's forward-looking clause on 2026-08-05 —
+        // danny + nuttycom's ruling; see `MigrationSyncGate`'s type doc.
         for account in accounts {
-            // Degrade to "no ready broadcast" on any engine error, exactly like
-            // OrchardMigration.isSyncBlocked().
-            let hasReadyBroadcast = (try? await welding.migrationHasReadyBroadcast(for: account.id, estimatedTip: nil)) ?? false
             let fileInputs = MigrationSyncGate.persistedGateInputs(
                 directory: generalStorageURL,
                 accountUUID: account.id,
@@ -283,7 +282,6 @@ actor OrchardMigrationHost {
             )
             let fileBlocked = MigrationSyncGate.isBlocked(
                 now: evaluatedAt,
-                hasReadyBroadcast: hasReadyBroadcast,
                 resumeAt: fileInputs.resumeAt,
                 inFlightUntil: fileInputs.inFlightUntil
             )
@@ -293,7 +291,6 @@ actor OrchardMigrationHost {
             let liveBlocked = liveGateRegistry.inputs(for: account.id).map { liveInputs in
                 MigrationSyncGate.isBlocked(
                     now: evaluatedAt,
-                    hasReadyBroadcast: hasReadyBroadcast,
                     resumeAt: liveInputs.resumeAt,
                     inFlightUntil: liveInputs.inFlightUntil
                 )
@@ -301,15 +298,6 @@ actor OrchardMigrationHost {
             if fileBlocked || liveBlocked {
                 return true
             }
-        }
-
-        // Pass 2 — nothing blocked at the scanned tip: project the estimate ONCE and re-ask the
-        // ready-broadcast question per account (U8). Only a `false` scanned answer can flip.
-        guard let estimatedTip = await MigrationTipEstimation.gatingEstimatedTip(welding: welding, now: evaluatedAt) else {
-            return false
-        }
-        for account in accounts where (try? await welding.migrationHasReadyBroadcast(for: account.id, estimatedTip: estimatedTip)) ?? false {
-            return true
         }
         return false
     }

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1476,17 +1476,13 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
 
     @DBActor
     func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvanceStep? {
-        // The bare compatibility overload: scanned target only, and — matching that — no
-        // compressed-schedule policy either. `MigrationSpacingFloors.zero` is the ZIP
-        // 318-verbatim behavior, identical to this call's behavior before the floors existed.
-        try await migrationAdvanceStep(for: account, estimatedTip: nil, spacingFloors: MigrationSpacingFloors.zero)
+        try await migrationAdvanceStep(for: account, estimatedTip: nil)
     }
 
     @DBActor
     func migrationAdvanceStep(
         for account: AccountUUID,
-        estimatedTip: BlockHeight?,
-        spacingFloors: MigrationSpacingFloors
+        estimatedTip: BlockHeight?
     ) async throws -> MigrationAdvanceStep? {
         // Clear any stale, unconsumed last-error before this sentinel read (see
         // `migrationIsNoteSplitNeeded` below): a NULL return overloads "no stored run" and
@@ -1498,9 +1494,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
             dbData.1,
             account.id,
             networkType.networkId,
-            estimatedTip.map(Int64.init) ?? -1,
-            spacingFloors.toleranceFloor,
-            spacingFloors.releaseSpacingFloor
+            estimatedTip.map(Int64.init) ?? -1
         )
 
         // NULL with no recorded error is the benign "no migration run is stored" answer (the

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -428,15 +428,9 @@ protocol ZcashRustBackendWelding {
 
     /// Estimate-aware drive entry point. `estimatedTip` is the wall-clock chain-tip estimate;
     /// destructive judgments remain anchored to the wallet's fully-scanned height upstream.
-    /// `spacingFloors` passes straight through to the pinned engine's
-    /// `AdvanceConfig::with_compressed_schedule_floors`: ``MigrationSpacingFloors/zero`` (both
-    /// fields zero) is byte-identical to this call's behavior before the floors existed — what
-    /// every mainnet caller passes. See ``OrchardMigration/spacingFloors(network:secondsPerBlock:)``
-    /// for how a compressed-schedule consumer derives a nonzero pair.
     func migrationAdvanceStep(
         for account: AccountUUID,
-        estimatedTip: BlockHeight?,
-        spacingFloors: MigrationSpacingFloors
+        estimatedTip: BlockHeight?
     ) async throws -> MigrationAdvanceStep?
 
     /// Live migration progress, or `nil` when no snapshot is reportable: present only while an
@@ -846,16 +840,9 @@ protocol ZcashRustBackendWelding {
 }
 
 extension ZcashRustBackendWelding {
-    /// The estimate-and-floors overload's default body: forwards to the plain
-    /// ``migrationAdvanceStep(for:)`` compatibility overload, discarding BOTH `estimatedTip` and
-    /// `spacingFloors` — exactly as it already discarded `estimatedTip` before floors existed.
-    /// `migrationAdvanceStep(for:)` has no floors concept of its own (the ZIP 318-verbatim,
-    /// scanned-target-only path), so a conformer that only implements it and relies on this
-    /// default never applies a floor, on any network.
     func migrationAdvanceStep(
         for account: AccountUUID,
-        estimatedTip: BlockHeight?,
-        spacingFloors: MigrationSpacingFloors
+        estimatedTip: BlockHeight?
     ) async throws -> MigrationAdvanceStep? {
         try await migrationAdvanceStep(for: account)
     }

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -908,7 +908,6 @@ final class MigrationFFITests: XCTestCase {
                 accountUUID: account,
                 bufferDuration: 600,
                 tickInterval: 3600,
-                readyBroadcastProvider: { false },
                 logger: logger
             ),
             logger: logger
@@ -985,7 +984,7 @@ final class MigrationFFITests: XCTestCase {
     /// every migration FFI call on a `.regtest`/custom network id (2) throws "custom network (id 2)
     /// used before it was configured" (see `rust/src/lib.rs`'s `parse_network`), which
     /// `migrationAdvanceStep()` surfaces as `rustMigrationAdvanceStep`, and which
-    /// `isSyncBlocked()`/the gate's `readyBroadcastProvider` silently swallow via `try?` instead (finding
+    /// `isSyncBlocked()`-style callers silently swallow via `try?` instead (finding
     /// 5's "migration dead on .custom/.regtest").
     ///
     /// `NetworkActivationHeights` here intentionally matches

--- a/Tests/OfflineTests/MigrationLogicTests.swift
+++ b/Tests/OfflineTests/MigrationLogicTests.swift
@@ -24,28 +24,35 @@ final class MigrationLogicTests: ZcashTestCase {
     func testGateBlockedImmediatelyAfterMark() {
         // The +600 s buffer starts at `now`, so `now` itself is inside the blocked window.
         let resumeAt = referenceDate.addingTimeInterval(buffer)
-        XCTAssertTrue(MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: false, resumeAt: resumeAt, inFlightUntil: nil))
+        XCTAssertTrue(MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: resumeAt, inFlightUntil: nil))
     }
 
     func testGateUnblocksAtExactlyBufferBoundary() {
         // At exactly `resumeAt` the buffer has elapsed: `now < resumeAt` is false.
         let resumeAt = referenceDate.addingTimeInterval(buffer)
-        XCTAssertFalse(MigrationSyncGate.isBlocked(now: resumeAt, hasReadyBroadcast: false, resumeAt: resumeAt, inFlightUntil: nil))
+        XCTAssertFalse(MigrationSyncGate.isBlocked(now: resumeAt, resumeAt: resumeAt, inFlightUntil: nil))
     }
 
-    func testGateReadyBroadcastForcesBlockedEvenAfterBufferElapsed() {
+    /// D1 (danny + nuttycom, 2026-08-05): the forward-looking ready-broadcast clause is GONE.
+    /// The gate's inputs are exactly the two persisted instants — with the buffer elapsed and no
+    /// in-flight marker, sync is unblocked no matter how servable a pending broadcast is. This is
+    /// the anti-regression pin for the clause's removal (it froze an awake session for 50+ min by
+    /// blocking the very sync its pending broadcast needed — FIND-5).
+    func testGateHasNoForwardLookingClauseAfterBufferElapsed() {
         let resumeAt = referenceDate.addingTimeInterval(buffer)
         let afterBuffer = resumeAt.addingTimeInterval(1)
-        XCTAssertTrue(MigrationSyncGate.isBlocked(now: afterBuffer, hasReadyBroadcast: true, resumeAt: resumeAt, inFlightUntil: nil))
+        XCTAssertFalse(MigrationSyncGate.isBlocked(now: afterBuffer, resumeAt: resumeAt, inFlightUntil: nil))
     }
 
-    func testGateReadyBroadcastForcesBlockedWithoutAnyBuffer() {
-        XCTAssertTrue(MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: true, resumeAt: nil, inFlightUntil: nil))
+    /// D1's second half: with no buffer at all, nothing but an in-flight marker can block — a
+    /// fresh gate is open regardless of any pending work.
+    func testGateHasNoForwardLookingClauseWithoutAnyBuffer() {
+        XCTAssertFalse(MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: nil, inFlightUntil: nil))
     }
 
     func testGateCorruptOrMissingFileUnblockedWhenNoReadyBroadcast() {
         // Corrupt/missing file resolves to `resumeAt == nil`, which is "no gate".
-        XCTAssertFalse(MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: false, resumeAt: nil, inFlightUntil: nil))
+        XCTAssertFalse(MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: nil, inFlightUntil: nil))
     }
 
     // MARK: - Gate math: broadcast in-flight marker
@@ -54,30 +61,30 @@ final class MigrationLogicTests: ZcashTestCase {
     /// buffer -- the third, independent reason the gate blocks (see `MigrationSyncGate`'s type doc).
     func testGateBlockedWhileInFlightMarkerUnexpired() {
         let inFlightUntil = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration)
-        XCTAssertTrue(MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: false, resumeAt: nil, inFlightUntil: inFlightUntil))
+        XCTAssertTrue(MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: nil, inFlightUntil: inFlightUntil))
     }
 
     /// At exactly `inFlightUntil` the marker has elapsed: `now < inFlightUntil` is false, mirroring
     /// the privacy buffer's own boundary rule.
     func testGateUnblocksAtExactlyInFlightMarkerBoundary() {
         let inFlightUntil = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration)
-        XCTAssertFalse(MigrationSyncGate.isBlocked(now: inFlightUntil, hasReadyBroadcast: false, resumeAt: nil, inFlightUntil: inFlightUntil))
+        XCTAssertFalse(MigrationSyncGate.isBlocked(now: inFlightUntil, resumeAt: nil, inFlightUntil: inFlightUntil))
     }
 
     /// `markBroadcastInFlight()` blocks sync immediately; `clearBroadcastInFlight()` releases it
     /// again -- without either an overdue transfer or a privacy buffer in play.
     func testMarkBroadcastInFlightBlocksAndClearReleases() {
         let gate = makeGate(account: accountA, clock: TestClock(referenceDate))
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false), "precondition: fresh gate is unblocked")
+        XCTAssertFalse(gate.currentlyBlocked(), "precondition: fresh gate is unblocked")
 
         gate.markBroadcastInFlight()
 
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(gate.currentlyBlocked())
         XCTAssertNotNil(gate.currentInFlightUntil())
 
         gate.clearBroadcastInFlight()
 
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertFalse(gate.currentlyBlocked())
         XCTAssertNil(gate.currentInFlightUntil())
     }
 
@@ -89,11 +96,11 @@ final class MigrationLogicTests: ZcashTestCase {
         let gate = makeGate(account: accountA, clock: clock)
 
         gate.markBroadcastInFlight()
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(gate.currentlyBlocked())
 
         clock.now = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration + 1)
 
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false), "an expired in-flight marker must stop blocking sync")
+        XCTAssertFalse(gate.currentlyBlocked(), "an expired in-flight marker must stop blocking sync")
     }
 
     /// `markBroadcastInFlight()` preserves an already-running privacy buffer (they are independent,
@@ -119,13 +126,13 @@ final class MigrationLogicTests: ZcashTestCase {
     func testIsBlockedIgnoresAnImplausiblyFarFutureInFlightMarker() {
         let farFuture = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration + 3600)
         XCTAssertFalse(
-            MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: false, resumeAt: nil, inFlightUntil: farFuture),
+            MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: nil, inFlightUntil: farFuture),
             "a clock-step artifact must not wedge sync"
         )
         // The boundary itself is plausible: a freshly armed marker sits at exactly now + guard.
         let freshlyArmed = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration)
         XCTAssertTrue(
-            MigrationSyncGate.isBlocked(now: referenceDate, hasReadyBroadcast: false, resumeAt: nil, inFlightUntil: freshlyArmed)
+            MigrationSyncGate.isBlocked(now: referenceDate, resumeAt: nil, inFlightUntil: freshlyArmed)
         )
     }
 
@@ -155,11 +162,11 @@ final class MigrationLogicTests: ZcashTestCase {
 
         let ceiling = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration)
         XCTAssertEqual(relaunchedGate.currentInFlightUntil(), ceiling, "the load must clamp the marker into its plausible window")
-        XCTAssertTrue(relaunchedGate.currentlyBlocked(hasReadyBroadcast: false), "the protective window survives the clamp")
+        XCTAssertTrue(relaunchedGate.currentlyBlocked(), "the protective window survives the clamp")
 
         steppedBackClock.now = ceiling.addingTimeInterval(1)
         XCTAssertFalse(
-            relaunchedGate.currentlyBlocked(hasReadyBroadcast: false),
+            relaunchedGate.currentlyBlocked(),
             "the clamped marker must expire a guard-duration after the relaunch, not an hour later"
         )
     }
@@ -177,12 +184,12 @@ final class MigrationLogicTests: ZcashTestCase {
 
         let ceiling = referenceDate.addingTimeInterval(MigrationSyncGate.broadcastInFlightGuardDuration)
         XCTAssertEqual(gate.currentInFlightUntil(), ceiling, "the read must clamp the marker to now + guard")
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(gate.currentlyBlocked())
 
         // The clamp persisted (write-back): advancing past the ceiling expires the marker even
         // though the ORIGINAL expiry is still far in this clock's future.
         clock.now = ceiling.addingTimeInterval(1)
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertFalse(gate.currentlyBlocked())
     }
 
     // MARK: - Gate file round-trip
@@ -194,7 +201,7 @@ final class MigrationLogicTests: ZcashTestCase {
         gate.markBroadcast()
 
         XCTAssertEqual(gate.currentResumeAt(), referenceDate.addingTimeInterval(buffer))
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(gate.currentlyBlocked())
     }
 
     func testGateUnblocksOnceRealTimePassesTheBuffer() {
@@ -205,8 +212,9 @@ final class MigrationLogicTests: ZcashTestCase {
         // Advance the injected clock past the buffer; the persisted resumeAt is unchanged.
         clock.now = referenceDate.addingTimeInterval(buffer + 1)
 
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false))
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: true))
+        // (This test's second half — "still blocked when a ready broadcast waits" — died with the
+        // gate's forward-looking clause, D1; the reversal pins above own that behavior now.)
+        XCTAssertFalse(gate.currentlyBlocked())
     }
 
     func testCorruptFileAtInitReadsAsNoGate() throws {
@@ -218,7 +226,7 @@ final class MigrationLogicTests: ZcashTestCase {
         let gate = makeGate(account: accountA, clock: TestClock(referenceDate))
 
         XCTAssertNil(gate.currentResumeAt())
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertFalse(gate.currentlyBlocked())
     }
 
     /// Finding 14: `currentResumeAt()`/`currentlyBlocked` read the in-memory `resumeAt` cache, not a
@@ -241,7 +249,7 @@ final class MigrationLogicTests: ZcashTestCase {
         otherProcessGate.markBroadcast()
 
         XCTAssertNil(gate.currentResumeAt(), "an out-of-band file write after init must not change the cached answer")
-        XCTAssertFalse(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertFalse(gate.currentlyBlocked())
     }
 
     /// Finding 14: the in-memory `resumeAt` cache is loaded from the gate file once, at init -- a
@@ -257,7 +265,7 @@ final class MigrationLogicTests: ZcashTestCase {
         let secondLaunchGate = makeGate(account: accountA, clock: clock)
 
         XCTAssertEqual(secondLaunchGate.currentResumeAt(), persistedResumeAt)
-        XCTAssertTrue(secondLaunchGate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(secondLaunchGate.currentlyBlocked())
     }
 
     /// The in-flight marker persists exactly like `resumeAt`: a fresh gate instance over the same
@@ -273,7 +281,7 @@ final class MigrationLogicTests: ZcashTestCase {
         let secondLaunchGate = makeGate(account: accountA, clock: clock)
 
         XCTAssertEqual(secondLaunchGate.currentInFlightUntil(), persistedInFlightUntil)
-        XCTAssertTrue(secondLaunchGate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(secondLaunchGate.currentlyBlocked())
 
         let fileOnlyInputs = MigrationSyncGate.persistedGateInputs(directory: testGeneralStorageDirectory, accountUUID: accountA, logger: logger)
         XCTAssertEqual(fileOnlyInputs.inFlightUntil, persistedInFlightUntil)
@@ -291,7 +299,7 @@ final class MigrationLogicTests: ZcashTestCase {
         let secondLaunchGate = makeGate(account: accountA, clock: clock)
 
         XCTAssertNil(secondLaunchGate.currentInFlightUntil())
-        XCTAssertFalse(secondLaunchGate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertFalse(secondLaunchGate.currentlyBlocked())
     }
 
     /// Back-compat: a gate file persisted before the in-flight marker existed never carries an
@@ -308,7 +316,7 @@ final class MigrationLogicTests: ZcashTestCase {
 
         XCTAssertEqual(gate.currentResumeAt(), referenceDate.addingTimeInterval(buffer))
         XCTAssertNil(gate.currentInFlightUntil())
-        XCTAssertTrue(gate.currentlyBlocked(hasReadyBroadcast: false))
+        XCTAssertTrue(gate.currentlyBlocked())
     }
 
     // MARK: - Network-scaled privacy buffer
@@ -428,47 +436,46 @@ final class MigrationLogicTests: ZcashTestCase {
 
     // MARK: - Ticker gated on subscribers
 
+
     /// Finding 14: the ticker must do zero periodic work with no subscriber attached, start
-    /// evaluating on the first subscriber (0 -> 1), and stop again once the last one detaches (1 -> 0)
-    /// -- the `readyBroadcastProvider` invocation count freezes rather than merely slowing down. A very
-    /// short `tickInterval` keeps the "prove nothing fires" waits fast; unlike `now`, the ticker's
-    /// inter-tick delay is real wall-clock sleep, not injected, so those two waits are real-time
-    /// (mirrors the inverted-expectation style already used by
-    /// `testStaleRecomputeIsDroppedInFavorOfAFresherPublishedValue` above).
+    /// evaluating on the first subscriber (0 -> 1), and stop again once the last one detaches
+    /// (1 -> 0). OBSERVABLE REWIRED 2026-08-05: the old probe was the `readyBroadcastProvider`
+    /// invocation count, deleted with the gate's forward-looking clause (D1) — the injected
+    /// clock now stands in, since every recompute (and each ticker iteration's delay
+    /// computation) reads `now()`, while an idle, unsubscribed gate reads it never.
     func testTickerTicksOnlyWhileSubscribed() async throws {
-        let counter = CallCountingOverdueProvider()
-        let tickedAtLeastTwice = expectation(description: "ticker evaluates at least twice while subscribed")
+        let clock = CountingClock(referenceDate)
         let gate = MigrationSyncGate(
             directory: testGeneralStorageDirectory,
             accountUUID: accountA,
             bufferDuration: buffer,
             tickInterval: 0.02,
-            readyBroadcastProvider: {
-                let count = await counter.increment()
-                if count == 2 { tickedAtLeastTwice.fulfill() }
-                return false
-            },
+            now: { clock.tick() },
             logger: logger
         )
 
-        // No subscriber yet: several tick intervals' worth of real time must produce zero calls.
+        // No subscriber yet: several tick intervals' worth of real time must produce no reads
+        // beyond construction's own.
+        let countAfterInit = clock.count
         try await Task.sleep(nanoseconds: 200_000_000)
-        let countBeforeSubscribing = await counter.count
-        XCTAssertEqual(countBeforeSubscribing, 0, "the ticker must not run with no subscriber attached")
+        XCTAssertEqual(clock.count, countAfterInit, "the ticker must not run with no subscriber attached")
 
-        // Attaching a subscriber starts evaluation.
+        // Attaching a subscriber starts evaluation: the clock-read count must grow.
         let cancellable = gate.blockedStream.sink { _ in }
-        await fulfillment(of: [tickedAtLeastTwice], timeout: 2)
+        let deadline = Date().addingTimeInterval(2)
+        while clock.count < countAfterInit + 4, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertGreaterThanOrEqual(clock.count, countAfterInit + 4, "the ticker must evaluate while subscribed")
 
-        // Detaching stops it: the invocation count must stop growing across a further quiet period.
+        // Detaching stops it: the count must stop growing across a further quiet period.
         cancellable.cancel()
         // A tick may already be in flight at the moment of cancellation; let it settle before
         // snapshotting the count both sides of the quiet period.
         try await Task.sleep(nanoseconds: 50_000_000)
-        let countAfterCancel = await counter.count
+        let countAfterCancel = clock.count
         try await Task.sleep(nanoseconds: 200_000_000)
-        let countAfterQuietPeriod = await counter.count
-        XCTAssertEqual(countAfterQuietPeriod, countAfterCancel, "the ticker must stop once the last subscriber detaches")
+        XCTAssertEqual(clock.count, countAfterCancel, "the ticker must stop once the last subscriber detaches")
     }
 
     // MARK: - Blocked stream behavior (finding 13)
@@ -495,7 +502,7 @@ final class MigrationLogicTests: ZcashTestCase {
     /// emission is `true`, without waiting for any tick. Exercises `MigrationSyncGate`'s documented
     /// init-time seed (loads `cachedResumeAt` from the file once, then seeds `blockedSubject` from it)
     /// through the public `blockedStream`, complementing `testMemoryCacheHonorsAPreExistingFileValueAtInit`
-    /// above (which checks the same init-time load via `currentResumeAt()`/`currentlyBlocked(hasReadyBroadcast:)`
+    /// above (which checks the same init-time load via `currentResumeAt()`/`currentlyBlocked()`
     /// rather than the stream).
     func testBlockedStreamSubscribeTimeSeedIsTrueWhenAlreadyLiveInTheGateFileAtInit() {
         let clock = TestClock(referenceDate)
@@ -527,7 +534,6 @@ final class MigrationLogicTests: ZcashTestCase {
             // Long enough that no real tick can plausibly fire during this test's timeout below.
             tickInterval: 3600,
             now: { clock.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
 
@@ -546,38 +552,10 @@ final class MigrationLogicTests: ZcashTestCase {
         XCTAssertEqual(received, [false, true])
     }
 
-    /// Tick re-evaluation, "overdue flips on" half: the ticker's OWN periodic re-evaluation -- not a
-    /// `markBroadcast()` -- must pick up an `readyBroadcastProvider` answer that flips from `false` to `true`
-    /// between ticks. `GatedOverdueProvider` (already used by
-    /// `testStaleRecomputeIsDroppedInFavorOfAFresherPublishedValue` above) pre-queues both ticks'
-    /// answers so each `next()` call resolves immediately -- no suspension, no `Task.sleep` in this
-    /// test -- while the real (short) `tickInterval` is what actually paces the two ticks.
-    func testBlockedStreamTickEmitsTrueAfterOverdueProviderFlipsFromFalseToTrue() async throws {
-        let provider = GatedOverdueProvider()
-        await provider.queue(false) // generation 1 (the ticker's startup recompute): agrees with the seed
-        await provider.queue(true) // generation 2 (the next tick): the flip
-        let fixedNow = referenceDate
-        let gate = MigrationSyncGate(
-            directory: testGeneralStorageDirectory,
-            accountUUID: accountA,
-            bufferDuration: buffer,
-            tickInterval: 0.02,
-            now: { fixedNow },
-            readyBroadcastProvider: { await provider.next() },
-            logger: logger
-        )
 
-        var received: [Bool] = []
-        let trueReceived = expectation(description: "a tick observed the readyBroadcastProvider flip to true")
-        let cancellable = gate.blockedStream.sink { value in
-            received.append(value)
-            if value { trueReceived.fulfill() }
-        }
-        defer { cancellable.cancel() }
-
-        await fulfillment(of: [trueReceived], timeout: 5)
-        XCTAssertEqual(received, [false, true])
-    }
+    // (The "overdue flips on" tick test was deleted 2026-08-05 with the gate's forward-looking
+    // ready-broadcast clause — D1, danny + nuttycom's ruling; see `MigrationSyncGate`'s type doc.
+    // The ticker's remaining job is time-based flips, pinned by the buffer-expiry test below.)
 
     /// Tick re-evaluation, "buffer expires" half: with a live buffer already seeded at subscribe time
     /// (so the gate reads `true`) and nothing ever overdue, advancing the INJECTED clock past the
@@ -598,7 +576,6 @@ final class MigrationLogicTests: ZcashTestCase {
             bufferDuration: buffer,
             tickInterval: 0.02,
             now: { clock.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
 
@@ -621,25 +598,14 @@ final class MigrationLogicTests: ZcashTestCase {
 
     /// Duplicate collapse: several ticks that all agree with the already-published value must not
     /// produce any additional emissions -- pins `.removeDuplicates()` in `blockedStream`'s pipeline.
-    /// Reuses `CallCountingOverdueProvider` (already used by `testTickerTicksOnlyWhileSubscribed`
-    /// above) to prove multiple recomputes actually ran, rather than merely that nothing arrived
-    /// because nothing ticked.
     func testBlockedStreamCollapsesConsecutiveIdenticalTickEvaluationsIntoNoExtraEmissions() async throws {
-        let counter = CallCountingOverdueProvider()
-        let tickedAtLeastThreeTimes = expectation(description: "the ticker evaluates at least three times")
-        let fixedNow = referenceDate
+        let clock = CountingClock(referenceDate)
         let gate = MigrationSyncGate(
             directory: testGeneralStorageDirectory,
             accountUUID: accountA,
             bufferDuration: buffer,
             tickInterval: 0.02,
-            now: { fixedNow },
-            readyBroadcastProvider: {
-                let count = await counter.increment()
-                if count == 3 { tickedAtLeastThreeTimes.fulfill() }
-                // No buffer, never overdue: every tick agrees with the fresh-gate seed.
-                return false
-            },
+            now: { clock.tick() },
             logger: logger
         )
 
@@ -648,73 +614,28 @@ final class MigrationLogicTests: ZcashTestCase {
         defer { cancellable.cancel() }
         XCTAssertEqual(received, [false], "precondition: fresh gate seeds false")
 
-        await fulfillment(of: [tickedAtLeastThreeTimes], timeout: 5)
+        // Recompute activity is observed through the injected clock (see
+        // `testTickerTicksOnlyWhileSubscribed`'s rewired observable): wait until enough reads
+        // prove several recomputes ran, rather than merely that nothing ticked.
+        let baseline = clock.count
+        let deadline = Date().addingTimeInterval(5)
+        while clock.count < baseline + 6, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertGreaterThanOrEqual(clock.count, baseline + 6, "several ticks must actually have evaluated")
 
-        XCTAssertEqual(received, [false], "three ticks agreeing with the seed must not add any emissions")
+        XCTAssertEqual(received, [false], "ticks agreeing with the seed must not add any emissions")
     }
 
     // MARK: - Concurrent send serialization
 
-    /// Reproduces finding 7's race directly: the ticker's very first recompute -- generation 1,
-    /// started by subscribing below (finding 14 gates the ticker on the first subscriber; it no
-    /// longer starts at construction) -- is held suspended in `readyBroadcastProvider`, standing in for "a
-    /// tick suspended when a broadcast lands", while a second, later-started `markBroadcast()`-
-    /// triggered recompute resolves immediately and publishes a fresher value. Releasing the stale
-    /// first recompute (with an answer engineered to compute a *different* `blocked` value, so
-    /// `removeDuplicates()` can't accidentally be the thing hiding the bug) must not publish a third,
-    /// stale emission: latest-wins, and a recompute that started earlier but finishes later is
-    /// dropped.
-    func testStaleRecomputeIsDroppedInFavorOfAFresherPublishedValue() async throws {
-        let clock = TestClock(referenceDate)
-        let provider = GatedOverdueProvider()
-        let gate = MigrationSyncGate(
-            directory: testGeneralStorageDirectory,
-            accountUUID: accountA,
-            bufferDuration: buffer,
-            // Long enough that only the ticker's own startup recompute fires during this test.
-            tickInterval: 3600,
-            now: { clock.now },
-            readyBroadcastProvider: { await provider.next() },
-            logger: logger
-        )
+    // (Finding 7's stale-recompute reproduction was deleted 2026-08-05: it held generation 1
+    // suspended INSIDE `recompute()` via the `readyBroadcastProvider` await, and that await —
+    // the only suspension point the recompute path ever had — is gone with the gate's
+    // forward-looking clause (D1). `recompute()` now runs draw-to-publish without suspending,
+    // so the reproduced interleaving is unbuildable; the generation-ordered `publish` funnel
+    // stays as the belt for plain cross-thread races.)
 
-        var received: [Bool] = []
-        let freshValuePublished = expectation(description: "fresher value published")
-        let noStaleValuePublished = expectation(description: "a stale third value must not publish")
-        noStaleValuePublished.isInverted = true
-        // Subscribing is what starts the ticker (finding 14): this kicks off generation 1, which
-        // immediately suspends in `readyBroadcastProvider` below.
-        let cancellable = gate.blockedStream.sink { value in
-            received.append(value)
-            if received.count == 2 { freshValuePublished.fulfill() }
-            if received.count >= 3 { noStaleValuePublished.fulfill() }
-        }
-        defer { cancellable.cancel() }
-
-        // Generation 1 is now in flight (started by the subscription above): wait for it to be
-        // suspended in `readyBroadcastProvider`, unresolved, until we explicitly release it below.
-        await provider.waitUntilWaiting()
-
-        // Generation 2: queued ahead of time, so `next()` returns immediately (no suspension) and
-        // this recompute -- started AFTER generation 1 -- finishes and publishes FIRST.
-        await provider.queue(true)
-        gate.markBroadcast()
-
-        await fulfillment(of: [freshValuePublished], timeout: 5)
-        XCTAssertEqual(received, [false, true])
-
-        // Advance the clock past the buffer `markBroadcast()` just started, so generation 1's
-        // eventual answer (`hasReadyBroadcast: false`) computes to `false` -- different from generation 2's
-        // published `true` -- rather than being incidentally deduplicated to the same value.
-        clock.now = referenceDate.addingTimeInterval(buffer + 1)
-
-        // Release the stale generation-1 call. Pre-fix this publishes a third, stale `false`;
-        // post-fix it is dropped (generation 1 < the already-published generation 2).
-        await provider.resolveOldestWaiting(false)
-
-        await fulfillment(of: [noStaleValuePublished], timeout: 0.5)
-        XCTAssertEqual(received, [false, true])
-    }
 
     // MARK: - Lock split regression (deadlock on synchronous cancel during publish)
 
@@ -1263,6 +1184,8 @@ final class MigrationLogicTests: ZcashTestCase {
         )
         let welding = ZcashRustBackendWeldingMock()
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x03, 0x04])
         // A no-op closure: if the fail-closed guard regresses and this ends up called anyway, it
         // completes instead of crashing the process, so the call-count assertion below fails cleanly
@@ -1310,7 +1233,6 @@ final class MigrationLogicTests: ZcashTestCase {
             // A long tick keeps the background re-evaluation out of these deterministic assertions.
             tickInterval: 3600,
             now: { clock.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
     }
@@ -1408,65 +1330,30 @@ final class MigrationLogicTests: ZcashTestCase {
     }
 }
 
-/// A controllable test double for `MigrationSyncGate`'s `readyBroadcastProvider` seam: each call to
-/// `next()` either returns an already-queued answer immediately, or suspends until `resolveOldestWaiting`
-/// releases the oldest still-waiting call. Lets a test pin the exact interleaving of two concurrent
-/// recomputes deterministically -- no `Task.sleep`, no polling -- by controlling which of two
-/// `readyBroadcastProvider` calls resolves first.
-private actor GatedOverdueProvider {
-    private var queuedAnswers: [Bool] = []
-    private var waiters: [CheckedContinuation<Bool, Never>] = []
-    private var suspensionSignals: [CheckedContinuation<Void, Never>] = []
+/// A `now` closure double that counts its reads — the rewired observable for the
+/// subscription-gated-ticker pins above (the old observable, `readyBroadcastProvider`, was
+/// deleted with the gate's forward-looking clause — D1). Always returns the same fixed instant,
+/// so the counted reads never move any time-based condition.
+private final class CountingClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private let fixed: Date
+    private var reads = 0
 
-    func next() async -> Bool {
-        if !queuedAnswers.isEmpty {
-            return queuedAnswers.removeFirst()
-        }
-        return await withCheckedContinuation { continuation in
-            waiters.append(continuation)
-            let signals = suspensionSignals
-            suspensionSignals = []
-            for signal in signals {
-                signal.resume()
-            }
-        }
+    init(_ fixed: Date) {
+        self.fixed = fixed
     }
 
-    /// Queues `answer` for the next call to `next()` that is not already suspended, so that call
-    /// returns immediately instead of waiting on `resolveOldestWaiting`.
-    func queue(_ answer: Bool) {
-        queuedAnswers.append(answer)
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads
     }
 
-    /// Resolves the oldest currently-suspended `next()` call with `answer`.
-    func resolveOldestWaiting(_ answer: Bool) {
-        guard !waiters.isEmpty else {
-            XCTFail("GatedOverdueProvider: no suspended `next()` call to resolve")
-            return
-        }
-        waiters.removeFirst().resume(returning: answer)
-    }
-
-    /// Suspends until at least one call to `next()` is itself suspended awaiting resolution.
-    func waitUntilWaiting() async {
-        if !waiters.isEmpty { return }
-        await withCheckedContinuation { continuation in
-            suspensionSignals.append(continuation)
-        }
-    }
-}
-
-/// A trivial, always-immediately-resolving `readyBroadcastProvider` double that just counts calls -- used
-/// to pin finding 14's subscription-gated ticker (``MigrationLogicTests/testTickerTicksOnlyWhileSubscribed()``):
-/// unlike `GatedOverdueProvider`, nothing here ever suspends, so the count only grows when the
-/// ticker itself actually decides to tick.
-private actor CallCountingOverdueProvider {
-    private(set) var count = 0
-
-    @discardableResult
-    func increment() -> Int {
-        count += 1
-        return count
+    func tick() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        reads += 1
+        return fixed
     }
 }
 

--- a/Tests/OfflineTests/MigrationLogicTests.swift
+++ b/Tests/OfflineTests/MigrationLogicTests.swift
@@ -337,34 +337,6 @@ final class MigrationLogicTests: ZcashTestCase {
     // `privacySyncBufferDuration(for: .mainnet)` (U11), so no equality-policing test exists for
     // it — the mainnet pin above covers the one real constant.
 
-    // MARK: - Compressed-schedule spacing floors
-
-    /// Mainnet answers the zero pair unconditionally -- a hard requirement, not a derived
-    /// result. Three very different spacings all land on the same zero pair, pinning that the
-    /// mainnet branch never even evaluates the formula.
-    func testSpacingFloorsIsZeroOnMainnetForAnySpacing() {
-        XCTAssertEqual(OrchardMigration.spacingFloors(network: .mainnet, secondsPerBlock: 5), MigrationSpacingFloors.zero)
-        XCTAssertEqual(OrchardMigration.spacingFloors(network: .mainnet, secondsPerBlock: 75), MigrationSpacingFloors.zero)
-        XCTAssertEqual(OrchardMigration.spacingFloors(network: .mainnet, secondsPerBlock: 150), MigrationSpacingFloors.zero)
-    }
-
-    /// Testnet's 180 s privacy buffer over a measured 39 s spacing: `bufferBlocks = ceil(180/39)
-    /// = 5`, so `toleranceFloor = 5 + 2 = 7` and `releaseSpacingFloor = 2*5 + 2 = 12`.
-    func testSpacingFloorsDerivesFromMeasuredSpacingOnTestnet() {
-        let floors = OrchardMigration.spacingFloors(network: .testnet, secondsPerBlock: 39)
-        XCTAssertEqual(floors.toleranceFloor, 7)
-        XCTAssertEqual(floors.releaseSpacingFloor, 12)
-    }
-
-    /// The fallback-spacing case: a caller with no measurement in reach passes
-    /// `ChainTipEstimator.fallbackSecondsPerBlock` (the nominal 75 s Zcash target spacing).
-    /// `bufferBlocks = ceil(180/75) = 3`, so `toleranceFloor = 5` and `releaseSpacingFloor = 8`.
-    func testSpacingFloorsUsesNominalFallbackSpacingOnTestnet() {
-        let floors = OrchardMigration.spacingFloors(network: .testnet, secondsPerBlock: ChainTipEstimator.fallbackSecondsPerBlock)
-        XCTAssertEqual(floors.toleranceFloor, 5)
-        XCTAssertEqual(floors.releaseSpacingFloor, 8)
-    }
-
     // MARK: - MigrationSchedule persistence (A10)
 
     /// A10 round trip: `encode(to:)` omits `proposalHandle` (a process-lifetime plan-cache key no

--- a/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
@@ -60,6 +60,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             XCTAssertEqual(receivedAccount, self.accountA)
             return prepared
         }
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForClosure = { pczt, _ in
             recorder.record("extract")
             XCTAssertEqual(pczt, prepared.pczt)
@@ -96,6 +98,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let proposal = NoteSplitProposal(outputNotes: [Zatoshi(100_000)], fee: Zatoshi(5_000), proposalHandle: 1)
         let prepared = makePreparedTransfer(id: 0)
         welding.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x02, 0x03])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.transportError))
@@ -125,6 +129,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let proposal = NoteSplitProposal(outputNotes: [Zatoshi(100_000)], fee: Zatoshi(5_000), proposalHandle: 1)
         let prepared = makePreparedTransfer(id: 0)
         welding.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x02, 0x03])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable))
@@ -189,6 +195,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferSuccessPathRecordsAndMarksGate() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.submitted))
@@ -212,6 +220,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferInvalidNoteRejectionRecordsAndLeavesGateUntouched() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.rejected(errorCode: -25, message: "missing inputs")))
@@ -234,6 +244,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferExpiredRejectionRecordsAndLeavesGateUntouched() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.rejected(errorCode: -26, message: "tx-expiring-soon")))
@@ -257,6 +269,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testBroadcasterReceivesExactlyOneCallToTheResolvedEndpoint() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let overrideEndpoint = LightWalletEndpoint(address: "override.example", port: 443)
@@ -443,6 +457,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let expectedDisplayTxId = "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100"
         let prepared = PreparedMigrationTransfer(id: 1, txid: Data(rawTxId), pczt: Data([0x01, 0x02]))
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.submitted))
@@ -469,6 +485,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferRecordThrowAfterSuccessfulBroadcastMarksGateAndThrowsWrapped() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForThrowableError = StubEngineError()
         let broadcaster = ScriptedBroadcaster(script: .outcome(.submitted))
@@ -494,6 +512,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testSubmitNoteSplitRecordThrowAfterSuccessfulBroadcastMarksGateAndThrowsWrapped() async throws {
         let proposal = NoteSplitProposal(outputNotes: [Zatoshi(100_000)], fee: Zatoshi(5_000), proposalHandle: 1)
         welding.migrationSignNoteSplitProposalUskForReturnValue = makePreparedTransfer(id: 0)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x02, 0x03])
         welding.migrationRecordTransferResultTransferIdResultForThrowableError = StubEngineError()
         let broadcaster = ScriptedBroadcaster(script: .outcome(.submitted))
@@ -523,6 +543,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferRecordThrowOnTransportErrorPropagatesRawAndLeavesGateUntouched() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForThrowableError = StubEngineError()
         let broadcaster = ScriptedBroadcaster(script: .outcome(.transportError))
@@ -560,6 +582,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         for (script, expected) in rejections {
             let prepared = makePreparedTransfer(id: 1)
             welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+            // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+            welding.migrationTransactionStatusesForReturnValue = []
             welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
             welding.migrationRecordTransferResultTransferIdResultForThrowableError = StubEngineError()
             let broadcaster = ScriptedBroadcaster(script: .outcome(script))
@@ -592,6 +616,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferRecordSuccessOnNetworkErrorClearsInFlightMarker() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .outcome(.transportError)))
@@ -615,6 +641,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferReArmsTheInFlightMarkerAtSubmitTimeViaTheHook() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForThrowableError = StubEngineError()
         let broadcaster = ScriptedBroadcaster(script: .outcome(.transportError))
@@ -657,6 +685,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     func testExecuteNextPendingTransferFailClosedThrowNeverFiresTheHook() async throws {
         let prepared = makePreparedTransfer(id: 1)
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         let broadcaster = ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable))
         let migration = makeMigration(broadcaster: broadcaster)
@@ -684,6 +714,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             // The engine contract: the transfer stays "next due" until its result is recorded.
             welding?.migrationRecordTransferResultTransferIdResultForCalled == true ? .nothingDue : .ready(prepared)
         }
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = GatedBroadcaster(outcome: MigrationBroadcastOutcome.submitted)
@@ -737,6 +769,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             recorder.record("sign")
             return splitTransfer
         }
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { transferId, _, _ in
             recorder.record("record:\(transferId)")
@@ -788,6 +822,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let prepTransfer = makePreparedTransfer(id: 0)
         welding.migrationStoreSignedNoteSplitPcztsForReturnValue = prepTransfer
         welding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepTransfer)
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForClosure = { pczt, _ in
             XCTAssertEqual(pczt, prepTransfer.pczt)
             return Data([0x0A])
@@ -833,13 +869,19 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
 
     /// The gate's work-pending clause is the READY-broadcast predicate: a proved, due transfer
     /// blocks sync. The very wedge D1 exists to prevent is pinned separately below.
-    func testIsSyncBlockedBlocksWhenAReadyBroadcastIsWaiting() async throws {
+    /// D1 REVERSAL PIN (danny + nuttycom, 2026-08-05): a servable ready broadcast no longer
+    /// blocks sync — the forward-looking clause is deleted, and no gate path consults the
+    /// ready-broadcast probe at all (the probe answering `true` here proves the assertion is
+    /// about consultation, not about the engine's answer).
+    func testIsSyncBlockedIgnoresAWaitingReadyBroadcast() async throws {
         welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
         let blocked = await migration.isSyncBlocked()
 
-        XCTAssertTrue(blocked, "a proved, due, valid transfer must hold sync for a broadcast session")
+        XCTAssertFalse(blocked, "sync holds only for past/present broadcasts (buffer, in-flight marker)")
+        XCTAssertFalse(welding.migrationHasReadyBroadcastForEstimatedTipCalled, "no gate path consults the probe anymore")
+        XCTAssertFalse(welding.migrationBlockRateSamplesWindowCalled, "no gate path pays for the estimate anymore")
     }
 
     /// THE WEDGE (D1): a due-but-unproved row — `migrationHasOverdueTransfers` would answer `true`
@@ -864,76 +906,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     /// U8 ordering: the gate asks the ready-broadcast question at the SCANNED tip FIRST (nil
     /// estimate). When that answer is already `true`, the block-rate samples are never read — the
     /// estimate could not change the answer.
-    func testIsSyncBlockedAsksScannedTipFirstAndSkipsTheEstimateWhenAlreadyBlocked() async throws {
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
-        let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
-        let blocked = await migration.isSyncBlocked()
 
-        XCTAssertTrue(blocked)
-        XCTAssertEqual(welding.migrationHasReadyBroadcastForEstimatedTipCallsCount, 1)
-        XCTAssertNil(
-            welding.migrationHasReadyBroadcastForEstimatedTipReceivedArguments?.estimatedTip,
-            "the first (and only) ask must be at the scanned tip"
-        )
-        XCTAssertFalse(
-            welding.migrationBlockRateSamplesWindowCalled,
-            "a true scanned answer must not pay for the sample read"
-        )
-    }
-
-    /// U8 ordering, second half: only a `false` scanned answer pays for the estimate projection
-    /// and re-asks with it — the estimate can only ACCELERATE due-ness, so it is consulted second.
-    func testIsSyncBlockedReAsksWithTheEstimateOnlyAfterAFalseScannedAnswer() async throws {
-        let sampleTime = referenceDate.addingTimeInterval(-100)
-        welding.migrationBlockRateSamplesWindowReturnValue = [
-            MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(sampleTime.timeIntervalSince1970))
-        ]
-        var receivedTips: [BlockHeight?] = []
-        welding.migrationHasReadyBroadcastForEstimatedTipClosure = { _, estimatedTip in
-            receivedTips.append(estimatedTip)
-            // Scanned tip says no; the estimate-accelerated re-ask says yes.
-            return estimatedTip != nil
-        }
-        let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
-
-        let blocked = await migration.isSyncBlocked()
-
-        XCTAssertTrue(blocked, "an estimate-accelerated ready broadcast must block sync")
-        XCTAssertEqual(receivedTips.count, 2)
-        let firstTip = try XCTUnwrap(receivedTips.first)
-        XCTAssertNil(firstTip, "the scanned tip must be asked first")
-        let secondTip = try XCTUnwrap(receivedTips.last)
-        XCTAssertNotNil(secondTip, "the second ask must carry the projected estimate")
-    }
-
-    /// U7/U9: the estimate the gate feeds into the second ask is projected at the ACTOR'S injected
-    /// clock, not the wall clock — the deterministic fake-clock arithmetic only holds if the shared
-    /// tip-estimation helper received `clock.now`.
-    func testIsSyncBlockedProjectsTheEstimateAtTheInjectedClock() async throws {
-        // One sample 150 s (two 75 s target-spacing blocks) before the frozen test clock: the
-        // deterministic projection is height + 2 — any wall-clock leak (years past
-        // `referenceDate`) would project far beyond it.
-        let sampleTime = referenceDate.addingTimeInterval(-150)
-        welding.migrationBlockRateSamplesWindowReturnValue = [
-            MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(sampleTime.timeIntervalSince1970))
-        ]
-        var receivedTips: [BlockHeight?] = []
-        welding.migrationHasReadyBroadcastForEstimatedTipClosure = { _, estimatedTip in
-            receivedTips.append(estimatedTip)
-            return false
-        }
-        let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
-
-        _ = await migration.isSyncBlocked()
-
-        let projectedTip = try XCTUnwrap(receivedTips.last)
-        XCTAssertEqual(
-            projectedTip,
-            3_000_002,
-            "the projection must be evaluated at the actor's injected clock (height + floor(150/75))"
-        )
-    }
 
     // MARK: - Helpers
 
@@ -968,7 +942,6 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             // A long tick keeps the background re-evaluation out of these deterministic assertions.
             tickInterval: 3600,
             now: { clock.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
     }

--- a/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
@@ -343,13 +343,13 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         welding.migrationBlockRateSamplesWindowReturnValue = [
             MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(sampleTime.timeIntervalSince1970))
         ]
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
         let step = try await migration.advanceStep()
 
         XCTAssertEqual(step, .waiting)
-        let received = try XCTUnwrap(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments)
+        let received = try XCTUnwrap(welding.migrationAdvanceStepForEstimatedTipReceivedArguments)
         XCTAssertEqual(received.account, accountA)
         XCTAssertEqual(
             received.estimatedTip,
@@ -363,61 +363,16 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     /// engine's scheduled-height due-ness, never block the call that consults it.
     func testAdvanceStepDegradesToNilTipWhenBlockRateSamplesThrows() async throws {
         welding.migrationBlockRateSamplesWindowThrowableError = StubEngineError()
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
         let step = try await migration.advanceStep()
 
         XCTAssertEqual(step, .waiting, "an estimator failure must not fail the advance step")
         XCTAssertNil(
-            welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments?.estimatedTip,
+            welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.estimatedTip,
             "an estimator failure must degrade to the scanned-tip behavior"
         )
-    }
-
-    /// The whole reason ``MigrationSpacingFloors`` exists: an actor built for testnet must reach
-    /// the welding with a NONZERO floor pair, not the mainnet zero default -- pinning that the
-    /// actor itself derives and forwards them (``OrchardMigration/spacingFloors(network:secondsPerBlock:)``'s
-    /// own unit tests cover the formula in isolation; this is the composition wire-up).
-    func testAdvanceStepPassesNonzeroSpacingFloorsOnTestnet() async throws {
-        welding.migrationBlockRateSamplesWindowReturnValue = []
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
-        let migration = makeMigration(
-            broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())),
-            network: .testnet
-        )
-
-        _ = try await migration.advanceStep()
-
-        let received = try XCTUnwrap(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments)
-        XCTAssertNotEqual(
-            received.spacingFloors,
-            MigrationSpacingFloors.zero,
-            "testnet must derive nonzero spacing floors, never the mainnet zero pair"
-        )
-        XCTAssertGreaterThan(received.spacingFloors.toleranceFloor, 0)
-        XCTAssertGreaterThan(received.spacingFloors.releaseSpacingFloor, 0)
-    }
-
-    /// Mainnet's other half: even with a genuinely MEASURED `secondsPerBlock` in reach -- two
-    /// block-rate samples, enough for `ChainTipEstimator.secondsPerBlock()` to compute a real
-    /// delta rather than fall back to the nominal 75 s (which needs only one, or zero, samples
-    /// and so would not exercise this) -- a mainnet-built actor still reaches the welding with
-    /// the zero pair -- the hard requirement that mainnet never derives a floor, unconditionally.
-    func testAdvanceStepPassesZeroSpacingFloorsOnMainnetRegardlessOfMeasurement() async throws {
-        let firstSampleTime = referenceDate.addingTimeInterval(-150)
-        let secondSampleTime = referenceDate.addingTimeInterval(-90)
-        welding.migrationBlockRateSamplesWindowReturnValue = [
-            MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(firstSampleTime.timeIntervalSince1970)),
-            MigrationBlockRateSample(height: 3_000_001, unixTime: Int64(secondSampleTime.timeIntervalSince1970))
-        ]
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
-        let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
-
-        _ = try await migration.advanceStep()
-
-        let received = try XCTUnwrap(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments)
-        XCTAssertEqual(received.spacingFloors, MigrationSpacingFloors.zero)
     }
 
     /// `hasOverdueTransfers(useEstimatedTip:)` mirrors the same wiring as
@@ -911,7 +866,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
 
     // MARK: - Helpers
 
-    private func makeMigration(broadcaster: any MigrationBroadcasting, network: NetworkType = .mainnet) -> OrchardMigration {
+    private func makeMigration(broadcaster: any MigrationBroadcasting) -> OrchardMigration {
         // `isSyncBlocked()` and the `useEstimatedTip: true` paths unconditionally read
         // `migrationBlockRateSamples` (`ChainTipEstimator`'s raw input); default it to "no samples"
         // so a test that never cares about the estimate does not crash on the mock's un-stubbed,
@@ -929,8 +884,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             logger: logger,
             // The actor's estimate-consulting paths read the injected clock (U7), so the
             // fake-clock projection tests are deterministic.
-            now: { clockValue.now },
-            network: network
+            now: { clockValue.now }
         )
     }
 

--- a/Tests/OfflineTests/OrchardMigrationHostTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationHostTests.swift
@@ -42,7 +42,7 @@ final class OrchardMigrationHostTests: ZcashTestCase {
     /// driving each actor reaches the welding with that actor's own account UUID.
     func testMigrationForAccountCachesPerAccountAndRoutesTheRightUUID() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
         welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = false
         let host = makeHost(welding: welding, broadcaster: ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable)))
 
@@ -55,9 +55,9 @@ final class OrchardMigrationHostTests: ZcashTestCase {
 
         // Driving each actor (sequentially) reaches the welding with that actor's own account UUID.
         _ = try await firstA.advanceStep()
-        XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments?.account, accountA)
+        XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountA)
         _ = try await firstB.advanceStep()
-        XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments?.account, accountB)
+        XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountB)
     }
 
     // MARK: - Shared broadcaster (single Tor bootstrap across accounts)

--- a/Tests/OfflineTests/OrchardMigrationHostTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationHostTests.swift
@@ -90,6 +90,8 @@ final class OrchardMigrationHostTests: ZcashTestCase {
         let perAccountFactory: (AccountUUID, any MigrationBroadcasting) -> OrchardMigration = { [testGeneralStorageDirectory, buffer, clock, accountB] accountUUID, broadcaster in
             let accountWelding = ZcashRustBackendWeldingMock()
             accountWelding.migrationNextDueTransferForEstimatedTipReturnValue = .ready(prepared)
+            // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+            accountWelding.migrationTransactionStatusesForReturnValue = []
             accountWelding.migrationExtractBroadcastTxPcztForClosure = { _, _ in
                 if accountUUID == accountB {
                     accountBReachedTheBroadcaster.fulfill()
@@ -107,7 +109,6 @@ final class OrchardMigrationHostTests: ZcashTestCase {
                     bufferDuration: buffer,
                     tickInterval: 3600,
                     now: { clock!.now },
-                    readyBroadcastProvider: { false },
                     logger: logger
                 ),
                 logger: logger
@@ -170,7 +171,6 @@ final class OrchardMigrationHostTests: ZcashTestCase {
             bufferDuration: buffer,
             tickInterval: 3600,
             now: { [clock] in clock!.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
         dormantGateB.markBroadcast()
@@ -202,49 +202,22 @@ final class OrchardMigrationHostTests: ZcashTestCase {
     /// The wallet-scope gate consults the READY-broadcast predicate (D1): a proved, due transfer
     /// on any enumerated account blocks sync — and per U8 the scanned tip is asked first, so a
     /// `true` scanned answer never pays for the block-rate sample read.
-    func testIsSyncBlockedBlocksOnAReadyBroadcastWithoutReadingSamplesWhenScannedAnswers() async throws {
+    /// D1 REVERSAL PIN at wallet scope: a servable ready broadcast no longer blocks sync, and
+    /// the wallet-scope predicate consults neither the probe nor the estimate — its whole
+    /// second pass died with the gate's forward-looking clause.
+    func testIsSyncBlockedIgnoresReadyBroadcastsAcrossAllAccounts() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.listAccountsReturnValue = [makeAccount(accountA)]
+        welding.listAccountsReturnValue = [makeAccount(accountA), makeAccount(accountB)]
         welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
         let host = makeHost(welding: welding, broadcaster: ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable)))
 
         let blocked = await host.isSyncBlocked()
 
-        XCTAssertTrue(blocked)
-        XCTAssertEqual(welding.migrationHasReadyBroadcastForEstimatedTipCallsCount, 1)
-        XCTAssertNil(welding.migrationHasReadyBroadcastForEstimatedTipReceivedArguments?.estimatedTip)
-        XCTAssertFalse(welding.migrationBlockRateSamplesWindowCalled, "a true scanned answer must skip the estimate")
+        XCTAssertFalse(blocked, "sync holds only for past/present broadcasts (gate files, live views)")
+        XCTAssertFalse(welding.migrationHasReadyBroadcastForEstimatedTipCalled, "no gate path consults the probe anymore")
+        XCTAssertFalse(welding.migrationBlockRateSamplesWindowCalled, "the estimate pass is deleted")
     }
 
-    /// U8's second half at wallet scope: with every scanned answer `false`, the estimate is
-    /// projected ONCE (the samples are wallet-scoped) and each account is re-asked with it — an
-    /// estimate-accelerated ready broadcast then blocks.
-    func testIsSyncBlockedProjectsTheEstimateOnceAndReAsksEveryAccount() async throws {
-        let welding = ZcashRustBackendWeldingMock()
-        welding.listAccountsReturnValue = [makeAccount(accountA), makeAccount(accountB)]
-        let sampleTime = referenceDate.addingTimeInterval(-150)
-        welding.migrationBlockRateSamplesWindowReturnValue = [
-            MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(sampleTime.timeIntervalSince1970))
-        ]
-        var receivedAsks: [(account: AccountUUID, estimatedTip: BlockHeight?)] = []
-        welding.migrationHasReadyBroadcastForEstimatedTipClosure = { account, estimatedTip in
-            receivedAsks.append((account: account, estimatedTip: estimatedTip))
-            // Scanned answers are false; only account B is due under the estimate.
-            return estimatedTip != nil && account == self.accountB
-        }
-        let host = makeHost(welding: welding, broadcaster: ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable)))
-
-        let blocked = await host.isSyncBlocked()
-
-        XCTAssertTrue(blocked, "an estimate-accelerated ready broadcast on any account must block sync")
-        XCTAssertEqual(welding.migrationBlockRateSamplesWindowCallsCount, 1, "the wallet-scoped samples are read exactly once")
-        XCTAssertEqual(receivedAsks.filter { $0.estimatedTip == nil }.count, 2, "both accounts are asked at the scanned tip first")
-        // The frozen fake clock makes the projection deterministic: height + floor(150/75) (U7).
-        XCTAssertTrue(
-            receivedAsks.filter { $0.estimatedTip != nil }.allSatisfy { $0.estimatedTip == 3_000_002 },
-            "the estimate re-asks must carry the clock-injected projection; got \(receivedAsks)"
-        )
-    }
 
     /// A8: a mark whose gate-FILE write failed (the gate directory is made read-only, so
     /// `markBroadcast()`'s persist fails while its in-memory cache updates) must still block the
@@ -269,7 +242,6 @@ final class OrchardMigrationHostTests: ZcashTestCase {
                 bufferDuration: bufferDuration,
                 tickInterval: 3600,
                 now: { clockValue.now },
-                readyBroadcastProvider: { false },
                 logger: logger
             )
             capturedGates.append(gate)
@@ -341,6 +313,8 @@ final class OrchardMigrationHostTests: ZcashTestCase {
             txid: Data(repeating: 0xAB, count: 32),
             pczt: Data([0x01, 0x02])
         ))
+        // D2: broadcastAndRecord now reads statuses for the prep buffer exemption; empty = transfer treatment (buffer arms), the old semantics.
+        welding.migrationTransactionStatusesForReturnValue = []
         welding.migrationExtractBroadcastTxPcztForReturnValue = Data([0x07])
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
 
@@ -384,7 +358,6 @@ final class OrchardMigrationHostTests: ZcashTestCase {
             bufferDuration: buffer,
             tickInterval: 3600,
             now: { [clock] in clock!.now },
-            readyBroadcastProvider: { false },
             logger: logger
         )
         dormantGateD.markBroadcast()
@@ -557,7 +530,6 @@ final class OrchardMigrationHostTests: ZcashTestCase {
                     bufferDuration: bufferDuration,
                     tickInterval: gateTickInterval,
                     now: { clockValue.now },
-                    readyBroadcastProvider: { (try? await welding.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: nil)) ?? false },
                     logger: logger
                 ),
                 logger: logger

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -61,12 +61,12 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         ]
 
         for expectedStep in cases {
-            welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = expectedStep
+            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedStep
 
             let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
 
             XCTAssertEqual(step, expectedStep)
-            XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments?.account, accountUUID)
+            XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountUUID)
         }
     }
 
@@ -197,7 +197,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
     /// proposal. Hosts must not latch "never migrate again" off `migrationAdvanceStep` alone.
     func testAfterCompleteProposeMigrationTransfersAnswersWhetherAnythingRemains() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .complete
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = .complete
         welding.migrationProposeTransfersForReturnValue = MigrationSchedule(
             transfers: [],
             estimatedDurationHours: 0,

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -492,10 +492,21 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
 
     // MARK: - Forwarding: wallet-scope gate members
 
+    /// D1: the forwarding tests' "engineered-non-default blocked" driver — a gate FILE with a
+    /// live privacy buffer, written where `makeHost`'s storage points so the host's wallet-scope
+    /// predicate reads it. (The old lever — the ready-broadcast probe — died with the gate's
+    /// forward-looking clause, 2026-08-05.)
+    private func writeLiveBufferGateFile(accountUUID: AccountUUID) throws {
+        let fileURL = testGeneralStorageDirectory!
+            .appendingPathComponent(MigrationSyncGate.fileName(accountUUID: accountUUID))
+        let json = "{\"version\":1,\"resumeAtEpochSeconds\":\(Date().addingTimeInterval(3600).timeIntervalSince1970)}"
+        try Data(json.utf8).write(to: fileURL)
+    }
+
     func testIsMigrationSyncBlockedForwardsToHostPredicate() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
         let blocked = await synchronizer.isMigrationSyncBlocked()
@@ -508,7 +519,6 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
     func testMigrationSyncBlockedStreamForwardsToHostStream() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding, tickInterval: 0.02))
 
         var received: [Bool] = []
@@ -520,6 +530,14 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
             }
         }
         cancellables.append(cancellable)
+
+        // D1: the flip is driven by the gate FILE now — written only after the seed emission, so
+        // the "fresh host seeds false" precondition stays observable; the host's next 0.02 s
+        // recompute reads the file and flips.
+        while received.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
 
         await fulfillment(of: [sawBlocked], timeout: 5)
         // The inert protocol default only ever emits false; observing true here proves this is
@@ -540,7 +558,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
     func testStartThrowsMigrationSyncBlockedWhenHostReportsBlocked() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
         await synchronizer.updateStatus(.stopped)
 
@@ -842,7 +860,6 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
                         bufferDuration: 600,
                         tickInterval: tickInterval,
                         now: { Date() },
-                        readyBroadcastProvider: { (try? await welding.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: nil)) ?? false },
                         logger: logger
                     ),
                     logger: logger

--- a/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
@@ -465,10 +465,21 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
 
     // MARK: - Forwarding: wallet-scope gate members
 
+    /// D1: the forwarding tests' "engineered-non-default blocked" driver — a gate FILE with a
+    /// live privacy buffer, written where `makeHost`'s storage points so the host's wallet-scope
+    /// predicate reads it. (The old lever — the ready-broadcast probe — died with the gate's
+    /// forward-looking clause, 2026-08-05.)
+    private func writeLiveBufferGateFile(accountUUID: AccountUUID) throws {
+        let fileURL = testGeneralStorageDirectory!
+            .appendingPathComponent(MigrationSyncGate.fileName(accountUUID: accountUUID))
+        let json = "{\"version\":1,\"resumeAtEpochSeconds\":\(Date().addingTimeInterval(3600).timeIntervalSince1970)}"
+        try Data(json.utf8).write(to: fileURL)
+    }
+
     func testIsMigrationSyncBlockedForwardsToHostPredicate() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
         let blocked = await synchronizer.isMigrationSyncBlocked()
@@ -481,7 +492,6 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
     func testMigrationSyncBlockedStreamForwardsToHostStream() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding, tickInterval: 0.02))
 
         var received: [Bool] = []
@@ -493,6 +503,14 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
             }
         }
         cancellables.append(cancellable)
+
+        // D1: the flip is driven by the gate FILE now — written only after the seed emission, so
+        // the "fresh host seeds false" precondition stays observable; the host's next 0.02 s
+        // recompute reads the file and flips.
+        while received.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
 
         await fulfillment(of: [sawBlocked], timeout: 5)
         // The inert protocol default only ever emits false; observing true here proves this is
@@ -533,7 +551,7 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
     func testStartThrowsMigrationSyncBlockedWhenHostReportsBlocked() async throws {
         let welding = ZcashRustBackendWeldingMock()
         welding.listAccountsReturnValue = [makeAccount(accountUUID)]
-        welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = true
+        try writeLiveBufferGateFile(accountUUID: accountUUID)
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
         await synchronizer.setInternalSyncStatusForTesting(.disconnected)
 
@@ -759,7 +777,6 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
                         bufferDuration: 600,
                         tickInterval: tickInterval,
                         now: { Date() },
-                        readyBroadcastProvider: { (try? await welding.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: nil)) ?? false },
                         logger: logger
                     ),
                     logger: logger

--- a/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
@@ -83,12 +83,12 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
         ]
 
         for expectedStep in cases {
-            welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = expectedStep
+            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedStep
 
             let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
 
             XCTAssertEqual(step, expectedStep)
-            XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments?.account, accountUUID)
+            XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountUUID)
         }
     }
 
@@ -537,7 +537,7 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
     /// `testMigrationSyncBlockedStreamForwardsToHostStream`).
     func testThrowingMigrationMemberIsSlipstreamSynchronizersOwnWitnessNotTheProtocolDefault() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
         // If SlipstreamSynchronizer still fell through to the protocol default, this would throw

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2773,6 +2773,30 @@ class SynchronizerMock: Synchronizer {
         }
     }
 
+    // MARK: - reconcileUnrecordedMigrationBroadcasts
+
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDThrowableError: Error?
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount = 0
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDCalled: Bool {
+        return reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount > 0
+    }
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDReceivedAccountUUID: AccountUUID?
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDReturnValue: Bool!
+    var reconcileUnrecordedMigrationBroadcastsAccountUUIDClosure: ((AccountUUID) async throws -> Bool)?
+
+    func reconcileUnrecordedMigrationBroadcasts(accountUUID: AccountUUID) async throws -> Bool {
+        if let error = reconcileUnrecordedMigrationBroadcastsAccountUUIDThrowableError {
+            throw error
+        }
+        reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount += 1
+        reconcileUnrecordedMigrationBroadcastsAccountUUIDReceivedAccountUUID = accountUUID
+        if let closure = reconcileUnrecordedMigrationBroadcastsAccountUUIDClosure {
+            return try await closure(accountUUID)
+        } else {
+            return reconcileUnrecordedMigrationBroadcastsAccountUUIDReturnValue
+        }
+    }
+
     // MARK: - migrationSyncWakeups
 
     var migrationSyncWakeupsAccountUUIDThrowableError: Error?
@@ -5025,25 +5049,25 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
 
     // MARK: - migrationAdvanceStep
 
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsThrowableError: Error?
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsCallsCount = 0
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsCalled: Bool {
-        return migrationAdvanceStepForEstimatedTipSpacingFloorsCallsCount > 0
+    var migrationAdvanceStepForEstimatedTipThrowableError: Error?
+    var migrationAdvanceStepForEstimatedTipCallsCount = 0
+    var migrationAdvanceStepForEstimatedTipCalled: Bool {
+        return migrationAdvanceStepForEstimatedTipCallsCount > 0
     }
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments: (account: AccountUUID, estimatedTip: BlockHeight?, spacingFloors: MigrationSpacingFloors)?
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue: MigrationAdvanceStep?
-    var migrationAdvanceStepForEstimatedTipSpacingFloorsClosure: ((AccountUUID, BlockHeight?, MigrationSpacingFloors) async throws -> MigrationAdvanceStep?)?
+    var migrationAdvanceStepForEstimatedTipReceivedArguments: (account: AccountUUID, estimatedTip: BlockHeight?)?
+    var migrationAdvanceStepForEstimatedTipReturnValue: MigrationAdvanceStep?
+    var migrationAdvanceStepForEstimatedTipClosure: ((AccountUUID, BlockHeight?) async throws -> MigrationAdvanceStep?)?
 
-    func migrationAdvanceStep(for account: AccountUUID, estimatedTip: BlockHeight?, spacingFloors: MigrationSpacingFloors) async throws -> MigrationAdvanceStep? {
-        if let error = migrationAdvanceStepForEstimatedTipSpacingFloorsThrowableError {
+    func migrationAdvanceStep(for account: AccountUUID, estimatedTip: BlockHeight?) async throws -> MigrationAdvanceStep? {
+        if let error = migrationAdvanceStepForEstimatedTipThrowableError {
             throw error
         }
-        migrationAdvanceStepForEstimatedTipSpacingFloorsCallsCount += 1
-        migrationAdvanceStepForEstimatedTipSpacingFloorsReceivedArguments = (account: account, estimatedTip: estimatedTip, spacingFloors: spacingFloors)
-        if let closure = migrationAdvanceStepForEstimatedTipSpacingFloorsClosure {
-            return try await closure(account, estimatedTip, spacingFloors)
+        migrationAdvanceStepForEstimatedTipCallsCount += 1
+        migrationAdvanceStepForEstimatedTipReceivedArguments = (account: account, estimatedTip: estimatedTip)
+        if let closure = migrationAdvanceStepForEstimatedTipClosure {
+            return try await closure(account, estimatedTip)
         } else {
-            return migrationAdvanceStepForEstimatedTipSpacingFloorsReturnValue
+            return migrationAdvanceStepForEstimatedTipReturnValue
         }
     }
 
@@ -5116,6 +5140,30 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
             return try await closure(window)
         } else {
             return migrationBlockRateSamplesWindowReturnValue
+        }
+    }
+
+    // MARK: - migrationReconcileUnrecordedBroadcasts
+
+    var migrationReconcileUnrecordedBroadcastsForThrowableError: Error?
+    var migrationReconcileUnrecordedBroadcastsForCallsCount = 0
+    var migrationReconcileUnrecordedBroadcastsForCalled: Bool {
+        return migrationReconcileUnrecordedBroadcastsForCallsCount > 0
+    }
+    var migrationReconcileUnrecordedBroadcastsForReceivedAccount: AccountUUID?
+    var migrationReconcileUnrecordedBroadcastsForReturnValue: Bool!
+    var migrationReconcileUnrecordedBroadcastsForClosure: ((AccountUUID) async throws -> Bool)?
+
+    func migrationReconcileUnrecordedBroadcasts(for account: AccountUUID) async throws -> Bool {
+        if let error = migrationReconcileUnrecordedBroadcastsForThrowableError {
+            throw error
+        }
+        migrationReconcileUnrecordedBroadcastsForCallsCount += 1
+        migrationReconcileUnrecordedBroadcastsForReceivedAccount = account
+        if let closure = migrationReconcileUnrecordedBroadcastsForClosure {
+            return try await closure(account)
+        } else {
+            return migrationReconcileUnrecordedBroadcastsForReturnValue
         }
     }
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -19,10 +19,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     decision into `FfiMigrationAdvanceStep`, freed by
     `zcashlc_free_migration_advance_step`; `NULL` with no last error means no run is stored; the
     step discriminants are exported as `ZCASHLC_ADVANCE_STEP_*` constants; upstream `Reevaluate`
-    and `Replan` map to the compatibility `_ATTEND` case; two trailing `u32` params,
-    `overdue_tolerance_floor`/`release_spacing_floor`, pass through to
-    `AdvanceConfig::with_compressed_schedule_floors` — zero means no floor, and mainnet callers
-    pass zero on every call), `_progress`,
+    and `Replan` map to the compatibility `_ATTEND` case), `_progress`,
     `_is_note_split_needed`, `_has_overdue_transfers`, `_has_invalid_transfers` (true iff the
     NON-terminal stored run holds an engine-`Invalid` or expired-unmined transaction; a cancelled
     run answers `false`), `_has_ready_broadcast` (the sync-gate's work-pending predicate:

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -91,7 +91,7 @@ use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{PoolType, ShieldedPool, TxId};
 
 use zcash_pool_migration::engine::{
-    self, MigrationBackend, MigrationPlan, MigrationState, MigrationStatus, MigrationTransaction,
+    self, MigrationBackend, MigrationPlan, MigrationState, MigrationTransaction,
     MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 use zcash_pool_migration::satisfiability::{
@@ -494,9 +494,11 @@ fn resolve_immediate_run(
 
 // ----- reconciliation, planning, committing -----
 
-/// Loads the stored run with its `Broadcast` transactions promoted to `Mined` wherever the
-/// wallet's scan has since seen them, persisting once if anything changed. `None` means no
-/// migration is stored.
+/// Loads the stored run — TERMINAL RUNS INCLUDED, via [`Backend::latest_migration`], since
+/// upstream's `get_migration` went pending-only and the reads built on this must keep serving a
+/// completed, failed, or cancelled run (progress, statuses, history) — with its `Broadcast`
+/// transactions promoted to `Mined` wherever the wallet's scan has since seen them, persisting
+/// once if anything changed. `None` means no migration was ever stored.
 ///
 /// The promotion itself is the ENGINE's — [`PoolMigrationRead::mined_height`], the same query
 /// `advance_migration` sweeps with, bounded by the wallet's fully-scanned height rather than by
@@ -506,7 +508,7 @@ fn resolve_immediate_run(
 /// is not answered from a state the wallet's own scan has already moved past.
 fn reconcile_mined(ctx: &mut CallCtx) -> anyhow::Result<Option<MigrationState>> {
     let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-    let Some(mut state) = backend.get_migration()? else {
+    let Some(mut state) = backend.latest_migration()? else {
         return Ok(None);
     };
     if state.is_terminal() {
@@ -1259,7 +1261,8 @@ fn next_due(state: &MigrationState, targets: DuenessTargets) -> DueOutcome {
 /// The id [`zcashlc_migration_next_due_transfer`] WOULD serve once every outstanding
 /// proof exists: the next broadcastable row after virtually proving every prove-ready `Signed` row
 /// over a scratch copy — no prover runs and nothing persists (`set_transaction_proved` with the
-/// row's own bytes only flips the lifecycle state). `None` when the delivery lane has nothing
+/// row's own bytes and no lock owner only flips the lifecycle state). `None` when the delivery
+/// lane has nothing
 /// actionable: nothing schedule-due yet, dependencies unmined, rows awaiting an external signature
 /// (the signing ceremony, not the delivery lane, advances those), or everything already
 /// broadcast/mined.
@@ -1295,7 +1298,7 @@ fn due_assuming_proving(
             .find(|t| t.id() == id)
             .map(|t| t.pczt().clone())
             .unwrap_or_default();
-        scratch.set_transaction_proved(id, bytes);
+        scratch.set_transaction_proved(id, bytes, None);
     }
     scratch.next_due_broadcast(targets)
 }
@@ -2238,14 +2241,17 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         // would only ask the same question twice.
         let Some(mut state) = ({
             let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-            backend.get_migration()?
+            // `latest_migration`, not the trait's `get_migration`: upstream made the latter
+            // PENDING-ONLY, and this conduit's contract still reports `Complete` (below) for a
+            // terminal stored run rather than "no run".
+            backend.latest_migration()?
         }) else {
             // No stored run: NULL with NO error (see the function doc). Returned before any
             // chain-tip lookup, so it holds even before the wallet ever saw a chain tip.
             return Ok(ptr::null_mut());
         };
         // Upstream `next_step`'s own first check, hoisted ahead of the target lookup (not a
-        // carve-out — identical answers): a cancelled (Failed) run reports Complete even on a
+        // carve-out — identical answers): a cancelled or failed run reports Complete even on a
         // wallet with no chain tip, and is never driven further.
         if state.is_terminal() {
             return Ok(FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_COMPLETE));
@@ -2260,7 +2266,10 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
             // librustzcash #2910: re-spreading a missed broadcast schedule draws fresh
             // inter-broadcast gaps, so advancing needs entropy.
             &mut OsRng,
-        )?;
+        )?
+        // librustzcash #2936: the advance returns the verified step plus a next-wake outlook;
+        // this conduit marshals the step alone (no FFI field carries the outlook yet).
+        .step();
         Ok(match step {
             AdvanceStep::Reevaluate | AdvanceStep::Replan => {
                 let id = state
@@ -3498,9 +3507,10 @@ pub unsafe extern "C" fn zcashlc_migration_record_immediate_run(
     unwrap_exc_or(res, false)
 }
 
-/// Cancels the stored run (persisting it as `Failed` — its pre-signed transactions are abandoned;
-/// already-broadcast ones are unaffected on-chain) and previews a fresh plan against the live
-/// balance for the platform's re-confirm lane.
+/// Cancels the stored run through the engine's own cancel (persisting it as `Cancelled` and
+/// releasing every note reservation its never-broadcast transactions hold — its pre-signed
+/// transactions are abandoned; already-broadcast ones are unaffected on-chain) and previews a
+/// fresh plan against the live balance for the platform's re-confirm lane.
 ///
 /// Cancelling is also what clears the attention state: a terminal run surfaces neither
 /// `AdvanceStep::Attend` (upstream `next_step` answers `Complete` for it) nor
@@ -3521,19 +3531,12 @@ pub unsafe extern "C" fn zcashlc_migration_restart_step(
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
         {
             let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-            if let Some(state) = backend.get_migration()? {
-                if !state.is_terminal() {
-                    let cancelled = MigrationState::from_parts(
-                        MigrationStatus::Failed,
-                        state.denominations().clone(),
-                        state.preparation().clone(),
-                        state.transactions().clone(),
-                        state.anchor_bucket_interval(),
-                        state.replan_threshold(),
-                    );
-                    backend.replace_migration(&cancelled)?;
-                }
-            }
+            // The engine's own cancel: releases every note reservation the pending run's
+            // never-broadcast transactions hold and records the terminal `Cancelled` status, in
+            // one store transaction. Hand-writing `Failed` (the pre-locking behavior) would
+            // leave those reservations standing, and the fresh plan below would select around
+            // notes the abandoned run still holds.
+            backend.cancel_migration()?;
         }
         match plan_and_cache(&mut ctx, false)? {
             Some((plan, reference_height, handle)) => {
@@ -4150,6 +4153,7 @@ mod tests {
     use rand::rngs::StdRng;
     use zcash_client_backend::data_api::WalletWrite;
     use zcash_pool_migration::denomination::DenominationPlan;
+    use zcash_pool_migration::engine::{MigrationLockOwner, MigrationStatus};
     use zcash_pool_migration::preparation::PreparationPlan;
     use zcash_pool_migration::scheduling::{self, AnchorBucketInterval, SchedulingParams};
     use zcash_pool_migration::signing_rounds::min_signing_rounds;
@@ -4172,7 +4176,7 @@ mod tests {
         expiry_height: BlockHeight,
         anchor_boundary: Option<BlockHeight>,
         state: MigrationTxState,
-        lock_owner: Option<[u8; 32]>,
+        lock_owner: Option<MigrationLockOwner>,
     ) -> MigrationTransaction {
         MigrationTransaction::from_parts(
             id,
@@ -6659,7 +6663,7 @@ mod tests {
         )
         .expect("the account-keyed store resolves the fixture account");
         let stored = store
-            .get_migration()
+            .latest_migration()
             .expect("the store reads")
             .expect("the fixture state is still stored");
         let tx = stored
@@ -6687,7 +6691,7 @@ mod tests {
     /// The prover error type the dispatch tests fail with: the REAL upstream
     /// [`WalletProveError`] (so the classification under test is the production one), with unit
     /// tree/note/chain-state error parameters.
-    type TestProveError = WalletProveError<(), (), ()>;
+    type TestProveError = WalletProveError<(), (), (), ()>;
 
     /// Which prover method the dispatch routed a transaction to, and with which anchor.
     #[derive(Debug, PartialEq, Eq)]
@@ -6722,6 +6726,17 @@ mod tests {
             Ok(pczt)
         }
 
+        /// Models no note-lock state: reserves nothing and reports no owner, deliberately (the
+        /// trait has no default so that taking no locks is always an explicit choice). These
+        /// provers exercise dispatch and error classification, not the reservation.
+        fn lock_spent_notes(
+            &mut self,
+            _pczt: &pczt::Pczt,
+            _lock_expiry_height: BlockHeight,
+        ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+            Ok(None)
+        }
+
         fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
             AnchorBucketInterval::ZIP_318
         }
@@ -6753,6 +6768,17 @@ mod tests {
             Err(engine::ProveFailure::Other(
                 self.error.take().expect("the prover is consulted once"),
             ))
+        }
+
+        /// Models no note-lock state: reserves nothing and reports no owner, deliberately (the
+        /// trait has no default so that taking no locks is always an explicit choice). These
+        /// provers exercise dispatch and error classification, not the reservation.
+        fn lock_spent_notes(
+            &mut self,
+            _pczt: &pczt::Pczt,
+            _lock_expiry_height: BlockHeight,
+        ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+            Ok(None)
         }
 
         fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
@@ -6830,6 +6856,17 @@ mod tests {
             anchor: BlockHeight,
         ) -> Result<pczt::Pczt, engine::ProveFailure<Self::Error>> {
             self.answer(ProveCall::Preparation(anchor), pczt)
+        }
+
+        /// Models no note-lock state: reserves nothing and reports no owner, deliberately (the
+        /// trait has no default so that taking no locks is always an explicit choice). These
+        /// provers exercise dispatch and error classification, not the reservation.
+        fn lock_spent_notes(
+            &mut self,
+            _pczt: &pczt::Pczt,
+            _lock_expiry_height: BlockHeight,
+        ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+            Ok(None)
         }
 
         fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
@@ -7244,7 +7281,7 @@ mod tests {
         )
         .expect("the account-keyed store resolves the fixture account");
         store
-            .get_migration()
+            .latest_migration()
             .expect("the store reads")
             .expect("a migration is stored")
     }
@@ -7712,7 +7749,7 @@ mod tests {
         let mut proved_ids: Vec<MigrationTransferId> = Vec::new();
         let proved = prove_pending_rows(&mut state, h(4_100), Some(1), |state, id| {
             proved_ids.push(id);
-            state.set_transaction_proved(id, Vec::new());
+            state.set_transaction_proved(id, Vec::new(), None);
             Ok(true)
         })
         .expect("the recording prove closure must not fail");

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -2221,13 +2221,6 @@ fn remaining_orchard(ctx: &mut CallCtx) -> anyhow::Result<Zatoshis> {
 /// chain-tip lookup — the same answer `next_step` would give, available on a wallet that never
 /// saw a chain tip.)
 ///
-/// `overdue_tolerance_floor` and `release_spacing_floor` pass straight through to
-/// [`AdvanceConfig::with_compressed_schedule_floors`]: zero means no floor — the schedule runs
-/// exactly as ZIP 318 documents, byte-identical to this function's behavior before the floors
-/// existed. Production mainnet callers pass zero for both. A caller whose committed schedule is
-/// compressed below its own wall-clock privacy buffer derives nonzero floors from that buffer
-/// and its own block spacing and passes them here instead.
-///
 /// # Safety
 /// See [`open`]. Free the returned pointer with [`zcashlc_free_migration_advance_step`].
 #[unsafe(no_mangle)]
@@ -2237,8 +2230,6 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
     account_uuid_bytes: *const u8,
     network_id: u32,
     estimated_tip: i64,
-    overdue_tolerance_floor: u32,
-    release_spacing_floor: u32,
 ) -> *mut FfiMigrationAdvanceStep {
     let res = catch_panic(|| {
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
@@ -2265,8 +2256,7 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
             &mut backend,
             &mut state,
             targets,
-            &AdvanceConfig::new(ReorgSettleDepth::new(10))
-                .with_compressed_schedule_floors(overdue_tolerance_floor, release_spacing_floor),
+            &AdvanceConfig::new(ReorgSettleDepth::new(10)),
             // librustzcash #2910: re-spreading a missed broadcast schedule draws fresh
             // inter-broadcast gaps, so advancing needs entropy.
             &mut OsRng,
@@ -6309,8 +6299,6 @@ mod tests {
                 account.as_ptr(),
                 NETWORK_ID_MAINNET,
                 -1,
-                0,
-                0,
             )
         };
         assert!(
@@ -8382,8 +8370,6 @@ mod tests {
                 account.as_ptr(),
                 NETWORK_ID_MAINNET,
                 -1,
-                0,
-                0,
             )
         };
         assert!(

--- a/rust/src/migration_engine.rs
+++ b/rust/src/migration_engine.rs
@@ -89,6 +89,29 @@ impl<'a> Backend<'a> {
         })
     }
 
+    /// The account's most recent migration WHATEVER its status — the store's history-inclusive
+    /// read. `PoolMigrationRead::get_migration` (this backend's trait impl) is PENDING-ONLY
+    /// upstream: a terminal run is retained history and leaves that accessor, so every SDK read
+    /// that must keep serving a completed, failed, or cancelled run (progress, statuses, the
+    /// advance conduit's terminal `Complete` answer) reads through here instead.
+    pub(crate) fn latest_migration(&self) -> anyhow::Result<Option<MigrationState>> {
+        self.store
+            .latest_migration()
+            .map_err(|e| anyhow!("migration store read failed: {e}"))
+    }
+
+    /// Cancel the account's pending migration through the store: releases every note reservation
+    /// its never-broadcast transactions hold and moves the record to the terminal `Cancelled`
+    /// status, in one database transaction. With no pending migration it still performs the
+    /// repair half on the latest retained record (releasing reservations, e.g. of a run an older
+    /// client recorded `Failed` without unlocking).
+    pub(crate) fn cancel_migration(&mut self) -> anyhow::Result<()> {
+        self.store
+            .cancel_migration()
+            .map(|_outcome| ())
+            .map_err(|e| anyhow!("cancelling the migration failed: {e}"))
+    }
+
     /// The target height for note selection (the chain tip plus one).
     fn selection_target(&self) -> anyhow::Result<TargetHeight> {
         let tip = self

--- a/rust/src/migration_finalize.rs
+++ b/rust/src/migration_finalize.rs
@@ -52,6 +52,7 @@
 
 use anyhow::anyhow;
 use zcash_client_backend::data_api::WalletRead;
+use zcash_client_backend::data_api::locking::LockError;
 use zcash_pool_migration::engine::{
     self, MigrationProver, MigrationState, MigrationTransferId, MigrationTxKind,
 };
@@ -86,21 +87,26 @@ pub(crate) trait ProveErrorClass {
     fn is_transient(&self) -> bool;
 }
 
-impl<TE, NE, RE> ProveErrorClass for WalletProveError<TE, NE, RE> {
+impl<TE, NE, RE, LE> ProveErrorClass for WalletProveError<TE, NE, RE, LE> {
     /// Transient = "not scanned/retained yet or transiently unqueryable — resolves as the wallet
     /// syncs": no spendable note yet matches the spend's revealed nullifier (`UnknownSpentNote` —
     /// a late-mining dependency's note the wallet has not seen yet), no root at the anchor
     /// checkpoint yet (`AnchorNotFound`), the spent note not witnessable there yet
     /// (`WitnessNotFound`), a commitment-tree QUERY failure (`Tree(ShardTreeError::Query(_))` —
     /// shard-tree query races during sync; this exact case crash-looped a prove batch on Android
-    /// on 2026-07-28), or no chain data at all (`ChainTipUnknown`).
+    /// on 2026-07-28), no chain data at all (`ChainTipUnknown`), or a note-lock CONFLICT
+    /// (`Lock(LockFailure)` — another flow, typically a user payment proposed mid-prove, holds a
+    /// spent note's lock; it may release or let it expire, so a later attempt can succeed, and if
+    /// the competing transaction mines instead the next attempt reports `UnknownSpentNote` and
+    /// the store oracle takes it from there).
     ///
     /// Hard = genuinely unrecoverable, must not be swallowed: everything else, including
     /// `IronwoodTreeUnavailable` explicitly — the backend tracks no Ironwood commitment tree at
-    /// all, which no amount of syncing produces — and the NON-query `Tree` variants (A6): a
+    /// all, which no amount of syncing produces — the NON-query `Tree` variants (A6): a
     /// `Storage(_)` failure is the persistence layer erroring and an `Insert(_)` a corrupt tree
     /// write, neither of which more syncing repairs, so deferring them would stall the sweep
-    /// silently forever.
+    /// silently forever — and `Lock(Storage(_))`, the same persistence-layer rationale at the
+    /// lock table.
     fn is_transient(&self) -> bool {
         matches!(
             self,
@@ -109,6 +115,7 @@ impl<TE, NE, RE> ProveErrorClass for WalletProveError<TE, NE, RE> {
                 | WalletProveError::WitnessNotFound(_)
                 | WalletProveError::Tree(shardtree::error::ShardTreeError::Query(_))
                 | WalletProveError::ChainTipUnknown
+                | WalletProveError::Lock(LockError::LockFailure(_))
         )
     }
 }


### PR DESCRIPTION
Part of #1946. D1+D2 rebased onto `michal/delegate-migration-selection-upstream` per danny's and nuttycom's 2026-08-05 rulings:

- **D1 (danny):** the sync gate loses its forward-looking clause — sync holds only for past/present broadcasts (privacy buffer + in-flight marker); a *ready* transfer no longer blocks sync before its window.
- **D2 (nuttycom, Shape A):** `Prove { id, kind }` is itself the sanction — when `kind` is a preparation the host proves and broadcasts in the same pass, no second `next_step` call, and preparations arm no privacy buffer.

Notes for review:

- The original branch carried a third commit widening the debug fast-reschedule to preparations; **dropped as superseded** — this base retires that endpoint in favor of the engine's exported schedule. One question to confirm on your side: the QA fast lane previously compressed preparations via that endpoint; with selection delegated to the engine, do the #1806 spacing floors also govern *preparation* scheduling, so compressed QA runs don't wedge at layer-1 splits again? (Field context: campaigns 7/8a died exactly there; yesterday's instrumented run also showed the app-side rescheduler re-running per session and desyncing scheds from anchors — retiring it kills that whole class, which is another argument for this base.)
- Verified on this base: swift build + OfflineTests green with a locally rebuilt FFI slice against the moved librustzcash pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
