### PR TITLE
Gate PRs on the Rust unit tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,17 +46,16 @@ jobs:
         path: BuildSupport/products/libzcashlc.xcframework
         key: ffi-xcframework-macos-only-${{ runner.os }}-${{ steps.ffi-hash.outputs.hash }}
 
-    # Only set up Rust if we need to build FFI
+    # Needed unconditionally: even on an FFI cache hit, the Rust test step below
+    # compiles the crate's test profile and so needs the toolchain.
     - name: Setup Rust
-      if: steps.cache-ffi.outputs.cache-hit != 'true'
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
         toolchain: stable
         targets: aarch64-apple-darwin, x86_64-apple-darwin
 
-    # Cache Cargo dependencies (only if building FFI)
+    # Cache Cargo dependencies (used by both the FFI build and the Rust tests)
     - name: Cache Cargo
-      if: steps.cache-ffi.outputs.cache-hit != 'true'
       uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
     # Build FFI for macOS only (sufficient for running tests)
@@ -68,6 +67,13 @@ jobs:
     # Verify xcframework exists (whether from cache or fresh build)
     - name: Verify XCFramework
       run: make verify-ffi
+
+    # The Rust unit tests cover the FFI layer below the Swift package, so no
+    # `swift test` filter reaches them. Without this step a failing Rust test
+    # can sit on a branch indefinitely.
+    - name: Run Rust unit tests
+      timeout-minutes: 30
+      run: make test-rust
 
     # Set up LocalPackages so Package.swift auto-detects the local build
     - name: Configure local FFI for CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ hand-written `swift` command:
 
 | Workflow | Trigger | Local equivalent |
 |---|---|---|
-| `swift.yml` | any PR outside its `paths-ignore` list | `make check` (`make build` then `make test-offline`) |
+| `swift.yml` | any PR outside its `paths-ignore` list | `make check` (`make build`, `make test-offline`, `make test-rust`) |
 | `swiftlint.yml` | any PR touching `**/*.swift` or `.swiftlint.yml` | `make lint` |
 | `proto-sync.yml` | any PR outside its `paths-ignore` list | `./Scripts/update-proposal-proto.sh --check` |
 | `zizmor.yml` | every PR | matters when you change a workflow file |
@@ -223,8 +223,12 @@ macOS slice alone is enough to build and test the Swift package:
 ```bash
 make ffi-macos           # once per branch, and after each Rust edit
 make configure-local-ffi # point Package.swift at the local build
-make check               # build, then the offline suite
+make check               # build, the offline suite, then the Rust tests
 ```
+
+`make test-rust` runs `cargo test`. The Rust unit tests sit below the Swift
+package, so no `swift test` filter reaches them and `make test-offline` passing
+says nothing about them; `swift.yml` runs both.
 
 ### When to run which
 
@@ -234,7 +238,7 @@ make check               # build, then the offline suite
 | Any other doc, including this one | `make check` — the build runs regardless |
 | Swift style or rename | `make lint` |
 | Swift logic or refactor | `make check`, then `make lint` |
-| Rust internals | `make ffi-macos`, then `make check` |
+| Rust internals | `make ffi-macos`, then `make check` (which runs `make test-rust`) |
 | Any change to an FFI signature or a new FFI function | `make ffi-all` (all five architectures) before PRing |
 | Bumping the pinned `zcash_client_backend` | `./Scripts/update-proposal-proto.sh --check` |
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-release: ## Build the Swift package in release mode
 test: test-offline ## Run the offline test suite
 
 .PHONY: check
-check: build test ## Build and run the offline tests
+check: build test test-rust ## Build, run the offline tests, then the Rust tests
 
 # `build` links whatever FFI is already in place; these build the Rust from
 # source first, so the XCFramework matches the tree.
@@ -136,6 +136,12 @@ test-offline: ## Run the offline tests (no network, no lightwalletd)
 .PHONY: test-all
 test-all: ## Run the whole test suite, including networked tests
 	$(SWIFT) test
+
+# The Rust unit tests. These cover the FFI layer below the Swift package, so
+# they are not reached by any `swift test` filter and need their own target.
+.PHONY: test-rust
+test-rust: ## Run the Rust unit tests
+	cargo test
 
 .PHONY: lint
 lint: ## Lint the Swift sources with SwiftLint


### PR DESCRIPTION
Nothing runs the Rust unit tests. `swift.yml` builds the FFI and runs the offline Swift suite, but the crate's own tests sit below the Swift package and no `swift test` filter reaches them, so `make test-offline` passing says nothing about them. None of the other three workflows touches them either.

The cost is not hypothetical. A failing test — `migration_keystone::tests::build_sign_batch_qr_parts_retains_the_dummy_orchard_spend_auth_sig` — sat on `feature/ironwood-slipstream` undetected, and surfaced only because I ran `cargo test` by hand while merging that branch forward. #1955 corrects it.

### What this adds

- `make test-rust`, running `cargo test`.
- Folded into `make check`, so the local equivalent of `swift.yml` stays one command.
- A `Run Rust unit tests` step in `swift.yml`, between the FFI build and the Swift build — the Rust layer is verified before the Swift package that links it.
- `AGENTS.md`'s pre-push table updated to match, so it keeps describing what CI actually does.

### Two details worth review

**`Setup Rust` and `Cache Cargo` lose their cache-miss conditions.** They were skipped whenever the XCFramework came from cache, which is the common case. The test step compiles the crate's test profile and needs the toolchain regardless; the Cargo cache now serves both.

**`cargo test`, not `cargo test --lib`.** A future `rust/tests/` file is then picked up rather than silently skipped. A gate that quietly omits new tests is the failure mode being fixed.

### This line compiles no Rust tests at all

Every `#[test]` in the tree is under `rust/src/voting`, which is behind `#[cfg(zcash_voting)]` here, so the step reports **0 tests** on `maint/v2.7.x`.

It is still the right line to add it on: later lines inherit it by merging forward, and it starts gating the moment any test becomes reachable. Verified green as-is on every line it will reach:

| Line | `cargo test` |
|---|---|
| `maint/v2.7.x` | 0 tests (all voting, `cfg`-gated off) |
| `maint/v2.8.x` | 0 tests (same) |
| `main` | 73 passed |
| `feature/ironwood-slipstream` | 145 passed |

### Merging forward

- **`maint/v2.8.x`** — merges clean.
- **`main`** — conflicts in `BroadcasterTests.swift` and `rust/CHANGELOG.md`, i.e. the ordinary accumulated `v2.7.x → main` delta, unrelated to this change. Should ride the normal train rather than a direct cherry-pick.
- **`feature/ironwood-slipstream`** — `swift.yml` conflicts, and the resolution is **not** mechanical. That line's hand-rolled `actions/cache` must win over the `Swatinem/rust-cache` here: Swatinem caches `~/.cargo` wholesale, including cargo's clone of the private `zodl-inc/slipstream` repo, and fork PRs can restore base-branch caches. The authorization step also has to widen, because until now an FFI cache hit meant no cargo command ran at all. A prepared branch carries that resolution and follows once #1955 lands — the gate arrives red without it.

### Test plan

- `make test-rust` on this branch: runs, reports 0 tests, exits 0.
- `make check` runs build → offline suite → Rust tests in order.
- `swift.yml` parses; step order and conditions confirmed (only `Build FFI for macOS` remains cache-conditional).
- The real exercise is this PR's own CI run, which is the first to execute the new step.
- Each downstream line was checked out and `cargo test` run directly to produce the table above, so merging forward cannot turn a line red on arrival.

---
🤖 Opened with [Claude Code](https://claude.com/claude-code) assistance.
