### PR TITLE
Span-rate tip estimator + bare Replan/Reevaluate discriminants

### DIFF
--- a/Sources/ZcashLightClientKit/Migration/ChainTipEstimator.swift
+++ b/Sources/ZcashLightClientKit/Migration/ChainTipEstimator.swift
@@ -10,27 +10,45 @@ import Foundation
 /// (`ZcashRustBackendWelding.migrationBlockRateSamples(window:)`).
 ///
 /// The projection feeds the migration delivery lane's `estimatedTip` inputs
-/// (`migrationHasOverdueTransfers(for:estimatedTip:)` / `migrationAdvanceStep(for:estimatedTip:)`),
-/// where it may only ACCELERATE scheduled-height due-ness — the rust side takes
-/// `max(scanned, estimated)` and always evaluates expiry against the SCANNED tip — so an
-/// over-estimate here costs nothing worse than an early "due" answer, and an under-estimate
-/// degrades to the scanned-tip behavior.
+/// (`migrationHasOverdueTransfers(for:estimatedTip:)` / `migrationAdvanceStep(for:estimatedTip:)`)
+/// AND — since upstream #2927 — the overdue re-spread inside `advance_migration`, which is
+/// **judged and sized at the estimate and PERSISTED**: an over-estimate is no longer "at worst an
+/// early due answer"; it writes phantom deferral into the stored schedule. Accuracy here is
+/// load-bearing. (Field incident, 2026-08-08 `data37`: a burst-skewed measurement compounded by
+/// two wake-time re-spreads parked a live testnet run ~2,690 blocks — half a day — past the real
+/// chain. The engine-side hardening — bounding what a caller estimate may size — is tracked
+/// separately; this type's job is to not hand it poison in the first place.)
 ///
-/// The constants mirror the Android SDK's estimator exactly: a window of up to the last
-/// ``sampleWindow`` samples, every per-delta and the final mean clamped to
-/// [``minSecondsPerBlock``, ``maxSecondsPerBlock``] seconds, and ``fallbackSecondsPerBlock``
-/// when fewer than two samples exist. Deltas are the raw header-time differences of consecutive
-/// samples — the samples are the most recently scanned blocks, so consecutive rows are adjacent
-/// heights and a delta IS one block's spacing; the clamp bounds the damage of any gapped or
-/// out-of-order header times.
+/// THE RATE IS A SPAN, NOT A DELTA MEAN. `secondsPerBlock()` divides the window's total
+/// header-time span by its total height span. The previous implementation averaged consecutive
+/// per-delta spacings, each clamped to [``minSecondsPerBlock``, ``maxSecondsPerBlock``] — a
+/// statistic that is biased LOW on bimodal spacing: testnet's min-difficulty rule yields bursts
+/// (seconds apart, clamped UP to 5) punctuated by gaps (clamped DOWN to 150), and the bursts
+/// dominate by count. A span is immune: a gap and the burst it triggers average out inside it. A
+/// span also needs no adjacency assumption — non-consecutive sample heights divide by the true
+/// height distance instead of counting rows.
+///
+/// THE WINDOW IS ABSENCE-SCALED. The rate is extrapolated across app-dead gaps measured in hours,
+/// so the sample span must cover hours: ``sampleWindow`` is 1000 blocks (~21 h at target spacing;
+/// ~6–9 h on a burst-fast testnet). The prior 100-block window (~2 h at target, and as little as
+/// ~30 min on a fast chain) measured whatever regime the chain happened to be in right before
+/// sleep and projected it across the whole night — in the field incident the pre-sleep half hour
+/// ran ~20 s/block while the night averaged 31 s/block, an error the span statistic alone cannot
+/// fix.
+///
+/// Constants heritage: the clamps and fallback still mirror the Android SDK's estimator; the
+/// method (span vs clamped-delta mean) and the window (1000 vs 100) deliberately diverge — the
+/// Kotlin estimator retains the biased statistic and the short window and needs the same fix.
 struct ChainTipEstimator {
-    /// How many of the latest samples participate, at most (Android parity: 100).
-    static let sampleWindow = 100
-    /// The lower clamp on any per-delta and on the final mean, in seconds (Android parity: 5).
+    /// How many of the latest samples participate, at most. Widened from the Android-parity 100:
+    /// the rate extrapolates across absence-scale gaps, so the sample span must cover
+    /// absence-scale regime changes (see the type doc).
+    static let sampleWindow = 1000
+    /// The lower sanity clamp on the final span rate, in seconds (Android parity: 5).
     static let minSecondsPerBlock: Double = 5
-    /// The upper clamp on any per-delta and on the final mean, in seconds (Android parity: 150).
+    /// The upper sanity clamp on the final span rate, in seconds (Android parity: 150).
     static let maxSecondsPerBlock: Double = 150
-    /// The seconds-per-block assumed when fewer than two samples exist (Android parity: 75 — the
+    /// The seconds-per-block assumed when no rate can be measured (Android parity: 75 — the
     /// Zcash target block spacing).
     static let fallbackSecondsPerBlock: Double = 75
 
@@ -42,26 +60,27 @@ struct ChainTipEstimator {
         self.samples = samples
     }
 
-    /// The measured seconds-per-block: the mean of the consecutive header-time deltas over up to
-    /// the last ``sampleWindow`` samples, each delta and the result clamped to
-    /// [``minSecondsPerBlock``, ``maxSecondsPerBlock``]; ``fallbackSecondsPerBlock`` when fewer
-    /// than two samples exist.
+    /// The measured seconds-per-block: the SPAN rate over up to the last ``sampleWindow``
+    /// samples — total header-time span divided by total height span — clamped once to
+    /// [``minSecondsPerBlock``, ``maxSecondsPerBlock``].
+    ///
+    /// ``fallbackSecondsPerBlock`` when no rate can be measured: fewer than two samples, a window
+    /// spanning no height, or header times that do not advance across the window (header times
+    /// are miner-supplied and may locally regress; a whole window that fails to advance is a
+    /// broken measurement, not a fast chain).
     func secondsPerBlock() -> Double {
         let window = samples.suffix(Self.sampleWindow)
-        guard window.count >= 2 else {
+        guard window.count >= 2, let first = window.first, let last = window.last else {
             return Self.fallbackSecondsPerBlock
         }
 
-        var deltaSum: Double = 0
-        var deltaCount = 0
-        for (previous, next) in zip(window, window.dropFirst()) {
-            let delta = Double(next.unixTime - previous.unixTime)
-            deltaSum += min(max(delta, Self.minSecondsPerBlock), Self.maxSecondsPerBlock)
-            deltaCount += 1
+        let heightSpan = Double(last.height - first.height)
+        let timeSpan = Double(last.unixTime - first.unixTime)
+        guard heightSpan > 0, timeSpan > 0 else {
+            return Self.fallbackSecondsPerBlock
         }
 
-        let mean = deltaSum / Double(deltaCount)
-        return min(max(mean, Self.minSecondsPerBlock), Self.maxSecondsPerBlock)
+        return min(max(timeSpan / heightSpan, Self.minSecondsPerBlock), Self.maxSecondsPerBlock)
     }
 
     /// The estimated chain tip at `now`: the latest sample's height plus the whole blocks that
@@ -90,7 +109,7 @@ struct ChainTipEstimator {
 enum MigrationTipEstimation {
     /// One projection over one samples read: the estimated tip (`nil` with no samples at all —
     /// the wallet has never scanned) and the measured seconds-per-block (the estimator's
-    /// fallback when fewer than two samples exist).
+    /// fallback when no rate can be measured).
     struct Projection {
         /// The wall-clock estimated chain tip, or `nil` when there are no samples to project from.
         let estimatedTip: BlockHeight?
@@ -110,7 +129,9 @@ enum MigrationTipEstimation {
 
     /// The estimated tip for gate/delivery due-ness checks: ``project(welding:now:)``'s tip,
     /// degraded to `nil` (scanned-tip behavior) on ANY failure — sample read errors included — so
-    /// the estimate can only ever accelerate, never block or crash, the paths that consult it.
+    /// a read failure can only ever fall back to, never block or crash, the paths that consult
+    /// it. NOTE: since upstream #2927 the non-nil estimate is not merely accelerating — it sizes
+    /// the persisted overdue re-spread (see the type doc above).
     static func gatingEstimatedTip(welding: ZcashRustBackendWelding, now: Date) async -> BlockHeight? {
         (try? await project(welding: welding, now: now))?.estimatedTip
     }

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -9,17 +9,16 @@ import Foundation
 /// by `Synchronizer.migrationAdvanceStep(accountUUID:)` /
 /// `ZcashRustBackendWelding.migrationAdvanceStep(for:)`.
 ///
-/// A conduit of the upstream engine's public `advance_migration` API. The SDK preserves this
-/// enum's source-compatible shape by projecting upstream `Reevaluate` and `Replan` decisions onto
-/// ``requiresAttention(id:)``; the broadcast/prove/rebuild/waiting/complete cases marshal directly
-/// (upstream PR #2871).
+/// A conduit of the upstream engine's public `advance_migration` API: every upstream case
+/// marshals onto its own case here — ``replan`` and ``reevaluate`` included, bare, exactly as
+/// upstream carries them. (The interim `requiresAttention(id:)` collapse, which folded both
+/// behind one synthesised transaction id, is retired — 2026-08-08.)
 /// `nil` at the API level (the call returns an optional) means no migration run is stored at all —
 /// none was ever committed for the account — so there is nothing to advance and nothing to poll.
-/// The engine's priority order is attend > broadcast > prove > rebuild:
-/// ``requiresAttention(id:)`` outranks every actionable step (a run holding an invalid
-/// transaction is not driven further until resolved), and a proven, due transaction broadcasts
-/// ahead of any new proving work (its broadcast window is the scarcer resource; proving can
-/// happen on any later wake-up).
+/// The engine's priority order: ``reevaluate`` outranks everything (an open rejection report
+/// freezes adjudication until the scan catches up), ``replan`` ends the drive until the user
+/// re-plans, and a proven, due transaction broadcasts ahead of any new proving work (its
+/// broadcast window is the scarcer resource; proving can happen on any later wake-up).
 ///
 /// Evaluated with both the wallet's fully-scanned target and its wall-clock tip estimate. Upstream
 /// uses the estimate only for reversible scheduling/withholding; persisted or destructive
@@ -29,12 +28,14 @@ import Foundation
 /// belongs to the caller and the sync gate, not to this value.
 ///
 /// Discharging each step:
-/// - ``requiresAttention(id:)`` → SYNC, then call `migrationAdvanceStep(accountUUID:)` again: the
-///   engine adjudicates against the newly scanned data and, where the obstruction was transient,
-///   re-offers the work in that same call. Only if attention persists does the run need the
-///   out-of-band resolution — surface the attention UX over the
-///   ``MigrationTransactionStatus/State/invalid(reason:)`` row(s), then
-///   `restartCurrentMigrationStep(accountUUID:)` to cancel and re-plan.
+/// - ``reevaluate`` → SYNC (to at least the tip the rejecting node reported), then call
+///   `migrationAdvanceStep(accountUUID:)` again: the engine adjudicates against the newly scanned
+///   data and, where the rejection was transient, re-offers the work in that same call. Not a
+///   user-facing state — the run is alive and nothing is asked of anyone but the syncer.
+/// - ``replan`` → the run is finished deciding and is not driven further: surface the re-plan UX
+///   over the ``MigrationTransactionStatus/State/invalid(reason:)`` row(s), then
+///   `restartCurrentMigrationStep(accountUUID:)` to cancel and re-plan. No sync first — the
+///   verdict is already persisted and cannot be scanned away.
 /// - ``broadcast(_:)`` → `performMigrationBroadcast(accountUUID:_:options:)`: hand the case's
 ///   opaque ``MigrationBroadcastInstruction`` straight to the executor and end the session — a
 ///   broadcast session must not sync.
@@ -86,12 +87,17 @@ public enum MigrationAdvanceStep: Equatable, Sendable {
     case waiting
     /// The stored run is terminal (fully mined, or cancelled): stop polling it.
     case complete
-    /// The transaction identified by `id` either has an open node-rejection report that requires
-    /// more sync (`Reevaluate`) or was determined unsatisfiable and requires a new plan (`Replan`).
-    /// Discharge: sync and call `migrationAdvanceStep` again for reevaluation; if attention
-    /// remains, show the status and use `restartCurrentMigrationStep` (see the type doc's
-    /// mapping).
-    case requiresAttention(id: UInt32)
+    /// The PLAN needs replacing: the run's unsatisfiable share passed the engine's committed
+    /// replan threshold, or dead value would otherwise be stranded — an ORDINARY outcome (most
+    /// often an ordinary wallet spend consuming notes the plan had allocated), and a verdict the
+    /// engine has ALREADY persisted, so more scanning cannot change it. Names no transaction: the
+    /// verdict is about the run. See the type doc's discharge mapping.
+    case replan
+    /// A broadcast this wallet made was REJECTED by a node whose chain view is ahead of this
+    /// wallet's scan, and the engine will not adjudicate on stale data. Names no transaction and
+    /// asks for nothing but a sync; the engine keeps answering this until the scan reaches the
+    /// tip the rejecting node reported. See the type doc's discharge mapping.
+    case reevaluate
 }
 
 /// The drive's instruction to broadcast one transaction — the payload of
@@ -417,7 +423,7 @@ public struct MigrationTransactionStatus: Equatable, Sendable {
         /// projection of that upstream condition. Chain inclusion OUTRANKS it: a
         /// row the wallet's scan has observed mined reports `.mined`, never `.invalid` — a stale
         /// verdict cannot shadow a landed transaction. Resolved out-of-band via the
-        /// ``MigrationAdvanceStep/requiresAttention(id:)`` discharge mapping (typically
+        /// ``MigrationAdvanceStep/replan`` discharge mapping (typically
         /// `restartCurrentMigrationStep`).
         case invalid(reason: MigrationInvalidReason)
     }
@@ -446,7 +452,7 @@ public struct MigrationTransactionStatus: Equatable, Sendable {
         /// Marked dead by an observed event (its state is
         /// ``MigrationTransactionStatus/State/invalid(reason:)``): no chain condition makes it
         /// actionable again — resolution is out-of-band, via the
-        /// ``MigrationAdvanceStep/requiresAttention(id:)`` discharge mapping.
+        /// ``MigrationAdvanceStep/replan`` discharge mapping.
         case invalid
     }
 

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -3059,8 +3059,12 @@ extension FfiMigrationAdvanceStep {
             step = .waiting
         case ZCASHLC_ADVANCE_STEP_COMPLETE:
             step = .complete
-        case ZCASHLC_ADVANCE_STEP_ATTEND:
-            step = .requiresAttention(id: self.id)
+        case ZCASHLC_ADVANCE_STEP_REPLAN:
+            // Bare on both sides of the FFI: upstream's Replan/Reevaluate name no transaction,
+            // so there is no id to carry (the retired Attend collapse synthesised one).
+            step = .replan
+        case ZCASHLC_ADVANCE_STEP_REEVALUATE:
+            step = .reevaluate
         default:
             return nil
         }

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -418,7 +418,8 @@ protocol ZcashRustBackendWelding {
     /// The engine's next step to advance `account`'s stored migration run, wrapped with its
     /// advisory OUTLOOK (upstream #2936; see ``MigrationAdvance``). This compatibility overload
     /// drives at the scanned target; migration hosts use the estimate-aware overload. Upstream
-    /// `Reevaluate` and `Replan` project to ``MigrationAdvanceStep/requiresAttention(id:)``.
+    /// `Reevaluate` and `Replan` arrive as their own bare cases
+    /// (``MigrationAdvanceStep/reevaluate`` / ``MigrationAdvanceStep/replan``).
     /// Mined
     /// transactions reconciled first like every other read. `nil` means NO run is stored at all
     /// (nothing to advance); a stored TERMINAL run — complete or cancelled — reports

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -646,16 +646,18 @@ public protocol Synchronizer: AnyObject {
     ///     _ = try await synchronizer.performMigrationBroadcast(accountUUID: account, instruction, options: options)
     /// case .rebuild:
     ///     _ = try await synchronizer.refreshStaleMigrationTransfers(accountUUID: account, usk: usk)
-    /// case .requiresAttention, .waiting, .complete, nil:
+    /// case .replan, .reevaluate, .waiting, .complete, nil:
     ///     break // nothing to perform; see the per-step notes below
     /// }
     /// ```
     ///
     /// Discharging each step (see ``MigrationAdvanceStep`` for the full contract):
-    /// - `.requiresAttention` — surfaced first, before any actionable step, when a transaction of
-    ///   the run is ``MigrationTransactionStatus/State/invalid(reason:)`` → sync and call this
-    ///   again so the engine can adjudicate against the newly scanned data; only if attention
-    ///   persists, surface the attention UX and then
+    /// - `.reevaluate` — surfaced first, before any actionable step, while a broadcast-rejection
+    ///   report is open → sync and call this again so the engine can adjudicate against the newly
+    ///   scanned data; it keeps answering this until the scan reaches the rejecting node's tip.
+    /// - `.replan` — the run's plan was undercut past the committed threshold and the verdict is
+    ///   already persisted (no sync changes it) → surface the re-plan UX over the
+    ///   ``MigrationTransactionStatus/State/invalid(reason:)`` row(s), then
     ///   ``restartCurrentMigrationStep(accountUUID:)``. Invalid rows are excluded from delivery
     ///   and from the sync gate.
     /// - `.broadcast` → ``performMigrationBroadcast(accountUUID:_:options:)`` with the step's own

--- a/Tests/OfflineTests/ChainTipEstimatorTests.swift
+++ b/Tests/OfflineTests/ChainTipEstimatorTests.swift
@@ -8,6 +8,11 @@
 //  No network, no FFI, no wallet database -- `ChainTipEstimator` is constructed directly from
 //  hand-built `MigrationBlockRateSample` fixtures.
 //
+//  The rate is a SPAN (total header-time span / total height span), not a mean of per-delta
+//  spacings -- see the type doc for the field incident that killed the delta mean. The suite
+//  pins the span semantics, the bias cases that distinguish it from the old statistic, and one
+//  fixture lifted verbatim from the incident wallet's `blocks` table.
+//
 
 import XCTest
 @testable import ZcashLightClientKit
@@ -15,12 +20,18 @@ import XCTest
 final class ChainTipEstimatorTests: XCTestCase {
     private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
 
-    // MARK: - Android-parity constants
+    private func s(_ height: BlockHeight, _ unixTime: Int64) -> MigrationBlockRateSample {
+        MigrationBlockRateSample(height: height, unixTime: unixTime)
+    }
 
-    /// Pins the exact constants the type doc claims mirror the Android SDK's estimator -- a
-    /// regression here is a silent behavior change, not just a cosmetic one.
-    func testConstantsMatchAndroidParity() {
-        XCTAssertEqual(ChainTipEstimator.sampleWindow, 100)
+    // MARK: - Constants
+
+    /// Pins the constants -- a regression here is a silent behavior change, not a cosmetic one.
+    /// The clamps and the fallback still mirror the Android SDK's estimator; the window is
+    /// DELIBERATELY diverged from Android's 100 (absence-scale sampling -- see the type doc), and
+    /// a change to any of these must be a decision, not drift.
+    func testConstants() {
+        XCTAssertEqual(ChainTipEstimator.sampleWindow, 1000)
         XCTAssertEqual(ChainTipEstimator.minSecondsPerBlock, 5)
         XCTAssertEqual(ChainTipEstimator.maxSecondsPerBlock, 150)
         XCTAssertEqual(ChainTipEstimator.fallbackSecondsPerBlock, 75)
@@ -34,99 +45,187 @@ final class ChainTipEstimatorTests: XCTestCase {
     }
 
     func testSecondsPerBlockFallsBackWithExactlyOneSample() {
+        let estimator = ChainTipEstimator(samples: [s(1_000_000, 1_700_000_000)])
+        XCTAssertEqual(estimator.secondsPerBlock(), 75)
+    }
+
+    /// Header times are miner-supplied and can regress; a window whose time span fails to advance
+    /// is a broken measurement, not an infinitely fast chain -- it must fall back, never clamp to
+    /// the floor (the floor would be the maximum-overshoot answer).
+    func testSecondsPerBlockFallsBackWhenTheTimeSpanDoesNotAdvance() {
+        let stalled = ChainTipEstimator(samples: [s(1_000_000, 1_700_000_000), s(1_000_001, 1_700_000_000)])
+        let backward = ChainTipEstimator(samples: [s(1_000_000, 1_700_000_000), s(1_000_001, 1_699_999_000)])
+
+        XCTAssertEqual(stalled.secondsPerBlock(), 75)
+        XCTAssertEqual(backward.secondsPerBlock(), 75)
+    }
+
+    /// A hand-built window spanning no height (the DB cannot produce one -- height is the primary
+    /// key) still answers the fallback rather than dividing by zero.
+    func testSecondsPerBlockFallsBackWhenTheHeightSpanIsZero() {
+        let estimator = ChainTipEstimator(samples: [s(1_000_000, 1_700_000_000), s(1_000_000, 1_700_000_060)])
+        XCTAssertEqual(estimator.secondsPerBlock(), 75)
+    }
+
+    // MARK: - secondsPerBlock(): the span
+
+    /// The boundary: exactly two samples is enough to stop falling back and measure a real span.
+    func testSecondsPerBlockComputesASpanWithExactlyTwoSamples() {
+        let estimator = ChainTipEstimator(samples: [s(1_000_000, 1_700_000_000), s(1_000_001, 1_700_000_060)])
+        XCTAssertEqual(estimator.secondsPerBlock(), 60)
+    }
+
+    /// Four samples over three blocks and 210 s: the span is 70 s/block. (On adjacent heights
+    /// with no clamps engaged the old delta mean agreed -- the statistics only diverge on bimodal
+    /// spacing or non-adjacent heights, pinned below.)
+    func testSecondsPerBlockIsTheSpanOfTheWindow() {
         let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 1_700_000_000)
+            s(1_000_000, 1_700_000_000),
+            s(1_000_001, 1_700_000_060),
+            s(1_000_002, 1_700_000_130),
+            s(1_000_003, 1_700_000_210)
+        ])
+        XCTAssertEqual(estimator.secondsPerBlock(), 70)
+    }
+
+    /// THE BIAS PIN. Burst-then-gap spacing (testnet's min-difficulty pattern): nine 2 s deltas
+    /// and one 300 s gap over ten blocks is a true 31.8 s/block. The retired statistic -- mean of
+    /// per-delta values clamped to [5, 150] -- answered 19.5 on this same fixture ((9×5 + 150)/10),
+    /// biased low because the bursts dominate by count. The span absorbs a gap and the burst it
+    /// triggers together.
+    func testSecondsPerBlockIsNotBiasedLowByBurstGapSpacing() {
+        var samples: [MigrationBlockRateSample] = []
+        var time: Int64 = 1_700_000_000
+        for index in 0...10 {
+            samples.append(s(BlockHeight(1_000_000 + index), time))
+            time += index == 9 ? 300 : 2
+        }
+
+        let estimator = ChainTipEstimator(samples: samples)
+
+        XCTAssertEqual(estimator.secondsPerBlock(), 31.8, accuracy: 0.0001)
+    }
+
+    /// Non-adjacent sample heights divide by the true HEIGHT span, not the row count: three rows
+    /// spanning twenty blocks and 1500 s is 75 s/block. The old statistic read the same fixture
+    /// as two 750 s "spacings", clamped both to 150, and answered exactly double.
+    func testSecondsPerBlockDividesByHeightSpanNotRowCount() {
+        let estimator = ChainTipEstimator(samples: [
+            s(1_000_000, 0),
+            s(1_000_010, 750),
+            s(1_000_020, 1_500)
         ])
         XCTAssertEqual(estimator.secondsPerBlock(), 75)
     }
 
-    /// The boundary: exactly two samples is enough to stop falling back and compute a real mean.
-    func testSecondsPerBlockComputesAMeanWithExactlyTwoSamples() {
-        let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 1_700_000_000),
-            MigrationBlockRateSample(height: 1_000_001, unixTime: 1_700_000_060)
-        ])
-        XCTAssertEqual(estimator.secondsPerBlock(), 60)
-    }
-
-    // MARK: - secondsPerBlock(): mean of deltas
-
-    /// Three samples, two deltas (60 s, 70 s, 80 s), neither clamp engaged: the mean is the plain
-    /// arithmetic mean of the consecutive header-time deltas.
-    func testSecondsPerBlockIsTheMeanOfConsecutiveDeltas() {
-        let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 1_700_000_000),
-            MigrationBlockRateSample(height: 1_000_001, unixTime: 1_700_000_060),
-            MigrationBlockRateSample(height: 1_000_002, unixTime: 1_700_000_130),
-            MigrationBlockRateSample(height: 1_000_003, unixTime: 1_700_000_210)
-        ])
-        // Deltas: 60, 70, 80 -- mean 70.
-        XCTAssertEqual(estimator.secondsPerBlock(), 70)
-    }
-
-    /// Only the last `sampleWindow` (100) samples participate: a 101-sample fixture whose single
-    /// OLDEST delta is a wild outlier must compute the same mean as the same fixture with that
-    /// oldest sample removed -- proving the window, not just "some" bound, is enforced.
+    /// Only the last `sampleWindow` (1000) samples participate: a 1001-sample fixture whose
+    /// single OLDEST sample sits a wild 100 000 s before the rest must measure the same span as
+    /// the same fixture with that oldest sample removed.
     func testSecondsPerBlockOnlyConsidersTheLastSampleWindowSamples() {
-        var samples: [MigrationBlockRateSample] = [
-            // The outlier: a 100_000 s gap to the next sample -- would drag the mean far above 150
-            // (even after per-delta clamping to 150) if it were included.
-            MigrationBlockRateSample(height: 0, unixTime: 0)
-        ]
+        var samples: [MigrationBlockRateSample] = [s(0, 0)]
         var time: Int64 = 100_000
-        var height = 1
-        // 100 more samples (101 total), each 60 s apart -- exactly `sampleWindow` deltas among the
-        // last 100 samples once the outlier at index 0 is excluded.
-        for _ in 0..<100 {
-            samples.append(MigrationBlockRateSample(height: height, unixTime: time))
+        for index in 1...1_000 {
+            samples.append(s(BlockHeight(index), time))
             time += 60
-            height += 1
         }
 
         let estimator = ChainTipEstimator(samples: samples)
         let estimatorWithoutOutlier = ChainTipEstimator(samples: Array(samples.dropFirst()))
 
-        XCTAssertEqual(estimator.secondsPerBlock(), 60, "the outlier at index 0 must fall outside the last-100-sample window")
+        XCTAssertEqual(estimator.secondsPerBlock(), 60, "the outlier at index 0 must fall outside the last-1000-sample window")
         XCTAssertEqual(estimator.secondsPerBlock(), estimatorWithoutOutlier.secondsPerBlock())
     }
 
-    // MARK: - secondsPerBlock(): per-delta and result clamps
+    /// WHY THE WINDOW IS 1000 AND NOT 100. A chain that ran ~31 s/block for hours and then
+    /// bursts to 20 s/block for its last 100 blocks: the 1000-sample window blends the regimes
+    /// (~29.9 s), where a 100-sample window would have measured only the final burst (20 s) and
+    /// projected it across an hours-long absence -- the field incident's dominant error.
+    func testSecondsPerBlockWindowSpansRegimeChanges() {
+        var samples: [MigrationBlockRateSample] = []
+        var time: Int64 = 1_700_000_000
+        for index in 0..<1_100 {
+            samples.append(s(BlockHeight(2_000_000 + index), time))
+            time += index < 1_000 ? 31 : 20
+        }
 
-    /// A delta below `minSecondsPerBlock` is clamped to 5 BEFORE averaging, not just at the end:
-    /// paired with a delta above `maxSecondsPerBlock` (clamped to 150), the mean of the CLAMPED
-    /// values is 77.5 -- the raw (unclamped) mean of 2 and 500 would be 251, so this fixture
-    /// distinguishes "clamp every delta, then average" from "average, then clamp the result".
-    func testSecondsPerBlockClampsEachDeltaBeforeAveraging() {
-        let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 0),
-            // A 2 s delta: clamped up to 5.
-            MigrationBlockRateSample(height: 1_000_001, unixTime: 2),
-            // A 500 s delta: clamped down to 150.
-            MigrationBlockRateSample(height: 1_000_002, unixTime: 502)
-        ])
-        XCTAssertEqual(estimator.secondsPerBlock(), 77.5, "(5 + 150) / 2, the clamped deltas' mean")
+        let estimator = ChainTipEstimator(samples: samples)
+
+        // suffix(1000) spans 999 heights: 900 deltas at 31 s + 99 at 20 s.
+        XCTAssertEqual(estimator.secondsPerBlock(), (900.0 * 31.0 + 99.0 * 20.0) / 999.0, accuracy: 0.0001)
     }
 
-    /// The final mean is itself clamped too: every delta identically 5 (already at the floor)
-    /// leaves the mean at exactly the floor, never below it.
-    func testSecondsPerBlockResultNeverGoesBelowTheFloor() {
-        let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 0),
-            MigrationBlockRateSample(height: 1_000_001, unixTime: 5),
-            MigrationBlockRateSample(height: 1_000_002, unixTime: 10)
-        ])
-        XCTAssertEqual(estimator.secondsPerBlock(), 5)
-    }
+    // MARK: - secondsPerBlock(): the final clamps
 
-    /// Symmetric case at the ceiling: every delta identically 150 leaves the mean at exactly the
-    /// ceiling, never above it.
-    func testSecondsPerBlockResultNeverGoesAboveTheCeiling() {
+    /// The clamp applies to the FINAL span rate, never per delta. A 2 s delta next to a 500 s
+    /// delta is a true span of 251 s/block -- an absurd rate, clamped to the 150 ceiling. (The
+    /// retired statistic clamped each delta first and answered 77.5 -- a plausible-looking number
+    /// manufactured from two implausible ones, which is exactly how it hid.)
+    func testSecondsPerBlockClampsTheFinalRateNotEachDelta() {
         let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 0),
-            MigrationBlockRateSample(height: 1_000_001, unixTime: 150),
-            MigrationBlockRateSample(height: 1_000_002, unixTime: 300)
+            s(1_000_000, 0),
+            s(1_000_001, 2),
+            s(1_000_002, 502)
         ])
         XCTAssertEqual(estimator.secondsPerBlock(), 150)
+    }
+
+    func testSecondsPerBlockResultNeverGoesBelowTheFloor() {
+        let estimator = ChainTipEstimator(samples: [
+            s(1_000_000, 0),
+            s(1_000_001, 1),
+            s(1_000_002, 2)
+        ])
+        XCTAssertEqual(estimator.secondsPerBlock(), 5, "a 1 s/block span clamps up to the 5 s floor")
+    }
+
+    func testSecondsPerBlockResultNeverGoesAboveTheCeiling() {
+        let estimator = ChainTipEstimator(samples: [
+            s(1_000_000, 0),
+            s(1_000_001, 150),
+            s(1_000_002, 300)
+        ])
+        XCTAssertEqual(estimator.secondsPerBlock(), 150)
+    }
+
+    // MARK: - The incident fixture
+
+    /// Lifted VERBATIM from the 2026-08-08 incident wallet (`data37`, public testnet): the 100
+    /// most recently scanned blocks at the moment the wallet slept -- the exact window the
+    /// pre-widening estimator measured when the overnight re-spread fired. Real chain data, warts
+    /// included (heights 4244849→4244850 carry header times that go BACKWARD 140 s).
+    ///
+    /// Span: 1996 s over 99 blocks = 20.1616 s/block. The retired clamped-delta mean read 18.70.
+    /// The night this window was projected across averaged 31.1 s/block -- the residual error is
+    /// the window's narrowness (33 minutes of burst-heavy chain), which is what
+    /// ``ChainTipEstimator/sampleWindow`` = 1000 addresses; this fixture pins the statistic on
+    /// real data and documents that a 100-sample window is measurement, not prophecy.
+    func testIncidentWindowMeasuresItsTrueSpanRate() {
+        let samples: [MigrationBlockRateSample] = [
+            s(4244839, 1786136187), s(4244840, 1786136306), s(4244841, 1786136327), s(4244842, 1786136343), s(4244843, 1786136388),
+            s(4244844, 1786136426), s(4244845, 1786136627), s(4244846, 1786136758), s(4244847, 1786136760), s(4244848, 1786136767),
+            s(4244849, 1786137218), s(4244850, 1786137078), s(4244851, 1786137095), s(4244852, 1786137098), s(4244853, 1786137103),
+            s(4244854, 1786137104), s(4244855, 1786137110), s(4244856, 1786137114), s(4244857, 1786137124), s(4244858, 1786137140),
+            s(4244859, 1786137149), s(4244860, 1786137156), s(4244861, 1786137157), s(4244862, 1786137158), s(4244863, 1786137164),
+            s(4244864, 1786137169), s(4244865, 1786137172), s(4244866, 1786137184), s(4244867, 1786137186), s(4244868, 1786137189),
+            s(4244869, 1786137191), s(4244870, 1786137192), s(4244871, 1786137206), s(4244872, 1786137221), s(4244873, 1786137245),
+            s(4244874, 1786137253), s(4244875, 1786137297), s(4244876, 1786137302), s(4244877, 1786137302), s(4244878, 1786137318),
+            s(4244879, 1786137323), s(4244880, 1786137327), s(4244881, 1786137331), s(4244882, 1786137342), s(4244883, 1786137366),
+            s(4244884, 1786137373), s(4244885, 1786137392), s(4244886, 1786137397), s(4244887, 1786137405), s(4244888, 1786137407),
+            s(4244889, 1786137413), s(4244890, 1786137415), s(4244891, 1786137443), s(4244892, 1786137478), s(4244893, 1786137484),
+            s(4244894, 1786137487), s(4244895, 1786137500), s(4244896, 1786137509), s(4244897, 1786137514), s(4244898, 1786137518),
+            s(4244899, 1786137534), s(4244900, 1786137563), s(4244901, 1786137583), s(4244902, 1786137599), s(4244903, 1786137617),
+            s(4244904, 1786137620), s(4244905, 1786137625), s(4244906, 1786137634), s(4244907, 1786137655), s(4244908, 1786137665),
+            s(4244909, 1786137679), s(4244910, 1786137691), s(4244911, 1786137695), s(4244912, 1786137700), s(4244913, 1786137706),
+            s(4244914, 1786137715), s(4244915, 1786137749), s(4244916, 1786137750), s(4244917, 1786137783), s(4244918, 1786137826),
+            s(4244919, 1786137830), s(4244920, 1786137846), s(4244921, 1786137848), s(4244922, 1786137851), s(4244923, 1786137860),
+            s(4244924, 1786137883), s(4244925, 1786137889), s(4244926, 1786137902), s(4244927, 1786137988), s(4244928, 1786138005),
+            s(4244929, 1786138020), s(4244930, 1786138040), s(4244931, 1786138047), s(4244932, 1786138065), s(4244933, 1786138096),
+            s(4244934, 1786138100), s(4244935, 1786138116), s(4244936, 1786138124), s(4244937, 1786138142), s(4244938, 1786138183)
+        ]
+
+        let estimator = ChainTipEstimator(samples: samples)
+
+        XCTAssertEqual(estimator.secondsPerBlock(), 1_996.0 / 99.0, accuracy: 0.0001, "20.16 s/block -- the window's true span")
     }
 
     // MARK: - estimatedTip(now:): nil with no samples
@@ -141,7 +240,7 @@ final class ChainTipEstimatorTests: XCTestCase {
     /// `elapsed / secondsPerBlock()` is FLOORED, not rounded: 200 s elapsed at 75 s/block
     /// (fallback, one sample) is 2.66\u{2026} blocks -- floor gives 2, whereas rounding would give 3.
     func testEstimatedTipFloorsThePartialBlockRatherThanRounding() {
-        let latest = MigrationBlockRateSample(height: 2_000_000, unixTime: Int64(referenceDate.timeIntervalSince1970))
+        let latest = s(2_000_000, Int64(referenceDate.timeIntervalSince1970))
         let estimator = ChainTipEstimator(samples: [latest])
 
         let tip = estimator.estimatedTip(now: referenceDate.addingTimeInterval(200))
@@ -152,7 +251,7 @@ final class ChainTipEstimatorTests: XCTestCase {
     /// An elapsed duration that divides the block rate exactly still floors correctly (no
     /// off-by-one from floating-point wobble at an exact boundary).
     func testEstimatedTipAtAnExactBlockBoundary() {
-        let latest = MigrationBlockRateSample(height: 2_000_000, unixTime: Int64(referenceDate.timeIntervalSince1970))
+        let latest = s(2_000_000, Int64(referenceDate.timeIntervalSince1970))
         let estimator = ChainTipEstimator(samples: [latest])
 
         let tip = estimator.estimatedTip(now: referenceDate.addingTimeInterval(150))
@@ -165,7 +264,7 @@ final class ChainTipEstimatorTests: XCTestCase {
     /// `now` at or before the latest sample's header time (clock skew, or a caller re-evaluating
     /// against a stale `now`) must never project BACKWARD past the latest known height.
     func testEstimatedTipClampsNegativeElapsedToTheLatestSampleHeight() {
-        let latest = MigrationBlockRateSample(height: 2_000_000, unixTime: Int64(referenceDate.timeIntervalSince1970))
+        let latest = s(2_000_000, Int64(referenceDate.timeIntervalSince1970))
         let estimator = ChainTipEstimator(samples: [latest])
 
         let tipBeforeLatest = estimator.estimatedTip(now: referenceDate.addingTimeInterval(-1_000))
@@ -179,12 +278,31 @@ final class ChainTipEstimatorTests: XCTestCase {
     /// earlier samples exist.
     func testEstimatedTipProjectsFromTheLatestSampleNotTheFirst() {
         let estimator = ChainTipEstimator(samples: [
-            MigrationBlockRateSample(height: 1_000_000, unixTime: 0),
-            MigrationBlockRateSample(height: 1_000_010, unixTime: 600)
+            s(1_000_000, 0),
+            s(1_000_010, 600)
         ])
 
         let tip = estimator.estimatedTip(now: Date(timeIntervalSince1970: 600))
 
         XCTAssertEqual(tip, 1_000_010, "with zero elapsed time past the latest sample, the tip is exactly its height")
+    }
+
+    /// End-to-end overnight projection at the incident's scale: latest sample at height H with a
+    /// 27 900 s (7.75 h) absence over a 31 s/block window projects +900 blocks -- the real
+    /// overnight advance the incident chain produced, and the number the overdue re-spread should
+    /// have been sized by.
+    func testEstimatedTipProjectsAnOvernightAbsenceAtTheMeasuredRate() {
+        var samples: [MigrationBlockRateSample] = []
+        var time: Int64 = 1_700_000_000
+        for index in 0..<1_000 {
+            samples.append(s(BlockHeight(3_000_000 + index), time))
+            time += 31
+        }
+        let latestTime = samples[samples.count - 1].unixTime
+        let estimator = ChainTipEstimator(samples: samples)
+
+        let tip = estimator.estimatedTip(now: Date(timeIntervalSince1970: TimeInterval(latestTime + 27_900)))
+
+        XCTAssertEqual(tip, 3_000_999 + 900, "floor(27900 / 31) == 900 blocks across the absence")
     }
 }

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -760,9 +760,9 @@ final class MigrationFFITests: XCTestCase {
     // a renumbering on either side surfaces here. Assertions unwrap `.step`; the outlook
     // (`.next`) has its own dedicated section below.
 
-    /// Every step discriminant decodes to its case; `requiresAttention` (ATTEND) carries the id
-    /// like the other id-bearing steps.
-    func testAdvanceStepDecodeMapsEveryStepIncludingAttend() throws {
+    /// Every step discriminant decodes to its case; `replan`/`reevaluate` decode BARE — upstream
+    /// carries no transaction id on either step, and the marshal must not invent one.
+    func testAdvanceStepDecodeMapsEveryStepIncludingReplanAndReevaluate() throws {
         let prove = makeProveAdvanceStep([
             FfiProveTarget(id: 4, kind_is_preparation: false, kind_layer: 0, kind_index: 0, kind_crossing: 2, schedule_due: false)
         ])
@@ -794,16 +794,26 @@ final class MigrationFFITests: XCTestCase {
         let complete = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_COMPLETE), id: 0)
         XCTAssertEqual(complete.unsafeToMigrationAdvance()?.step, .complete)
 
-        let attend = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_ATTEND), id: 9)
+        let replan = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_REPLAN), id: 9)
         XCTAssertEqual(
-            attend.unsafeToMigrationAdvance()?.step,
-            .requiresAttention(id: 9),
-            "the engine's Attend step must pass through verbatim, carrying the invalid transaction's id"
+            replan.unsafeToMigrationAdvance()?.step,
+            .replan,
+            "Replan decodes bare — an id on the DTO is ignored, never surfaced"
+        )
+
+        let reevaluate = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_REEVALUATE), id: 9)
+        XCTAssertEqual(
+            reevaluate.unsafeToMigrationAdvance()?.step,
+            .reevaluate,
+            "Reevaluate decodes bare — an id on the DTO is ignored, never surfaced"
         )
     }
 
     func testAdvanceStepDecodeReturnsNilForAnOutOfRangeStep() {
         XCTAssertNil(makeAdvanceStep(step: 99, id: 1).unsafeToMigrationAdvance())
+        // 5 is the retired Attend discriminant — a HOLE, never reused: a stale header speaking
+        // the old vocabulary must decode to nil, not to some other step.
+        XCTAssertNil(makeAdvanceStep(step: 5, id: 1).unsafeToMigrationAdvance())
     }
 
     /// A multi-entry Prove batch marshals every row, ordered and typed, mixing preparation and

--- a/Tests/OfflineTests/MigrationInstructionOpacityTests.swift
+++ b/Tests/OfflineTests/MigrationInstructionOpacityTests.swift
@@ -75,7 +75,8 @@ final class MigrationInstructionOpacityTests: XCTestCase {
             .waiting,
             .complete,
             .rebuild(id: 6),
-            .requiresAttention(id: 7)
+            .replan,
+            .reevaluate
         ]
 
         for step in instructionFree {
@@ -112,7 +113,7 @@ final class MigrationInstructionOpacityTests: XCTestCase {
             return "proveMigrationTransactions"
         case .broadcast:
             return "performMigrationBroadcast"
-        case .rebuild, .requiresAttention, .waiting, .complete:
+        case .rebuild, .replan, .reevaluate, .waiting, .complete:
             return nil
         }
     }
@@ -159,7 +160,7 @@ private func performDictate(
     case .rebuild:
         // The third executor, unchanged by this task: it already discharged the `.rebuild` dictate.
         _ = try await synchronizer.refreshStaleMigrationTransfers(accountUUID: accountUUID, usk: nil)
-    case .requiresAttention, .waiting, .complete, .none:
+    case .replan, .reevaluate, .waiting, .complete, .none:
         break
     }
 }

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -63,7 +63,8 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
             MigrationAdvance(step: .rebuild(id: 6), next: nil),
             MigrationAdvance(step: .waiting, next: MigrationNextWork(height: 850_000, kind: .broadcast)),
             MigrationAdvance(step: .complete, next: nil),
-            MigrationAdvance(step: .requiresAttention(id: 7), next: nil)
+            MigrationAdvance(step: .replan, next: nil),
+            MigrationAdvance(step: .reevaluate, next: nil)
         ]
 
         for expectedAdvance in cases {

--- a/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
@@ -85,7 +85,8 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
             MigrationAdvance(step: .rebuild(id: 6), next: nil),
             MigrationAdvance(step: .waiting, next: MigrationNextWork(height: 850_000, kind: .broadcast)),
             MigrationAdvance(step: .complete, next: nil),
-            MigrationAdvance(step: .requiresAttention(id: 7), next: nil)
+            MigrationAdvance(step: .replan, next: nil),
+            MigrationAdvance(step: .reevaluate, next: nil)
         ]
 
         for expectedAdvance in cases {

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -1698,7 +1698,12 @@ pub const ZCASHLC_ADVANCE_STEP_BROADCAST: u32 = 1;
 pub const ZCASHLC_ADVANCE_STEP_REBUILD: u32 = 2;
 pub const ZCASHLC_ADVANCE_STEP_WAITING: u32 = 3;
 pub const ZCASHLC_ADVANCE_STEP_COMPLETE: u32 = 4;
-pub const ZCASHLC_ADVANCE_STEP_ATTEND: u32 = 5;
+// 5 was ZCASHLC_ADVANCE_STEP_ATTEND — the collapsed Reevaluate/Replan projection (with a
+// synthesised transaction id neither upstream step carries), retired 2026-08-08 when the two
+// steps gained their own bare discriminants below. The value stays a HOLE on purpose: reusing
+// it would let a stale header decode one vocabulary as the other.
+pub const ZCASHLC_ADVANCE_STEP_REPLAN: u32 = 6;
+pub const ZCASHLC_ADVANCE_STEP_REEVALUATE: u32 = 7;
 
 /// The step-kind discriminants of [`FfiMigrationAdvanceStep::next_kind`], a verbatim export of
 /// upstream `state::StepKind` (the outlook's kind — WHICH transaction a wake-up serves is decided
@@ -2606,8 +2611,9 @@ fn drive_advance(
 }
 
 /// Advances the stored run with upstream's public satisfiability API, using scanned and estimated
-/// targets plus the provable-anchor reorg-settle depth. Reevaluate and Replan are projected onto
-/// the existing Attend DTO case so the Swift public enum remains source-compatible.
+/// targets plus the provable-anchor reorg-settle depth. Every upstream step marshals onto its own
+/// discriminant — Reevaluate and Replan included (bare, as upstream carries them; the collapsed
+/// Attend projection is retired).
 ///
 /// Returns NULL **with no error recorded** when `get_migration()` returns `None` — no run is
 /// stored, so there is nothing to advance and no step to report. Distinguish that benign NULL
@@ -2665,23 +2671,14 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         let advance = drive_advance(&mut ctx, &mut state, estimated_tip)?;
         let next = advance.next();
         Ok(match advance.step() {
-            AdvanceStep::Reevaluate | AdvanceStep::Replan => {
-                let id = state
-                    .transaction_statuses(targets)
-                    .into_iter()
-                    .find(|status| {
-                        matches!(
-                            status.blocked_on(),
-                            Some(
-                                Blocker::AwaitingReevaluation
-                                    | Blocker::Unsatisfiable
-                                    | Blocker::Expired
-                            )
-                        )
-                    })
-                    .map(|status| status.id())
-                    .unwrap_or_else(|| MigrationTransferId::new(0));
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_ATTEND, id, next)
+            // Both are BARE: neither upstream step names a transaction — Replan is a verdict
+            // about the RUN (its unsatisfiable share passed the committed threshold), Reevaluate
+            // asks for a sync and nothing else — and the retired Attend collapse synthesised an
+            // id at least one of them never had. The platform's per-row detail, when it wants
+            // one, is `transaction_statuses`' own blockers, not this step.
+            AdvanceStep::Replan => FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_REPLAN, next),
+            AdvanceStep::Reevaluate => {
+                FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_REEVALUATE, next)
             }
             AdvanceStep::Prove { transactions } => {
                 FfiMigrationAdvanceStep::prove(&state, transactions, targets, next)
@@ -3844,8 +3841,8 @@ pub unsafe extern "C" fn zcashlc_migration_take_preparation_by_txid(
 /// `txid_bytes`, 32 raw bytes) — the transaction is marked broadcast, to be reconciled to mined
 /// as the wallet scans; 1 = network error (retryable — nothing is recorded, the transaction stays
 /// offered); 2 = invalid note, 3 = expired — each rejection is reported to the engine at the
-/// wallet's observed chain tip. The next advance reevaluates satisfiability and projects any
-/// resulting Reevaluate/Replan step onto the existing Attend DTO case.
+/// wallet's observed chain tip. The next advance reevaluates satisfiability and surfaces any
+/// resulting Reevaluate/Replan step on its own discriminant.
 ///
 /// An unknown id or already-mined transaction is left untouched; both still answer `true`, since
 /// the reported outcome was consumed.


### PR DESCRIPTION
Part of #1806. Two migration hardening changes from the gardening pass; each commit builds and tests green on its own, and the branch merges cleanly into the current base tip.

### Tip estimator: span rate over an absence-scale window (f2798af0)

The measured seconds-per-block was the mean of consecutive header-time deltas, each clamped to [5, 150] s, over the last 100 scanned blocks. Two structural failures, both field-hit on 2026-08-08 (testnet run data37):

- The clamped-delta mean is biased **low** on bimodal spacing (testnet's min-difficulty bursts + gaps): bursts dominate by count, so the tip projection overshoots the real chain.
- The 100-block window (~33 min on a fast chain) measures whatever regime preceded sleep and extrapolates it across an hours-long absence; the incident window ran 20 s/block against a night that averaged 31 s/block.

Since upstream #2927 the projection is not advisory: `advance_migration` sizes **and persists** its overdue re-spread at the estimate. The incident compounded two wake-time re-spreads into ~2,690 blocks of phantom deferral (real overnight advance: ~900), parking a live run ~15 wall-hours past the chain and rendering as the 7h/17h/12h ETA wobble.

`secondsPerBlock()` is now the **span** rate — total header-time span over total height span, clamped once — immune to the bimodal bias and free of the adjacent-heights assumption; `sampleWindow` widens 100 → 1000 so the sampled span covers absence-scale regime changes. The incident's exact 100-row window ships as a regression fixture (header times that regress 140 s included), and the stale "an over-estimate costs nothing worse than an early due answer" contract doc is rewritten to the post-#2927 reality.

Constants heritage: clamps + fallback still mirror the Android SDK; the method and window deliberately diverge — the Kotlin estimator has the same bias and needs the same fix.

### Split Replan and Reevaluate onto their own bare discriminants (93a11081)

The collapsed ATTEND projection is retired end-to-end: the FFI marshals upstream's `AdvanceStep::Replan`/`Reevaluate` as `ZCASHLC_ADVANCE_STEP_REPLAN=6` / `REEVALUATE=7` (5 stays a documented hole — a stale header must decode to nil, never to another step), `MigrationAdvanceStep` gains `.replan`/`.reevaluate` and loses `requiresAttention(id:)`, and the Blocker-scanning id synthesis is deleted. Neither case carries an id: upstream names no transaction on either. Docs and the four test files follow; a new pin holds the retired discriminant hole at nil.

### Gates

- f2798af0: OfflineTests 807/807 (iPhone 17 Pro sim); zodl-testnet BUILD SUCCEEDED against this checkout
- 93a11081 (branch tip): cargo test 162/0; iOS-sim suite 806/806
- Plain `swift build` fails on this branch with 28 pre-existing errors from the stale macOS FFI slice, with or without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)