### PR TITLE
[#1910] Expose the general send-max proposal through the Swift API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,10 @@ Changes are relative to `2.8.0-rc.3`.
   network — a modified-mainnet chain votes with mainnet hotkeys and address
   HRPs — so `open` fails if that network has not been configured yet.
 - `MaxSpendMode`: describes how a "spend max" request should be evaluated,
-  either targeting only currently-spendable funds (`maxSpendable`) or the
-  wallet's entire balance (`everything`, which fails if any funds are
-  unspendable or the wallet is unsynced).
+  either targeting only currently-spendable funds (`maxSpendable`) or all
+  non-dust funds in the wallet (`everything`, which excludes dust notes valued
+  at or below the ZIP-317 marginal fee from selection and fails only if non-dust
+  funds are unspendable or the wallet is unsynced).
 - `Proposal.totalSpendValue()`: the total value a proposal spends across all
   of its steps, before its fee is deducted — each step's inputs minus its
   non-ephemeral proposed change. Ephemeral (ZIP-320) change is spent by a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ Changes are relative to `2.8.0-rc.3`.
   custom (regtest) network takes its voting identity from the registered base
   network — a modified-mainnet chain votes with mainnet hotkeys and address
   HRPs — so `open` fails if that network has not been configured yet.
+- `MaxSpendMode`: describes how a "spend max" request should be evaluated,
+  either targeting only currently-spendable funds (`maxSpendable`) or the
+  wallet's entire balance (`everything`, which fails if any funds are
+  unspendable or the wallet is unsynced).
+- `ZcashRustBackendWelding.proposeSendMaxTransfer(accountUUID:to:memo:mode:)`:
+  binds the Rust FFI's `zcashlc_propose_send_max_transfer` for the public
+  send-max path, proposing a transaction that spends the maximum available
+  balance to a single recipient. Failures surface as the existing
+  `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`).
+- `Proposal.totalSpendValue()`: the total value a proposal spends across all
+  of its steps, before its fee is deducted. Combined with the existing
+  `totalFeeRequired()`, callers can derive the maximum amount a "spend max"
+  proposal sends to its recipient as `totalSpendValue() - totalFeeRequired()`.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,6 @@ Changes are relative to `2.8.0-rc.3`.
   either targeting only currently-spendable funds (`maxSpendable`) or the
   wallet's entire balance (`everything`, which fails if any funds are
   unspendable or the wallet is unsynced).
-- `ZcashRustBackendWelding.proposeSendMaxTransfer(accountUUID:to:memo:mode:)`:
-  binds the Rust FFI's `zcashlc_propose_send_max_transfer` for the public
-  send-max path, proposing a transaction that spends the maximum available
-  balance to a single recipient. Failures surface as the existing
-  `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`).
 - `Proposal.totalSpendValue()`: the total value a proposal spends across all
   of its steps, before its fee is deducted — each step's inputs minus its
   non-ephemeral proposed change. Ephemeral (ZIP-320) change is spent by a
@@ -52,14 +47,6 @@ Changes are relative to `2.8.0-rc.3`.
   is not deducted. Combined with the existing `totalFeeRequired()`, callers
   can derive the maximum amount a "spend max" proposal sends to its
   recipient as `totalSpendValue() - totalFeeRequired()`.
-- `Synchronizer.proposeSendMax(accountUUID:recipient:memo:mode:)`, plus the
-  matching `ClosureSynchronizer` and `CombineSynchronizer` entries: proposes a
-  transaction that spends the maximum amount available in the account to a
-  single recipient, using `MaxSpendMode` to control how much of the balance
-  is targeted. No `amount` is passed — the fee is already accounted for by
-  the returned proposal. Sending a memo to a transparent recipient still
-  throws `ZcashError.synchronizerSendMemoToTransparentAddress`, same as
-  `proposeTransfer`.
 
 ## Changed
 
@@ -116,6 +103,16 @@ Changes are relative to `2.8.0-rc.3`.
   write-lane pass (the platform's next advance-step, prove, or delivery call — typically its next
   sync edge or UI refresh); checkmark/"done" rendering is unaffected (it derives from the
   wallet's own mined transactions).
+- `Synchronizer` gained the required method `proposeSendMax(accountUUID:recipient:memo:mode:)` —
+  plus matching `ClosureSynchronizer` and `CombineSynchronizer` entries — with no default
+  implementation: any external conformer or test double of these protocols must now implement it.
+  It proposes a transaction that spends the maximum amount available in the account to a single
+  recipient, using `MaxSpendMode` to control how much of the balance is targeted; no `amount` is
+  passed, since the fee is already accounted for by the returned proposal. The proposal draws on
+  shielded funds only (Sapling, Orchard, Ironwood) — transparent balance is never selected and must
+  be shielded first (see `proposeShielding`). Sending a memo to a transparent recipient still throws
+  `ZcashError.synchronizerSendMemoToTransparentAddress`, same as `proposeTransfer`. Failures surface
+  as the existing `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`).
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ Changes are relative to `2.8.0-rc.3`.
   of its steps, before its fee is deducted. Combined with the existing
   `totalFeeRequired()`, callers can derive the maximum amount a "spend max"
   proposal sends to its recipient as `totalSpendValue() - totalFeeRequired()`.
+- `Synchronizer.proposeSendMax(accountUUID:recipient:memo:mode:)`, plus the
+  matching `ClosureSynchronizer` and `CombineSynchronizer` entries: proposes a
+  transaction that spends the maximum amount available in the account to a
+  single recipient, using `MaxSpendMode` to control how much of the balance
+  is targeted. No `amount` is passed — the fee is already accounted for by
+  the returned proposal. Sending a memo to a transparent recipient still
+  throws `ZcashError.synchronizerSendMemoToTransparentAddress`, same as
+  `proposeTransfer`.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,11 @@ Changes are relative to `2.8.0-rc.3`.
   and so absent from `getTransactionOutputs(for:)`, until the transaction was
   mined and scanned. Shielded outputs stored by this path are also now tagged with
   their note commitment tree, as the ordinary send path already did.
+- `proposeTransfer` and `proposeSendMax` now throw
+  `ZcashError.synchronizerSendMemoToTransparentAddress` when a memo accompanies a
+  TEX recipient, matching the existing behavior for transparent recipients.
+  Previously a memo aimed at a TEX address reached the rust backend and failed
+  with a generic `ZcashError.rust*` error instead.
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,12 @@ Changes are relative to `2.8.0-rc.3`.
   balance to a single recipient. Failures surface as the existing
   `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`).
 - `Proposal.totalSpendValue()`: the total value a proposal spends across all
-  of its steps, before its fee is deducted. Combined with the existing
-  `totalFeeRequired()`, callers can derive the maximum amount a "spend max"
-  proposal sends to its recipient as `totalSpendValue() - totalFeeRequired()`.
+  of its steps, before its fee is deducted — each step's inputs minus its
+  non-ephemeral proposed change. Ephemeral (ZIP-320) change is spent by a
+  later step of the same proposal rather than retained by the wallet, so it
+  is not deducted. Combined with the existing `totalFeeRequired()`, callers
+  can derive the maximum amount a "spend max" proposal sends to its
+  recipient as `totalSpendValue() - totalFeeRequired()`.
 - `Synchronizer.proposeSendMax(accountUUID:recipient:memo:mode:)`, plus the
   matching `ClosureSynchronizer` and `CombineSynchronizer` entries: proposes a
   transaction that spends the maximum amount available in the account to a

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -667,9 +667,11 @@ constants), so the two desynchronize — the registration call reports this (and
 `Synchronizer`, `ClosureSynchronizer`, and `CombineSynchronizer` each gained a new required method,
 `proposeSendMax(accountUUID:recipient:memo:mode:)`, alongside the existing `proposeTransfer`. It
 proposes a transaction that spends the maximum amount available in the account — as much as the new
-`MaxSpendMode` allows — to a single recipient. Unlike `proposeTransfer`, no `amount` is passed; the
-fee is already accounted for by the returned proposal. Any external conformer of these protocols must
-implement the new method.
+`MaxSpendMode` allows — to a single recipient. The proposal draws on shielded funds only (Sapling,
+Orchard, Ironwood); transparent balance is never selected and must be shielded first (see
+`proposeShielding`). Unlike `proposeTransfer`, no `amount` is passed; the fee is already accounted
+for by the returned proposal. Any external conformer of these protocols must implement the new
+method.
 
 # Migrating from previous versions to v2.8.0-rc.1
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -662,6 +662,15 @@ Anything that resolves the custom network id before that registration — e.g. a
 process-globally while earlier instances keep their own per-instance state (checkpoint sources,
 constants), so the two desynchronize — the registration call reports this (and asserts in debug).
 
+## `Synchronizer` gained `proposeSendMax`
+
+`Synchronizer`, `ClosureSynchronizer`, and `CombineSynchronizer` each gained a new required method,
+`proposeSendMax(accountUUID:recipient:memo:mode:)`, alongside the existing `proposeTransfer`. It
+proposes a transaction that spends the maximum amount available in the account — as much as the new
+`MaxSpendMode` allows — to a single recipient. Unlike `proposeTransfer`, no `amount` is passed; the
+fee is already accounted for by the returned proposal. Any external conformer of these protocols must
+implement the new method.
+
 # Migrating from previous versions to v2.8.0-rc.1
 
 ## `prepare` now validates the seed against the existing wallet

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -62,6 +62,14 @@ public protocol ClosureSynchronizer {
     /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
     /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
     ///
+    /// The proposal draws on shielded funds only (Sapling, Orchard, Ironwood); transparent balance is never
+    /// selected and must be shielded first — see `proposeShielding`.
+    ///
+    /// When the account has no spendable balance, or its balance cannot cover the fee, this method throws
+    /// `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`). There is currently no dedicated typed error for
+    /// the nothing-to-send case, so a caller that wants to special-case an empty wallet should check the
+    /// spendable balance before calling this method.
+    ///
     /// - Parameter accountUUID: the account from which to spend funds.
     /// - Parameter recipient: the recipient's address.
     /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -56,6 +56,27 @@ public protocol ClosureSynchronizer {
         completion: @escaping (Result<Proposal, Error>) -> Void
     )
 
+    /// Creates a proposal that spends the maximum amount available in the given account to a single recipient.
+    ///
+    /// Unlike `proposeTransfer`, no `amount` is passed: the proposal is constructed to spend as much of the
+    /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
+    /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
+    ///
+    /// - Parameter accountUUID: the account from which to spend funds.
+    /// - Parameter recipient: the recipient's address.
+    /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
+    /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the synchronizer instance or since the last wipe then this method throws
+    /// `SynchronizerErrors.notPrepared`.
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode,
+        completion: @escaping (Result<Proposal, Error>) -> Void
+    )
+
     /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
     /// Fails unless NU6.3 is active at the chain tip.
     func proposeOrchardToIronwoodMigration(

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -59,6 +59,14 @@ public protocol CombineSynchronizer {
     /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
     /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
     ///
+    /// The proposal draws on shielded funds only (Sapling, Orchard, Ironwood); transparent balance is never
+    /// selected and must be shielded first — see `proposeShielding`.
+    ///
+    /// When the account has no spendable balance, or its balance cannot cover the fee, this method throws
+    /// `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`). There is currently no dedicated typed error for
+    /// the nothing-to-send case, so a caller that wants to special-case an empty wallet should check the
+    /// spendable balance before calling this method.
+    ///
     /// - Parameter accountUUID: the account from which to spend funds.
     /// - Parameter recipient: the recipient's address.
     /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -53,6 +53,26 @@ public protocol CombineSynchronizer {
         memo: Memo?
     ) -> SinglePublisher<Proposal, Error>
 
+    /// Creates a proposal that spends the maximum amount available in the given account to a single recipient.
+    ///
+    /// Unlike `proposeTransfer`, no `amount` is passed: the proposal is constructed to spend as much of the
+    /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
+    /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
+    ///
+    /// - Parameter accountUUID: the account from which to spend funds.
+    /// - Parameter recipient: the recipient's address.
+    /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
+    /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the synchronizer instance or since the last wipe then this method throws
+    /// `SynchronizerErrors.notPrepared`.
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode
+    ) -> SinglePublisher<Proposal, Error>
+
     /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
     /// Fails unless NU6.3 is active at the chain tip.
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) -> SinglePublisher<Proposal, Error>

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
@@ -607,7 +607,7 @@ actor OrchardMigration {
         )
         let proposal = Proposal(inner: ffiProposal)
         let fee = proposal.totalFeeRequired()
-        let amount = OrchardMigration.sweptPaymentValue(of: ffiProposal) - fee
+        let amount = proposal.totalSpendValue() - fee
         return ImmediateMigrationProposal(proposal: proposal, amount: amount, fee: fee)
     }
 
@@ -994,24 +994,5 @@ extension OrchardMigration {
             nextIndex += size
         }
         return sessions
-    }
-
-    /// The net value swept by an immediate-migration `FfiProposal` before its fee is subtracted:
-    /// the total value of the notes it consumes, minus any declared change. A send-max proposal
-    /// declares no change (there is nothing left to return), so this is ordinarily just the input
-    /// total; the change subtraction is defensive rather than load-bearing.
-    private static func sweptPaymentValue(of proposal: FfiProposal) -> Zatoshi {
-        proposal.steps.reduce(Zatoshi.zero) { total, step in
-            let stepInput = step.inputs.reduce(Zatoshi.zero) { inputTotal, input in
-                guard case .receivedOutput(let output) = input.value else {
-                    return inputTotal
-                }
-                return inputTotal + Zatoshi(Int64(output.value))
-            }
-            let stepChange = step.balance.proposedChange.reduce(Zatoshi.zero) { changeTotal, change in
-                changeTotal + Zatoshi(Int64(change.value))
-            }
-            return total + stepInput - stepChange
-        }
     }
 }

--- a/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
+++ b/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
@@ -5,9 +5,6 @@
 //  Created by Michal Fousek on 2026-07-29.
 //
 
-import Foundation
-import libzcashlc
-
 /// Specifies how a "spend max" request should be evaluated.
 public enum MaxSpendMode: Equatable, Sendable {
     /// Targets to spend all funds that are _currently_ spendable, where it could be the case that
@@ -17,14 +14,4 @@ public enum MaxSpendMode: Equatable, Sendable {
     /// Targets to spend **all funds** and will fail if there are unspendable funds in the wallet
     /// or if the wallet is not yet synced.
     case everything
-}
-
-extension MaxSpendMode {
-    /// The `libzcashlc` representation of this mode, as passed to `zcashlc_propose_send_max_transfer`.
-    var ffiMode: FfiMaxSpendMode {
-        switch self {
-        case .maxSpendable: return MaxSpendable
-        case .everything: return Everything
-        }
-    }
 }

--- a/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
+++ b/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
@@ -1,0 +1,30 @@
+//
+//  MaxSpendMode.swift
+//  ZcashLightClientKit
+//
+//  Created by Michal Fousek on 2026-07-29.
+//
+
+import Foundation
+import libzcashlc
+
+/// Specifies how a "spend max" request should be evaluated.
+public enum MaxSpendMode: Equatable, Sendable {
+    /// Targets to spend all funds that are _currently_ spendable, where it could be the case that
+    /// the wallet has received other funds that are not confirmed and therefore not spendable yet
+    /// and the caller evaluates that as an acceptable scenario.
+    case maxSpendable
+    /// Targets to spend **all funds** and will fail if there are unspendable funds in the wallet
+    /// or if the wallet is not yet synced.
+    case everything
+}
+
+extension MaxSpendMode {
+    /// The `libzcashlc` representation of this mode, as passed to `zcashlc_propose_send_max_transfer`.
+    var ffiMode: FfiMaxSpendMode {
+        switch self {
+        case .maxSpendable: return MaxSpendable
+        case .everything: return Everything
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
+++ b/Sources/ZcashLightClientKit/Model/MaxSpendMode.swift
@@ -11,7 +11,10 @@ public enum MaxSpendMode: Equatable, Sendable {
     /// the wallet has received other funds that are not confirmed and therefore not spendable yet
     /// and the caller evaluates that as an acceptable scenario.
     case maxSpendable
-    /// Targets to spend **all funds** and will fail if there are unspendable funds in the wallet
-    /// or if the wallet is not yet synced.
+    /// Targets to spend **all non-dust funds** in the wallet. Dust notes — those valued at or below
+    /// the ZIP-317 marginal fee — are excluded from note selection before this mode's eligibility
+    /// check runs, so a wallet holding only dust neither has that dust spent nor fails because of
+    /// it. This mode fails if the wallet holds other unspendable funds (for example unconfirmed or
+    /// unmined funds) or if the wallet is not yet synced.
     case everything
 }

--- a/Sources/ZcashLightClientKit/Model/Proposal.swift
+++ b/Sources/ZcashLightClientKit/Model/Proposal.swift
@@ -51,7 +51,10 @@ public struct Proposal: Equatable {
     ///
     /// This is the sum of the values of every step's inputs (only the `.receivedOutput` case draws
     /// new value from the wallet; an input that is a prior step's own output or change does not)
-    /// minus the sum of every step's proposed change values.
+    /// minus the sum of every step's non-ephemeral proposed change values. Ephemeral (ZIP-320)
+    /// change is spent by a later step of the same proposal rather than retained by the wallet, so
+    /// it is not deducted here — mirroring how a `priorStepChange` input that re-spends it is
+    /// already excluded from the input side.
     ///
     /// Combine with `totalFeeRequired()` to derive the maximum amount a "spend max" proposal can
     /// send to its recipient: `totalSpendValue() - totalFeeRequired()`.
@@ -64,7 +67,10 @@ public struct Proposal: Equatable {
                 return inputTotal + Zatoshi(Int64(output.value))
             }
             let stepChange = step.balance.proposedChange.reduce(Zatoshi.zero) { changeTotal, change in
-                changeTotal + Zatoshi(Int64(change.value))
+                guard !change.isEphemeral else {
+                    return changeTotal
+                }
+                return changeTotal + Zatoshi(Int64(change.value))
             }
             return total + stepInputs - stepChange
         }

--- a/Sources/ZcashLightClientKit/Model/Proposal.swift
+++ b/Sources/ZcashLightClientKit/Model/Proposal.swift
@@ -46,6 +46,29 @@ public struct Proposal: Equatable {
             }
         }
     }
+
+    /// Returns the total value this proposal spends, before its fee is deducted, in zatoshis.
+    ///
+    /// This is the sum of the values of every step's inputs (only the `.receivedOutput` case draws
+    /// new value from the wallet; an input that is a prior step's own output or change does not)
+    /// minus the sum of every step's proposed change values.
+    ///
+    /// Combine with `totalFeeRequired()` to derive the maximum amount a "spend max" proposal can
+    /// send to its recipient: `totalSpendValue() - totalFeeRequired()`.
+    public func totalSpendValue() -> Zatoshi {
+        inner.steps.reduce(Zatoshi.zero) { total, step in
+            let stepInputs = step.inputs.reduce(Zatoshi.zero) { inputTotal, input in
+                guard case .receivedOutput(let output) = input.value else {
+                    return inputTotal
+                }
+                return inputTotal + Zatoshi(Int64(output.value))
+            }
+            let stepChange = step.balance.proposedChange.reduce(Zatoshi.zero) { changeTotal, change in
+                changeTotal + Zatoshi(Int64(change.value))
+            }
+            return total + stepInputs - stepChange
+        }
+    }
 }
 
 public extension Proposal {

--- a/Sources/ZcashLightClientKit/Model/WalletTypes.swift
+++ b/Sources/ZcashLightClientKit/Model/WalletTypes.swift
@@ -352,3 +352,19 @@ public enum Recipient: Equatable, StringEncoded {
         }
     }
 }
+
+extension Recipient {
+    /// Memos can only ride in shielded outputs, so a memo aimed at a transparent or TEX
+    /// recipient must be rejected before the request reaches the FFI, where it would only
+    /// surface as an opaque rust error.
+    func ensureMemoIsAllowed(_ memo: Memo?) throws {
+        guard memo != nil else { return }
+
+        switch self {
+        case .transparent, .tex:
+            throw ZcashError.synchronizerSendMemoToTransparentAddress
+        case .sapling, .unified:
+            break
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -380,6 +380,38 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         ))
     }
 
+    // DB-READ (audited 2026-08-03): propose_send_max_transfer with lock_inputs = None — write
+    // branch statically gated off; selection over a shared read-only reference.
+    func proposeSendMaxTransfer(
+        accountUUID: AccountUUID,
+        to address: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> FfiProposal {
+        let proposal = zcashlc_propose_send_max_transfer(
+            dbData.0,
+            dbData.1,
+            networkType.networkId,
+            accountUUID.id,
+            [CChar](address.utf8CString),
+            memo?.bytes,
+            mode.ffiMode,
+            confirmationsPolicy.toBackend(),
+            false // orchard_only — the public send-max path draws on every shielded pool
+        )
+
+        guard let proposal else {
+            throw ZcashError.rustProposeSendMaxTransfer(lastErrorMessage(fallback: "`proposeSendMaxTransfer` failed with unknown error"))
+        }
+
+        defer { zcashlc_free_boxed_slice(proposal) }
+
+        return try FfiProposal(serializedBytes: Data(
+            bytes: proposal.pointee.ptr,
+            count: Int(proposal.pointee.len)
+        ))
+    }
+
     // DB-READ (audited 2026-08-03): propose_send_max_transfer with lock_inputs = None — the
     // only write arm statically skipped; input selection SELECT-only; proposal returned,
     // never stored. Bypasses the migration open() preamble entirely.

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -71,6 +71,16 @@ public struct ConfirmationsPolicy {
     }
 }
 
+extension MaxSpendMode {
+    /// The `libzcashlc` representation of this mode, as passed to `zcashlc_propose_send_max_transfer`.
+    var ffiMode: FfiMaxSpendMode {
+        switch self {
+        case .maxSpendable: return MaxSpendable
+        case .everything: return Everything
+        }
+    }
+}
+
 struct ZcashRustBackend: ZcashRustBackendWelding {
     let confirmationsPolicy: ConfirmationsPolicy = ConfirmationsPolicy.defaultTransferPolicy()
     let shieldingConfirmationsPolicy: ConfirmationsPolicy = ConfirmationsPolicy.defaultShieldingPolicy()

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -380,14 +380,13 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         ))
     }
 
-    // DB-READ (audited 2026-08-03): propose_send_max_transfer with lock_inputs = None — write
-    // branch statically gated off; selection over a shared read-only reference.
-    func proposeSendMaxTransfer(
+    private func proposeSendMaxTransfer(
         accountUUID: AccountUUID,
-        to address: String,
+        address: String,
         memo: MemoBytes?,
-        mode: MaxSpendMode
-    ) async throws -> FfiProposal {
+        ffiMode: FfiMaxSpendMode,
+        orchardOnly: Bool
+    ) throws -> FfiProposal {
         let proposal = zcashlc_propose_send_max_transfer(
             dbData.0,
             dbData.1,
@@ -395,9 +394,9 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
             accountUUID.id,
             [CChar](address.utf8CString),
             memo?.bytes,
-            mode.ffiMode,
+            ffiMode,
             confirmationsPolicy.toBackend(),
-            false // orchard_only — the public send-max path draws on every shielded pool
+            orchardOnly
         )
 
         guard let proposal else {
@@ -410,6 +409,23 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
             bytes: proposal.pointee.ptr,
             count: Int(proposal.pointee.len)
         ))
+    }
+
+    // DB-READ (audited 2026-08-03): propose_send_max_transfer with lock_inputs = None — write
+    // branch statically gated off; selection over a shared read-only reference.
+    func proposeSendMaxTransfer(
+        accountUUID: AccountUUID,
+        to address: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> FfiProposal {
+        return try proposeSendMaxTransfer(
+            accountUUID: accountUUID,
+            address: address,
+            memo: memo,
+            ffiMode: mode.ffiMode,
+            orchardOnly: false // orchard_only — the public send-max path draws on every shielded pool
+        )
     }
 
     // DB-READ (audited 2026-08-03): propose_send_max_transfer with lock_inputs = None — the
@@ -2006,28 +2022,13 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         memo: MemoBytes?,
         orchardOnly: Bool
     ) async throws -> FfiProposal {
-        let proposal = zcashlc_propose_send_max_transfer(
-            dbData.0,
-            dbData.1,
-            networkType.networkId,
-            accountUUID.id,
-            [CChar](recipient.utf8CString),
-            memo?.bytes,
-            MaxSpendable,
-            confirmationsPolicy.toBackend(),
-            orchardOnly
+        return try proposeSendMaxTransfer(
+            accountUUID: accountUUID,
+            address: recipient,
+            memo: memo,
+            ffiMode: MaxSpendable,
+            orchardOnly: orchardOnly
         )
-
-        guard let proposal else {
-            throw ZcashError.rustProposeSendMaxTransfer(lastErrorMessage(fallback: "`proposeSendMaxTransfer` failed with unknown error"))
-        }
-
-        defer { zcashlc_free_boxed_slice(proposal) }
-
-        return try FfiProposal(serializedBytes: Data(
-            bytes: proposal.pointee.ptr,
-            count: Int(proposal.pointee.len)
-        ))
     }
 
     @DBActor

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -268,6 +268,9 @@ protocol ZcashRustBackendWelding {
     /// as much of the account's balance as `mode` allows, for a transaction that can then be
     /// authorized and made ready for submission to the network with `createProposedTransaction`.
     ///
+    /// The proposal draws on shielded funds only (Sapling, Orchard, Ironwood); transparent balance
+    /// is never selected and must be shielded first — see `proposeShielding`.
+    ///
     /// - Parameter accountUUID: the account to spend from.
     /// - Parameter to: recipient address.
     /// - Parameter memo: the `MemoBytes` for this transaction. pass `nil` when sending to transparent receivers

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -264,6 +264,22 @@ protocol ZcashRustBackendWelding {
         memo: MemoBytes?
     ) async throws -> FfiProposal
 
+    /// Select transaction inputs, compute fees, and construct a "spend max" proposal that spends
+    /// as much of the account's balance as `mode` allows, for a transaction that can then be
+    /// authorized and made ready for submission to the network with `createProposedTransaction`.
+    ///
+    /// - Parameter accountUUID: the account to spend from.
+    /// - Parameter to: recipient address.
+    /// - Parameter memo: the `MemoBytes` for this transaction. pass `nil` when sending to transparent receivers
+    /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
+    /// - Throws: `rustProposeSendMaxTransfer`.
+    func proposeSendMaxTransfer(
+        accountUUID: AccountUUID,
+        to address: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> FfiProposal
+
     /// Proposes migrating the account's entire Orchard balance into the Ironwood pool.
     ///
     /// Sends the maximum from Orchard to the account's own internal receiver so nothing is

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -733,6 +733,13 @@ public actor SlipstreamSynchronizer: Synchronizer {
         memo: Memo?,
         mode: MaxSpendMode
     ) async throws -> Proposal {
+        // Parity with `start()`'s guard above and with `SDKSynchronizer.proposeSendMax`'s
+        // `throwIfUnprepared()`: the encoder path below never touches the engine handle, so
+        // without this check an unprepared call would fall straight through to the rust
+        // backend instead of failing with the documented `synchronizerNotPrepared`.
+        guard latestState.internalSyncStatus.isPrepared else {
+            throw ZcashError.synchronizerNotPrepared
+        }
         try recipient.ensureMemoIsAllowed(memo)
         return try await transactionEncoder.proposeSendMax(
             accountUUID: accountUUID,

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -718,6 +718,13 @@ public actor SlipstreamSynchronizer: Synchronizer {
         amount: Zatoshi,
         memo: Memo?
     ) async throws -> Proposal {
+        // Parity with `start()`'s guard above and with `SDKSynchronizer.proposeTransfer`'s
+        // `throwIfUnprepared()`: the encoder path below never touches the engine handle, so
+        // without this check an unprepared call would fall straight through to the rust
+        // backend instead of failing with the documented `synchronizerNotPrepared`.
+        guard latestState.internalSyncStatus.isPrepared else {
+            throw ZcashError.synchronizerNotPrepared
+        }
         try recipient.ensureMemoIsAllowed(memo)
         return try await transactionEncoder.proposeTransfer(
             accountUUID: accountUUID,
@@ -750,7 +757,14 @@ public actor SlipstreamSynchronizer: Synchronizer {
     }
 
     public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
-        try await transactionEncoder.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
+        // Parity with `start()`'s guard above and with `SDKSynchronizer.proposeOrchardToIronwoodMigration`'s
+        // `throwIfUnprepared()`: the encoder path below never touches the engine handle, so
+        // without this check an unprepared call would fall straight through to the rust
+        // backend instead of failing with the documented `synchronizerNotPrepared`.
+        guard latestState.internalSyncStatus.isPrepared else {
+            throw ZcashError.synchronizerNotPrepared
+        }
+        return try await transactionEncoder.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
     }
 
     public func proposeShielding(
@@ -759,6 +773,13 @@ public actor SlipstreamSynchronizer: Synchronizer {
         memo: Memo,
         transparentReceiver: TransparentAddress? = nil
     ) async throws -> Proposal? {
+        // Parity with `start()`'s guard above and with `SDKSynchronizer.proposeShielding`'s
+        // `throwIfUnprepared()`: the encoder path below never touches the engine handle, so
+        // without this check an unprepared call would fall straight through to the rust
+        // backend instead of failing with the documented `synchronizerNotPrepared`.
+        guard latestState.internalSyncStatus.isPrepared else {
+            throw ZcashError.synchronizerNotPrepared
+        }
         return try await transactionEncoder.proposeShielding(
             accountUUID: accountUUID,
             shieldingThreshold: shieldingThreshold,
@@ -771,6 +792,17 @@ public actor SlipstreamSynchronizer: Synchronizer {
         _ uri: String,
         accountUUID: AccountUUID
     ) async throws -> Proposal {
+        // Parity with `start()`'s guard above and with `SDKSynchronizer.proposefulfillingPaymentURI`'s
+        // `throwIfUnprepared()`: the encoder path below never touches the engine handle, so
+        // without this check an unprepared call would fall straight through to the rust
+        // backend instead of failing with the documented `synchronizerNotPrepared`. Placed before
+        // the `do` block (rather than as its first statement, where `SDKSynchronizer` puts its own
+        // copy) so the guard's throw bypasses the `rustCreateToAddress` remapping below -- it is
+        // not a rust error to remap, and the two placements are externally identical since neither
+        // catch clause matches `synchronizerNotPrepared`.
+        guard latestState.internalSyncStatus.isPrepared else {
+            throw ZcashError.synchronizerNotPrepared
+        }
         do {
             return try await transactionEncoder.proposeFulfillingPaymentFromURI(
                 uri,

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -729,6 +729,23 @@ public actor SlipstreamSynchronizer: Synchronizer {
         )
     }
 
+    public func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal {
+        if case Recipient.transparent = recipient, memo != nil {
+            throw ZcashError.synchronizerSendMemoToTransparentAddress
+        }
+        return try await transactionEncoder.proposeSendMax(
+            accountUUID: accountUUID,
+            recipient: recipient.stringEncoded,
+            memo: memo?.asMemoBytes(),
+            mode: mode
+        )
+    }
+
     public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
         try await transactionEncoder.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
     }

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -718,9 +718,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
         amount: Zatoshi,
         memo: Memo?
     ) async throws -> Proposal {
-        if case Recipient.transparent = recipient, memo != nil {
-            throw ZcashError.synchronizerSendMemoToTransparentAddress
-        }
+        try recipient.ensureMemoIsAllowed(memo)
         return try await transactionEncoder.proposeTransfer(
             accountUUID: accountUUID,
             recipient: recipient.stringEncoded,
@@ -735,9 +733,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
         memo: Memo?,
         mode: MaxSpendMode
     ) async throws -> Proposal {
-        if case Recipient.transparent = recipient, memo != nil {
-            throw ZcashError.synchronizerSendMemoToTransparentAddress
-        }
+        try recipient.ensureMemoIsAllowed(memo)
         return try await transactionEncoder.proposeSendMax(
             accountUUID: accountUUID,
             recipient: recipient.stringEncoded,

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -744,7 +744,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
         return try await transactionEncoder.proposeSendMax(
             accountUUID: accountUUID,
             recipient: recipient.stringEncoded,
-            memo: memo?.asMemoBytes(),
+            memoBytes: memo?.asMemoBytes(),
             mode: mode
         )
     }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -214,6 +214,26 @@ public protocol Synchronizer: AnyObject {
         memo: Memo?
     ) async throws -> Proposal
 
+    /// Creates a proposal that spends the maximum amount available in the given account to a single recipient.
+    ///
+    /// Unlike `proposeTransfer`, no `amount` is passed: the proposal is constructed to spend as much of the
+    /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
+    /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
+    ///
+    /// - Parameter accountUUID: the account from which to spend funds.
+    /// - Parameter recipient: the recipient's address.
+    /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
+    /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the synchronizer instance or since the last wipe then this method throws
+    /// `SynchronizerErrors.notPrepared`.
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal
+
     /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
     ///
     /// NU6.3 introduces the Orchard turnstile: value may leave the Orchard pool but never re-enter

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -220,6 +220,14 @@ public protocol Synchronizer: AnyObject {
     /// account's balance as `mode` allows, with the fee already accounted for by the proposal itself. The amount
     /// the recipient actually receives is `proposal.totalSpendValue() - proposal.totalFeeRequired()`.
     ///
+    /// The proposal draws on shielded funds only (Sapling, Orchard, Ironwood); transparent balance is never
+    /// selected and must be shielded first — see `proposeShielding`.
+    ///
+    /// When the account has no spendable balance, or its balance cannot cover the fee, this method throws
+    /// `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`). There is currently no dedicated typed error for
+    /// the nothing-to-send case, so a caller that wants to special-case an empty wallet should check the
+    /// spendable balance before calling this method.
+    ///
     /// - Parameter accountUUID: the account from which to spend funds.
     /// - Parameter recipient: the recipient's address.
     /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -125,6 +125,18 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         }
     }
 
+    public func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode,
+        completion: @escaping (Result<Proposal, Error>) -> Void
+    ) {
+        AsyncToClosureGateway.executeThrowingAction(completion) {
+            try await self.synchronizer.proposeSendMax(accountUUID: accountUUID, recipient: recipient, memo: memo, mode: mode)
+        }
+    }
+
     public func proposeOrchardToIronwoodMigration(
         accountUUID: AccountUUID,
         completion: @escaping (Result<Proposal, Error>) -> Void

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -92,6 +92,17 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         }
     }
 
+    public func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: Recipient,
+        memo: Memo?,
+        mode: MaxSpendMode
+    ) -> SinglePublisher<Proposal, Error> {
+        AsyncToCombineGateway.executeThrowingAction() {
+            try await self.synchronizer.proposeSendMax(accountUUID: accountUUID, recipient: recipient, memo: memo, mode: mode)
+        }
+    }
+
     public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) -> SinglePublisher<Proposal, Error> {
         AsyncToCombineGateway.executeThrowingAction() {
             try await self.synchronizer.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -450,9 +450,7 @@ public class SDKSynchronizer: Synchronizer {
     public func proposeTransfer(accountUUID: AccountUUID, recipient: Recipient, amount: Zatoshi, memo: Memo?) async throws -> Proposal {
         try throwIfUnprepared()
 
-        if case Recipient.transparent = recipient, memo != nil {
-            throw ZcashError.synchronizerSendMemoToTransparentAddress
-        }
+        try recipient.ensureMemoIsAllowed(memo)
 
         let proposal = try await transactionEncoder.proposeTransfer(
             accountUUID: accountUUID,
@@ -467,9 +465,7 @@ public class SDKSynchronizer: Synchronizer {
     public func proposeSendMax(accountUUID: AccountUUID, recipient: Recipient, memo: Memo?, mode: MaxSpendMode) async throws -> Proposal {
         try throwIfUnprepared()
 
-        if case Recipient.transparent = recipient, memo != nil {
-            throw ZcashError.synchronizerSendMemoToTransparentAddress
-        }
+        try recipient.ensureMemoIsAllowed(memo)
 
         let proposal = try await transactionEncoder.proposeSendMax(
             accountUUID: accountUUID,

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -464,6 +464,23 @@ public class SDKSynchronizer: Synchronizer {
         return proposal
     }
 
+    public func proposeSendMax(accountUUID: AccountUUID, recipient: Recipient, memo: Memo?, mode: MaxSpendMode) async throws -> Proposal {
+        try throwIfUnprepared()
+
+        if case Recipient.transparent = recipient, memo != nil {
+            throw ZcashError.synchronizerSendMemoToTransparentAddress
+        }
+
+        let proposal = try await transactionEncoder.proposeSendMax(
+            accountUUID: accountUUID,
+            recipient: recipient.stringEncoded,
+            memo: memo?.asMemoBytes(),
+            mode: mode
+        )
+
+        return proposal
+    }
+
     public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
         try throwIfUnprepared()
 

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -470,7 +470,7 @@ public class SDKSynchronizer: Synchronizer {
         let proposal = try await transactionEncoder.proposeSendMax(
             accountUUID: accountUUID,
             recipient: recipient.stringEncoded,
-            memo: memo?.asMemoBytes(),
+            memoBytes: memo?.asMemoBytes(),
             mode: mode
         )
 

--- a/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
@@ -40,6 +40,9 @@ protocol TransactionEncoder {
     /// Unlike `proposeTransfer`, no `amount` is passed: the proposal spends as much of the account's balance as
     /// `mode` allows, with the fee already accounted for by the proposal itself.
     ///
+    /// The proposal draws on shielded funds only (Sapling, Orchard, Ironwood); transparent balance is never
+    /// selected and must be shielded first — see `proposeShielding`.
+    ///
     /// - Parameter accountUUID: the account from which to spend funds.
     /// - Parameter recipient: string containing the recipient's address.
     /// - Parameter memoBytes: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.

--- a/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
@@ -42,7 +42,7 @@ protocol TransactionEncoder {
     ///
     /// - Parameter accountUUID: the account from which to spend funds.
     /// - Parameter recipient: string containing the recipient's address.
-    /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
+    /// - Parameter memoBytes: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
     /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
     ///
     /// If `prepare()` hasn't already been called since creation of the synchronizer instance or since the last wipe then this method throws
@@ -50,7 +50,7 @@ protocol TransactionEncoder {
     func proposeSendMax(
         accountUUID: AccountUUID,
         recipient: String,
-        memo: MemoBytes?,
+        memoBytes: MemoBytes?,
         mode: MaxSpendMode
     ) async throws -> Proposal
 

--- a/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
@@ -35,6 +35,25 @@ protocol TransactionEncoder {
         memoBytes: MemoBytes?
     ) async throws -> Proposal
 
+    /// Creates a proposal that spends the maximum amount available in the given account to a single recipient.
+    ///
+    /// Unlike `proposeTransfer`, no `amount` is passed: the proposal spends as much of the account's balance as
+    /// `mode` allows, with the fee already accounted for by the proposal itself.
+    ///
+    /// - Parameter accountUUID: the account from which to spend funds.
+    /// - Parameter recipient: string containing the recipient's address.
+    /// - Parameter memo: an optional memo to include as part of the proposal's transactions. Use `nil` when sending to transparent receivers otherwise the function will throw an error.
+    /// - Parameter mode: how much of the account's balance the proposal should target spending. See `MaxSpendMode`.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the synchronizer instance or since the last wipe then this method throws
+    /// `SynchronizerErrors.notPrepared`.
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal
+
     /// Proposes migrating the account's entire Orchard balance into the Ironwood pool.
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal
 

--- a/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
@@ -80,13 +80,13 @@ class WalletTransactionEncoder: TransactionEncoder {
     func proposeSendMax(
         accountUUID: AccountUUID,
         recipient: String,
-        memo: MemoBytes?,
+        memoBytes: MemoBytes?,
         mode: MaxSpendMode
     ) async throws -> Proposal {
         let proposal = try await rustBackend.proposeSendMaxTransfer(
             accountUUID: accountUUID,
             to: recipient,
-            memo: memo,
+            memo: memoBytes,
             mode: mode
         )
 

--- a/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
@@ -77,6 +77,22 @@ class WalletTransactionEncoder: TransactionEncoder {
         return Proposal(inner: proposal)
     }
 
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal {
+        let proposal = try await rustBackend.proposeSendMaxTransfer(
+            accountUUID: accountUUID,
+            to: recipient,
+            memo: memo,
+            mode: mode
+        )
+
+        return Proposal(inner: proposal)
+    }
+
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
         let proposal = try await rustBackend.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
 

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -388,7 +388,7 @@ private final class StubTransactionEncoder: TransactionEncoder {
     func proposeSendMax(
         accountUUID: AccountUUID,
         recipient: String,
-        memo: MemoBytes?,
+        memoBytes: MemoBytes?,
         mode: MaxSpendMode
     ) async throws -> Proposal {
         fatalError("Unused in test")

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -385,6 +385,15 @@ private final class StubTransactionEncoder: TransactionEncoder {
         fatalError("Unused in test")
     }
 
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
         fatalError("Unused in test")
     }

--- a/Tests/OfflineTests/MaxSpendModeTests.swift
+++ b/Tests/OfflineTests/MaxSpendModeTests.swift
@@ -1,0 +1,24 @@
+//
+//  MaxSpendModeTests.swift
+//  ZcashLightClientKitTests
+//
+//  Created by Michal Fousek on 2026-07-29.
+//
+
+import XCTest
+import libzcashlc
+@testable import ZcashLightClientKit
+
+final class MaxSpendModeTests: XCTestCase {
+    func testMaxSpendableMapsToFfiMaxSpendable() throws {
+        XCTAssertEqual(MaxSpendMode.maxSpendable.ffiMode, MaxSpendable)
+    }
+
+    func testEverythingMapsToFfiEverything() throws {
+        XCTAssertEqual(MaxSpendMode.everything.ffiMode, Everything)
+    }
+
+    func testTheTwoModesMapToDifferentFfiValues() throws {
+        XCTAssertNotEqual(MaxSpendMode.maxSpendable.ffiMode, MaxSpendMode.everything.ffiMode)
+    }
+}

--- a/Tests/OfflineTests/ProposalTests.swift
+++ b/Tests/OfflineTests/ProposalTests.swift
@@ -1,0 +1,176 @@
+//
+//  ProposalTests.swift
+//  ZcashLightClientKitTests
+//
+//  Created by Michal Fousek on 2026-07-29.
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+final class ProposalTests: XCTestCase {
+    // MARK: - totalSpendValue()
+
+    func testTotalSpendValueWithInputsOnly() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [1_000_000, 500_000], changeValues: [], fee: 10_000)
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(1_000_000 + 500_000))
+    }
+
+    func testTotalSpendValueWithInputsAndChangeSubtractsTheChange() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [1_000_000], changeValues: [200_000], fee: 10_000)
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(1_000_000 - 200_000))
+    }
+
+    func testTotalSpendValueWithMultipleChangeOutputsInAStep() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [1_000_000], changeValues: [120_000, 80_000], fee: 10_000)
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(1_000_000 - 120_000 - 80_000))
+    }
+
+    func testTotalSpendValueSumsAcrossMultipleSteps() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [1_000_000], changeValues: [100_000], fee: 5_000),
+                Self.Step(inputValues: [300_000, 200_000], changeValues: [50_000], fee: 5_000)
+            ]
+        )
+
+        let expected = Zatoshi((1_000_000 - 100_000) + (300_000 + 200_000 - 50_000))
+        XCTAssertEqual(proposal.totalSpendValue(), expected)
+    }
+
+    func testTotalSpendValueIgnoresInputsThatAreNotReceivedOutputs() throws {
+        let inputs = [
+            Self.receivedOutputInput(1_000_000),
+            Self.priorStepOutputInput(stepIndex: 0, paymentIndex: 0),
+            Self.priorStepChangeInput(stepIndex: 0, changeIndex: 0)
+        ]
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputs: inputs, changeValues: [], fee: 10_000)
+            ]
+        )
+
+        // Only the `receivedOutput` input draws new value from the wallet; the prior-step
+        // references must not be double-counted.
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(1_000_000))
+    }
+
+    func testTotalSpendValueIsZeroWhenThereAreNoSteps() throws {
+        let proposal = Self.makeProposal(steps: [])
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi.zero)
+    }
+
+    // MARK: - Relationship with totalFeeRequired()
+
+    func testMaxSendableAmountIsTotalSpendValueMinusTotalFeeRequired() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [2_000_000], changeValues: [], fee: 15_000)
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalFeeRequired(), Zatoshi(15_000))
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(2_000_000))
+
+        let maxSendable = proposal.totalSpendValue() - proposal.totalFeeRequired()
+        XCTAssertEqual(maxSendable, Zatoshi(2_000_000 - 15_000))
+    }
+
+    func testMaxSendableAmountAcrossMultipleStepsWithChange() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(inputValues: [1_000_000], changeValues: [50_000], fee: 10_000),
+                Self.Step(inputValues: [500_000], changeValues: [], fee: 5_000)
+            ]
+        )
+
+        let maxSendable = proposal.totalSpendValue() - proposal.totalFeeRequired()
+
+        XCTAssertEqual(maxSendable, Zatoshi((1_000_000 - 50_000 - 10_000) + (500_000 - 5_000)))
+    }
+}
+
+// MARK: - FfiProposal fixture builders
+
+extension ProposalTests {
+    private struct Step {
+        let inputs: [FfiProposedInput]
+        let changeValues: [UInt64]
+        let fee: UInt64
+
+        init(inputValues: [UInt64], changeValues: [UInt64], fee: UInt64) {
+            self.inputs = inputValues.map { ProposalTests.receivedOutputInput($0) }
+            self.changeValues = changeValues
+            self.fee = fee
+        }
+
+        init(inputs: [FfiProposedInput], changeValues: [UInt64], fee: UInt64) {
+            self.inputs = inputs
+            self.changeValues = changeValues
+            self.fee = fee
+        }
+    }
+
+    private static func receivedOutputInput(_ value: UInt64) -> FfiProposedInput {
+        var receivedOutput = FfiReceivedOutput()
+        receivedOutput.value = value
+        var input = FfiProposedInput()
+        input.receivedOutput = receivedOutput
+        return input
+    }
+
+    private static func priorStepOutputInput(stepIndex: UInt32, paymentIndex: UInt32) -> FfiProposedInput {
+        var priorStepOutput = FfiPriorStepOutput()
+        priorStepOutput.stepIndex = stepIndex
+        priorStepOutput.paymentIndex = paymentIndex
+        var input = FfiProposedInput()
+        input.priorStepOutput = priorStepOutput
+        return input
+    }
+
+    private static func priorStepChangeInput(stepIndex: UInt32, changeIndex: UInt32) -> FfiProposedInput {
+        var priorStepChange = FfiPriorStepChange()
+        priorStepChange.stepIndex = stepIndex
+        priorStepChange.changeIndex = changeIndex
+        var input = FfiProposedInput()
+        input.priorStepChange = priorStepChange
+        return input
+    }
+
+    private static func makeProposal(steps: [Step]) -> Proposal {
+        let ffiSteps: [FfiProposalStep] = steps.map { stepSpec in
+            var balance = FfiTransactionBalance()
+            balance.feeRequired = stepSpec.fee
+            balance.proposedChange = stepSpec.changeValues.map { value in
+                var change = FfiChangeValue()
+                change.value = value
+                return change
+            }
+
+            var step = FfiProposalStep()
+            step.inputs = stepSpec.inputs
+            step.balance = balance
+            return step
+        }
+
+        var ffiProposal = FfiProposal()
+        ffiProposal.steps = ffiSteps
+        return Proposal(inner: ffiProposal)
+    }
+}

--- a/Tests/OfflineTests/ProposalTests.swift
+++ b/Tests/OfflineTests/ProposalTests.swift
@@ -104,23 +104,82 @@ final class ProposalTests: XCTestCase {
 
         XCTAssertEqual(maxSendable, Zatoshi((1_000_000 - 50_000 - 10_000) + (500_000 - 5_000)))
     }
+
+    // MARK: - Ephemeral (ZIP-320) change
+
+    func testTotalSpendValueForZip320TwoStepProposalExcludesEphemeralChange() throws {
+        // Step 0 shields no new value: it spends wallet funds into a transparent ephemeral
+        // output that only exists to fund step 1's payment to the TEX recipient. Step 1's
+        // input is a `priorStepChange` reference to that ephemeral output, not a fresh spend.
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(
+                    inputValues: [1_000_000],
+                    changeValues: [Self.ChangeValue(value: 985_000, isEphemeral: true)],
+                    fee: 15_000
+                ),
+                Self.Step(
+                    inputs: [Self.priorStepChangeInput(stepIndex: 0, changeIndex: 0)],
+                    changeValues: [],
+                    fee: 10_000
+                )
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(1_000_000))
+        XCTAssertEqual(proposal.totalSpendValue() - proposal.totalFeeRequired(), Zatoshi(975_000))
+    }
+
+    func testTotalSpendValueWithMixedChangeSubtractsOnlyNonEphemeralChange() throws {
+        let proposal = Self.makeProposal(
+            steps: [
+                Self.Step(
+                    inputValues: [1_000_000],
+                    changeValues: [
+                        Self.ChangeValue(value: 200_000, isEphemeral: false),
+                        Self.ChangeValue(value: 700_000, isEphemeral: true)
+                    ],
+                    fee: 15_000
+                )
+            ]
+        )
+
+        XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(800_000))
+    }
 }
 
 // MARK: - FfiProposal fixture builders
 
 extension ProposalTests {
+    /// A single proposed-change entry for a fixture step. Conforms to `ExpressibleByIntegerLiteral`
+    /// so existing call sites that spell change values as bare `UInt64` literals keep compiling,
+    /// defaulting to non-ephemeral change.
+    private struct ChangeValue: ExpressibleByIntegerLiteral {
+        let value: UInt64
+        let isEphemeral: Bool
+
+        init(value: UInt64, isEphemeral: Bool = false) {
+            self.value = value
+            self.isEphemeral = isEphemeral
+        }
+
+        init(integerLiteral value: UInt64) {
+            self.init(value: value)
+        }
+    }
+
     private struct Step {
         let inputs: [FfiProposedInput]
-        let changeValues: [UInt64]
+        let changeValues: [ChangeValue]
         let fee: UInt64
 
-        init(inputValues: [UInt64], changeValues: [UInt64], fee: UInt64) {
+        init(inputValues: [UInt64], changeValues: [ChangeValue], fee: UInt64) {
             self.inputs = inputValues.map { ProposalTests.receivedOutputInput($0) }
             self.changeValues = changeValues
             self.fee = fee
         }
 
-        init(inputs: [FfiProposedInput], changeValues: [UInt64], fee: UInt64) {
+        init(inputs: [FfiProposedInput], changeValues: [ChangeValue], fee: UInt64) {
             self.inputs = inputs
             self.changeValues = changeValues
             self.fee = fee
@@ -157,9 +216,10 @@ extension ProposalTests {
         let ffiSteps: [FfiProposalStep] = steps.map { stepSpec in
             var balance = FfiTransactionBalance()
             balance.feeRequired = stepSpec.fee
-            balance.proposedChange = stepSpec.changeValues.map { value in
+            balance.proposedChange = stepSpec.changeValues.map { changeSpec in
                 var change = FfiChangeValue()
-                change.value = value
+                change.value = changeSpec.value
+                change.isEphemeral = changeSpec.isEphemeral
                 return change
             }
 

--- a/Tests/OfflineTests/ProposalTests.swift
+++ b/Tests/OfflineTests/ProposalTests.swift
@@ -6,15 +6,16 @@
 //
 
 import XCTest
+@testable import TestUtils
 @testable import ZcashLightClientKit
 
 final class ProposalTests: XCTestCase {
     // MARK: - totalSpendValue()
 
     func testTotalSpendValueWithInputsOnly() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [1_000_000, 500_000], changeValues: [], fee: 10_000)
+                FfiProposalFixtures.Step(inputValues: [1_000_000, 500_000], changeValues: [], fee: 10_000)
             ]
         )
 
@@ -22,9 +23,9 @@ final class ProposalTests: XCTestCase {
     }
 
     func testTotalSpendValueWithInputsAndChangeSubtractsTheChange() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [1_000_000], changeValues: [200_000], fee: 10_000)
+                FfiProposalFixtures.Step(inputValues: [1_000_000], changeValues: [200_000], fee: 10_000)
             ]
         )
 
@@ -32,9 +33,9 @@ final class ProposalTests: XCTestCase {
     }
 
     func testTotalSpendValueWithMultipleChangeOutputsInAStep() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [1_000_000], changeValues: [120_000, 80_000], fee: 10_000)
+                FfiProposalFixtures.Step(inputValues: [1_000_000], changeValues: [120_000, 80_000], fee: 10_000)
             ]
         )
 
@@ -42,10 +43,10 @@ final class ProposalTests: XCTestCase {
     }
 
     func testTotalSpendValueSumsAcrossMultipleSteps() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [1_000_000], changeValues: [100_000], fee: 5_000),
-                Self.Step(inputValues: [300_000, 200_000], changeValues: [50_000], fee: 5_000)
+                FfiProposalFixtures.Step(inputValues: [1_000_000], changeValues: [100_000], fee: 5_000),
+                FfiProposalFixtures.Step(inputValues: [300_000, 200_000], changeValues: [50_000], fee: 5_000)
             ]
         )
 
@@ -55,13 +56,13 @@ final class ProposalTests: XCTestCase {
 
     func testTotalSpendValueIgnoresInputsThatAreNotReceivedOutputs() throws {
         let inputs = [
-            Self.receivedOutputInput(1_000_000),
-            Self.priorStepOutputInput(stepIndex: 0, paymentIndex: 0),
-            Self.priorStepChangeInput(stepIndex: 0, changeIndex: 0)
+            FfiProposalFixtures.receivedOutputInput(1_000_000),
+            FfiProposalFixtures.priorStepOutputInput(stepIndex: 0, paymentIndex: 0),
+            FfiProposalFixtures.priorStepChangeInput(stepIndex: 0, changeIndex: 0)
         ]
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputs: inputs, changeValues: [], fee: 10_000)
+                FfiProposalFixtures.Step(inputs: inputs, changeValues: [], fee: 10_000)
             ]
         )
 
@@ -71,7 +72,7 @@ final class ProposalTests: XCTestCase {
     }
 
     func testTotalSpendValueIsZeroWhenThereAreNoSteps() throws {
-        let proposal = Self.makeProposal(steps: [])
+        let proposal = FfiProposalFixtures.makeProposal(steps: [])
 
         XCTAssertEqual(proposal.totalSpendValue(), Zatoshi.zero)
     }
@@ -79,9 +80,9 @@ final class ProposalTests: XCTestCase {
     // MARK: - Relationship with totalFeeRequired()
 
     func testMaxSendableAmountIsTotalSpendValueMinusTotalFeeRequired() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [2_000_000], changeValues: [], fee: 15_000)
+                FfiProposalFixtures.Step(inputValues: [2_000_000], changeValues: [], fee: 15_000)
             ]
         )
 
@@ -93,10 +94,10 @@ final class ProposalTests: XCTestCase {
     }
 
     func testMaxSendableAmountAcrossMultipleStepsWithChange() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(inputValues: [1_000_000], changeValues: [50_000], fee: 10_000),
-                Self.Step(inputValues: [500_000], changeValues: [], fee: 5_000)
+                FfiProposalFixtures.Step(inputValues: [1_000_000], changeValues: [50_000], fee: 10_000),
+                FfiProposalFixtures.Step(inputValues: [500_000], changeValues: [], fee: 5_000)
             ]
         )
 
@@ -111,15 +112,15 @@ final class ProposalTests: XCTestCase {
         // Step 0 shields no new value: it spends wallet funds into a transparent ephemeral
         // output that only exists to fund step 1's payment to the TEX recipient. Step 1's
         // input is a `priorStepChange` reference to that ephemeral output, not a fresh spend.
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(
+                FfiProposalFixtures.Step(
                     inputValues: [1_000_000],
-                    changeValues: [Self.ChangeValue(value: 985_000, isEphemeral: true)],
+                    changeValues: [FfiProposalFixtures.ChangeValue(value: 985_000, isEphemeral: true)],
                     fee: 15_000
                 ),
-                Self.Step(
-                    inputs: [Self.priorStepChangeInput(stepIndex: 0, changeIndex: 0)],
+                FfiProposalFixtures.Step(
+                    inputs: [FfiProposalFixtures.priorStepChangeInput(stepIndex: 0, changeIndex: 0)],
                     changeValues: [],
                     fee: 10_000
                 )
@@ -131,13 +132,13 @@ final class ProposalTests: XCTestCase {
     }
 
     func testTotalSpendValueWithMixedChangeSubtractsOnlyNonEphemeralChange() throws {
-        let proposal = Self.makeProposal(
+        let proposal = FfiProposalFixtures.makeProposal(
             steps: [
-                Self.Step(
+                FfiProposalFixtures.Step(
                     inputValues: [1_000_000],
                     changeValues: [
-                        Self.ChangeValue(value: 200_000, isEphemeral: false),
-                        Self.ChangeValue(value: 700_000, isEphemeral: true)
+                        FfiProposalFixtures.ChangeValue(value: 200_000, isEphemeral: false),
+                        FfiProposalFixtures.ChangeValue(value: 700_000, isEphemeral: true)
                     ],
                     fee: 15_000
                 )
@@ -145,92 +146,5 @@ final class ProposalTests: XCTestCase {
         )
 
         XCTAssertEqual(proposal.totalSpendValue(), Zatoshi(800_000))
-    }
-}
-
-// MARK: - FfiProposal fixture builders
-
-extension ProposalTests {
-    /// A single proposed-change entry for a fixture step. Conforms to `ExpressibleByIntegerLiteral`
-    /// so existing call sites that spell change values as bare `UInt64` literals keep compiling,
-    /// defaulting to non-ephemeral change.
-    private struct ChangeValue: ExpressibleByIntegerLiteral {
-        let value: UInt64
-        let isEphemeral: Bool
-
-        init(value: UInt64, isEphemeral: Bool = false) {
-            self.value = value
-            self.isEphemeral = isEphemeral
-        }
-
-        init(integerLiteral value: UInt64) {
-            self.init(value: value)
-        }
-    }
-
-    private struct Step {
-        let inputs: [FfiProposedInput]
-        let changeValues: [ChangeValue]
-        let fee: UInt64
-
-        init(inputValues: [UInt64], changeValues: [ChangeValue], fee: UInt64) {
-            self.inputs = inputValues.map { ProposalTests.receivedOutputInput($0) }
-            self.changeValues = changeValues
-            self.fee = fee
-        }
-
-        init(inputs: [FfiProposedInput], changeValues: [ChangeValue], fee: UInt64) {
-            self.inputs = inputs
-            self.changeValues = changeValues
-            self.fee = fee
-        }
-    }
-
-    private static func receivedOutputInput(_ value: UInt64) -> FfiProposedInput {
-        var receivedOutput = FfiReceivedOutput()
-        receivedOutput.value = value
-        var input = FfiProposedInput()
-        input.receivedOutput = receivedOutput
-        return input
-    }
-
-    private static func priorStepOutputInput(stepIndex: UInt32, paymentIndex: UInt32) -> FfiProposedInput {
-        var priorStepOutput = FfiPriorStepOutput()
-        priorStepOutput.stepIndex = stepIndex
-        priorStepOutput.paymentIndex = paymentIndex
-        var input = FfiProposedInput()
-        input.priorStepOutput = priorStepOutput
-        return input
-    }
-
-    private static func priorStepChangeInput(stepIndex: UInt32, changeIndex: UInt32) -> FfiProposedInput {
-        var priorStepChange = FfiPriorStepChange()
-        priorStepChange.stepIndex = stepIndex
-        priorStepChange.changeIndex = changeIndex
-        var input = FfiProposedInput()
-        input.priorStepChange = priorStepChange
-        return input
-    }
-
-    private static func makeProposal(steps: [Step]) -> Proposal {
-        let ffiSteps: [FfiProposalStep] = steps.map { stepSpec in
-            var balance = FfiTransactionBalance()
-            balance.feeRequired = stepSpec.fee
-            balance.proposedChange = stepSpec.changeValues.map { changeSpec in
-                var change = FfiChangeValue()
-                change.value = changeSpec.value
-                change.isEphemeral = changeSpec.isEphemeral
-                return change
-            }
-
-            var step = FfiProposalStep()
-            step.inputs = stepSpec.inputs
-            step.balance = balance
-            return step
-        }
-
-        var ffiProposal = FfiProposal()
-        ffiProposal.steps = ffiSteps
-        return Proposal(inner: ffiProposal)
     }
 }

--- a/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
@@ -16,7 +16,7 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
 
     func testProposeSendMaxPassesArgumentsThroughToTheRustBackendAndReturnsTheWrappedProposal() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
-        let ffiProposal = Self.makeFfiProposal(feeRequired: 5_000)
+        let ffiProposal = FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
         rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
 
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
@@ -46,7 +46,7 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
 
     func testProposeSendMaxAllowsNilMemoForTransparentRecipientAndPassesArgumentsThrough() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
-        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        let ffiProposal = FfiProposalFixtures.makeFfiProposal(feeRequired: 1_000)
         rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
 
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
@@ -105,7 +105,7 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
     /// same typed error must fire instead of letting the request reach the rust backend.
     func testProposeSendMaxThrowsWhenMemoIsSuppliedForATexRecipient() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
-        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        let ffiProposal = FfiProposalFixtures.makeFfiProposal(feeRequired: 1_000)
         rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
 
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
@@ -166,7 +166,7 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
     /// propose* methods have, so the TEX-recipient regression for `proposeTransfer` lives here too.
     func testProposeTransferThrowsWhenMemoIsSuppliedForATexRecipient() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
-        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        let ffiProposal = FfiProposalFixtures.makeFfiProposal(feeRequired: 1_000)
         rustBackend.proposeTransferAccountUUIDToValueMemoReturnValue = ffiProposal
 
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
@@ -222,17 +222,5 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
         )
 
         return SDKSynchronizer(initializer: initializer)
-    }
-
-    private static func makeFfiProposal(feeRequired: UInt64) -> FfiProposal {
-        var balance = FfiTransactionBalance()
-        balance.feeRequired = feeRequired
-
-        var step = FfiProposalStep()
-        step.balance = balance
-
-        var proposal = FfiProposal()
-        proposal.steps = [step]
-        return proposal
     }
 }

--- a/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
@@ -10,6 +10,7 @@ import XCTest
 final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
     private let recipientAddress = "zs1vp7kvlqr4n9gpehztr76lcn6skkss9p8keqs3nv8avkdtjrcctrvmk9a7u494kluv756jeee5k0"
     private let transparentAddress = "t1dRJRY7GmyeykJnMH38mdQoaZtFhn1QmGz"
+    private let texAddress = "tex1s2rt77ggv6q689lzd6c34zmc3jvgzn9skq6nzv"
 
     // MARK: - Pass-through to the rust backend
 
@@ -100,6 +101,41 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
         )
     }
 
+    /// TEX recipients are transparent-only and memo-incapable, same as `.transparent`, so the
+    /// same typed error must fire instead of letting the request reach the rust backend.
+    func testProposeSendMaxThrowsWhenMemoIsSuppliedForATexRecipient() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
+
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        await synchronizer.updateStatus(.stopped)
+
+        let recipient = Recipient.tex(TexAddress(validatedEncoding: texAddress))
+        let memo = try Memo(string: "not allowed")
+
+        do {
+            _ = try await synchronizer.proposeSendMax(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                memo: memo,
+                mode: .maxSpendable
+            )
+            XCTFail("Expected proposeSendMax to throw synchronizerSendMemoToTransparentAddress")
+        } catch let error as ZcashError {
+            guard case .synchronizerSendMemoToTransparentAddress = error else {
+                XCTFail("Expected synchronizerSendMemoToTransparentAddress but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeCallsCount,
+            0,
+            "The rust backend must not be reached when the memo-to-TEX-recipient guard rejects the request"
+        )
+    }
+
     func testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
@@ -121,6 +157,44 @@ final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
                 return
             }
         }
+    }
+
+    // MARK: - Guards (proposeTransfer)
+
+    /// `proposeTransfer` carries the same memo-to-transparent-recipient guard as `proposeSendMax`
+    /// tested above; this suite is the only mocked-rust-backend harness `SDKSynchronizer`'s
+    /// propose* methods have, so the TEX-recipient regression for `proposeTransfer` lives here too.
+    func testProposeTransferThrowsWhenMemoIsSuppliedForATexRecipient() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        rustBackend.proposeTransferAccountUUIDToValueMemoReturnValue = ffiProposal
+
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        await synchronizer.updateStatus(.stopped)
+
+        let recipient = Recipient.tex(TexAddress(validatedEncoding: texAddress))
+        let memo = try Memo(string: "not allowed")
+
+        do {
+            _ = try await synchronizer.proposeTransfer(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                amount: Zatoshi(1_000),
+                memo: memo
+            )
+            XCTFail("Expected proposeTransfer to throw synchronizerSendMemoToTransparentAddress")
+        } catch let error as ZcashError {
+            guard case .synchronizerSendMemoToTransparentAddress = error else {
+                XCTFail("Expected synchronizerSendMemoToTransparentAddress but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeTransferAccountUUIDToValueMemoCallsCount,
+            0,
+            "The rust backend must not be reached when the memo-to-TEX-recipient guard rejects the request"
+        )
     }
 
     // MARK: - Helpers

--- a/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerProposeSendMaxTests.swift
@@ -1,0 +1,164 @@
+//
+//  SDKSynchronizerProposeSendMaxTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class SDKSynchronizerProposeSendMaxTests: ZcashTestCase {
+    private let recipientAddress = "zs1vp7kvlqr4n9gpehztr76lcn6skkss9p8keqs3nv8avkdtjrcctrvmk9a7u494kluv756jeee5k0"
+    private let transparentAddress = "t1dRJRY7GmyeykJnMH38mdQoaZtFhn1QmGz"
+
+    // MARK: - Pass-through to the rust backend
+
+    func testProposeSendMaxPassesArgumentsThroughToTheRustBackendAndReturnsTheWrappedProposal() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let ffiProposal = Self.makeFfiProposal(feeRequired: 5_000)
+        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
+
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        await synchronizer.updateStatus(.stopped)
+
+        let accountUUID = TestsData.mockedAccountUUID
+        let recipient = Recipient.sapling(SaplingAddress(validatedEncoding: recipientAddress))
+        let memo = try Memo(string: "thank you")
+        let mode = MaxSpendMode.everything
+
+        let proposal = try await synchronizer.proposeSendMax(
+            accountUUID: accountUUID,
+            recipient: recipient,
+            memo: memo,
+            mode: mode
+        )
+
+        XCTAssertEqual(proposal, Proposal(inner: ffiProposal))
+        XCTAssertEqual(rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeCallsCount, 1)
+
+        let receivedArguments = try XCTUnwrap(rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReceivedArguments)
+        XCTAssertEqual(receivedArguments.accountUUID, accountUUID)
+        XCTAssertEqual(receivedArguments.address, recipient.stringEncoded)
+        XCTAssertEqual(receivedArguments.memo, try memo.asMemoBytes())
+        XCTAssertEqual(receivedArguments.mode, mode)
+    }
+
+    func testProposeSendMaxAllowsNilMemoForTransparentRecipientAndPassesArgumentsThrough() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let ffiProposal = Self.makeFfiProposal(feeRequired: 1_000)
+        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = ffiProposal
+
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        await synchronizer.updateStatus(.stopped)
+
+        let recipient = Recipient.transparent(TransparentAddress(validatedEncoding: transparentAddress))
+
+        let proposal = try await synchronizer.proposeSendMax(
+            accountUUID: TestsData.mockedAccountUUID,
+            recipient: recipient,
+            memo: nil,
+            mode: .maxSpendable
+        )
+
+        XCTAssertEqual(proposal, Proposal(inner: ffiProposal))
+
+        let receivedArguments = try XCTUnwrap(rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReceivedArguments)
+        XCTAssertEqual(receivedArguments.address, recipient.stringEncoded)
+        XCTAssertNil(receivedArguments.memo)
+        XCTAssertEqual(receivedArguments.mode, .maxSpendable)
+    }
+
+    // MARK: - Guards
+
+    func testProposeSendMaxThrowsWhenMemoIsSuppliedForATransparentRecipient() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        await synchronizer.updateStatus(.stopped)
+
+        let recipient = Recipient.transparent(TransparentAddress(validatedEncoding: transparentAddress))
+        let memo = try Memo(string: "not allowed")
+
+        do {
+            _ = try await synchronizer.proposeSendMax(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                memo: memo,
+                mode: .maxSpendable
+            )
+            XCTFail("Expected proposeSendMax to throw synchronizerSendMemoToTransparentAddress")
+        } catch let error as ZcashError {
+            guard case .synchronizerSendMemoToTransparentAddress = error else {
+                XCTFail("Expected synchronizerSendMemoToTransparentAddress but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeCallsCount,
+            0,
+            "The rust backend must not be reached when the memo-to-transparent-recipient guard rejects the request"
+        )
+    }
+
+    func testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value; `updateStatus` is deliberately not called.
+
+        let recipient = Recipient.sapling(SaplingAddress(validatedEncoding: recipientAddress))
+
+        do {
+            _ = try await synchronizer.proposeSendMax(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                memo: nil,
+                mode: .maxSpendable
+            )
+            XCTFail("Expected proposeSendMax to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(rustBackend: ZcashRustBackendWelding) throws -> SDKSynchronizer {
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in LightWalletServiceMock() }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in TransactionRepositoryMock() }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in submissionLifecycleLogger() }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        return SDKSynchronizer(initializer: initializer)
+    }
+
+    private static func makeFfiProposal(feeRequired: UInt64) -> FfiProposal {
+        var balance = FfiTransactionBalance()
+        balance.feeRequired = feeRequired
+
+        var step = FfiProposalStep()
+        step.balance = balance
+
+        var proposal = FfiProposal()
+        proposal.steps = [step]
+        return proposal
+    }
+}

--- a/Tests/OfflineTests/SlipstreamSynchronizerGuardTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerGuardTests.swift
@@ -1,0 +1,167 @@
+//
+//  SlipstreamSynchronizerGuardTests.swift
+//  ZcashLightClientKit
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+/// Prepared-state guards on the four `SlipstreamSynchronizer.propose*` methods that, unlike
+/// `proposeSendMax`, did not yet reject calls made before `prepare()`. Sibling coverage to
+/// `SlipstreamSynchronizerSendMaxTests.testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared`, one test
+/// per method: `proposeTransfer`, `proposeShielding`, `proposeOrchardToIronwoodMigration`, and
+/// `proposefulfillingPaymentURI`. Each mirrors the corresponding `SDKSynchronizer` method's
+/// `throwIfUnprepared()` contract. The synchronizer is built the same mocked-rust-backend way as that
+/// sibling suite (`makeSynchronizer(rustBackend:)`), substituted through the same container-mock seam
+/// `SlipstreamSynchronizer.init` resolves `rustBackend` through.
+final class SlipstreamSynchronizerGuardTests: ZcashTestCase {
+    private let recipientAddress = "zs1vp7kvlqr4n9gpehztr76lcn6skkss9p8keqs3nv8avkdtjrcctrvmk9a7u494kluv756jeee5k0"
+
+    /// A synchronizer that never had `prepare()` called must reject `proposeTransfer` with
+    /// `synchronizerNotPrepared`. The rust backend is pre-armed with a valid proposal so that, absent
+    /// the guard, the call would succeed instead of throwing -- proving a failure here comes from the
+    /// missing guard, not some unrelated backend error.
+    func testProposeTransferThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.proposeTransferAccountUUIDToValueMemoReturnValue =
+            FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
+
+        let recipient = Recipient.sapling(SaplingAddress(validatedEncoding: recipientAddress))
+
+        do {
+            _ = try await synchronizer.proposeTransfer(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                amount: Zatoshi(10_000),
+                memo: nil
+            )
+            XCTFail("Expected proposeTransfer to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeTransferAccountUUIDToValueMemoCallsCount,
+            0,
+            "The rust backend must not be reached when the synchronizer isn't prepared"
+        )
+    }
+
+    /// A synchronizer that never had `prepare()` called must reject `proposeShielding` with
+    /// `synchronizerNotPrepared`. Pre-armed the same way as the transfer case above.
+    func testProposeShieldingThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.proposeShieldingAccountUUIDMemoShieldingThresholdTransparentReceiverReturnValue =
+            FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
+
+        do {
+            _ = try await synchronizer.proposeShielding(
+                accountUUID: TestsData.mockedAccountUUID,
+                shieldingThreshold: Zatoshi(10_000),
+                memo: try Memo(string: "shielding")
+            )
+            XCTFail("Expected proposeShielding to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeShieldingAccountUUIDMemoShieldingThresholdTransparentReceiverCallsCount,
+            0,
+            "The rust backend must not be reached when the synchronizer isn't prepared"
+        )
+    }
+
+    /// A synchronizer that never had `prepare()` called must reject `proposeOrchardToIronwoodMigration`
+    /// with `synchronizerNotPrepared`. Pre-armed the same way as the transfer case above.
+    func testProposeOrchardToIronwoodMigrationThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.proposeOrchardToIronwoodMigrationAccountUUIDReturnValue =
+            FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
+
+        do {
+            _ = try await synchronizer.proposeOrchardToIronwoodMigration(accountUUID: TestsData.mockedAccountUUID)
+            XCTFail("Expected proposeOrchardToIronwoodMigration to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeOrchardToIronwoodMigrationAccountUUIDCallsCount,
+            0,
+            "The rust backend must not be reached when the synchronizer isn't prepared"
+        )
+    }
+
+    /// A synchronizer that never had `prepare()` called must reject `proposefulfillingPaymentURI` with
+    /// `synchronizerNotPrepared`. The guard must fire before any URI parsing, so the URI content itself
+    /// is unimportant here -- a syntactically plausible testnet ZIP-321 URI is used, pre-armed the same
+    /// way as the transfer case above.
+    func testProposefulfillingPaymentURIThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.proposeTransferFromURIAccountUUIDReturnValue =
+            FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
+
+        let paymentURI = "zcash:\(recipientAddress)?amount=0.0002"
+
+        do {
+            _ = try await synchronizer.proposefulfillingPaymentURI(paymentURI, accountUUID: TestsData.mockedAccountUUID)
+            XCTFail("Expected proposefulfillingPaymentURI to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeTransferFromURIAccountUUIDCallsCount,
+            0,
+            "The rust backend must not be reached when the synchronizer isn't prepared"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(rustBackend: ZcashRustBackendWelding) throws -> SlipstreamSynchronizer {
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in LightWalletServiceMock() }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in TransactionRepositoryMock() }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        return SlipstreamSynchronizer(initializer: initializer)
+    }
+}

--- a/Tests/OfflineTests/SlipstreamSynchronizerSendMaxTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerSendMaxTests.swift
@@ -1,0 +1,93 @@
+//
+//  SlipstreamSynchronizerSendMaxTests.swift
+//  ZcashLightClientKit
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+/// `proposeSendMax`'s prepared-state guard on `SlipstreamSynchronizer` -- this actor's analog of
+/// `SDKSynchronizerProposeSendMaxTests.testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared`. The
+/// synchronizer is built the same mocked-rust-backend way that sibling suite builds `SDKSynchronizer`
+/// (`makeSynchronizer(rustBackend:)`), substituted through the same container-mock seam
+/// `SlipstreamSynchronizer.init` resolves both `rustBackend` and its own `OrchardMigrationHost`
+/// through -- see `SlipstreamSynchronizerMigrationTests.makeSynchronizer(migrationHost:)` for that
+/// same seam applied to the migration host specifically.
+final class SlipstreamSynchronizerSendMaxTests: ZcashTestCase {
+    private let recipientAddress = "zs1vp7kvlqr4n9gpehztr76lcn6skkss9p8keqs3nv8avkdtjrcctrvmk9a7u494kluv756jeee5k0"
+
+    /// A synchronizer that never had `prepare()` called must reject `proposeSendMax` with
+    /// `synchronizerNotPrepared`, mirroring `SDKSynchronizer`'s `throwIfUnprepared()` contract
+    /// (`SDKSynchronizerProposeSendMaxTests.testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared`).
+    /// The rust backend is pre-armed with a valid proposal so that, absent the guard, the call would
+    /// succeed instead of throwing -- proving a failure here comes from the missing guard, not some
+    /// unrelated backend error.
+    func testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = Self.makeFfiProposal(feeRequired: 5_000)
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
+
+        let recipient = Recipient.sapling(SaplingAddress(validatedEncoding: recipientAddress))
+
+        do {
+            _ = try await synchronizer.proposeSendMax(
+                accountUUID: TestsData.mockedAccountUUID,
+                recipient: recipient,
+                memo: nil,
+                mode: .maxSpendable
+            )
+            XCTFail("Expected proposeSendMax to throw when the synchronizer isn't prepared")
+        } catch let error as ZcashError {
+            guard case .synchronizerNotPrepared = error else {
+                XCTFail("Expected synchronizerNotPrepared but got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeCallsCount,
+            0,
+            "The rust backend must not be reached when the synchronizer isn't prepared"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(rustBackend: ZcashRustBackendWelding) throws -> SlipstreamSynchronizer {
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in LightWalletServiceMock() }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in TransactionRepositoryMock() }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        return SlipstreamSynchronizer(initializer: initializer)
+    }
+
+    private static func makeFfiProposal(feeRequired: UInt64) -> FfiProposal {
+        var balance = FfiTransactionBalance()
+        balance.feeRequired = feeRequired
+
+        var step = FfiProposalStep()
+        step.balance = balance
+
+        var proposal = FfiProposal()
+        proposal.steps = [step]
+        return proposal
+    }
+}

--- a/Tests/OfflineTests/SlipstreamSynchronizerSendMaxTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerSendMaxTests.swift
@@ -25,7 +25,7 @@ final class SlipstreamSynchronizerSendMaxTests: ZcashTestCase {
     /// unrelated backend error.
     func testProposeSendMaxThrowsWhenSynchronizerIsNotPrepared() async throws {
         let rustBackend = ZcashRustBackendWeldingMock()
-        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = Self.makeFfiProposal(feeRequired: 5_000)
+        rustBackend.proposeSendMaxTransferAccountUUIDToMemoModeReturnValue = FfiProposalFixtures.makeFfiProposal(feeRequired: 5_000)
         let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
         // Status is left at its initial `.unprepared` value -- `prepare()` is deliberately not called.
 
@@ -77,17 +77,5 @@ final class SlipstreamSynchronizerSendMaxTests: ZcashTestCase {
         )
 
         return SlipstreamSynchronizer(initializer: initializer)
-    }
-
-    private static func makeFfiProposal(feeRequired: UInt64) -> FfiProposal {
-        var balance = FfiTransactionBalance()
-        balance.feeRequired = feeRequired
-
-        var step = FfiProposalStep()
-        step.balance = balance
-
-        var proposal = FfiProposal()
-        proposal.steps = [step]
-        return proposal
     }
 }

--- a/Tests/OfflineTests/SynchronizerMigrationDefaultsTests.swift
+++ b/Tests/OfflineTests/SynchronizerMigrationDefaultsTests.swift
@@ -323,6 +323,8 @@ private final class NonMigratingSynchronizer: Synchronizer {
 
     func proposeTransfer(accountUUID: AccountUUID, recipient: Recipient, amount: Zatoshi, memo: Memo?) async throws -> Proposal { Self.unused() }
 
+    func proposeSendMax(accountUUID: AccountUUID, recipient: Recipient, memo: Memo?, mode: MaxSpendMode) async throws -> Proposal { Self.unused() }
+
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal { Self.unused() }
 
     func proposeShielding(

--- a/Tests/TestUtils/FfiProposalFixtures.swift
+++ b/Tests/TestUtils/FfiProposalFixtures.swift
@@ -1,0 +1,122 @@
+//
+//  FfiProposalFixtures.swift
+//  TestUtils
+//
+
+import Foundation
+@testable import ZcashLightClientKit
+
+/// A shared `FfiProposal`/`Proposal` fixture builder for offline tests.
+///
+/// `ProposalTests`, `SDKSynchronizerProposeSendMaxTests`, and `SlipstreamSynchronizerSendMaxTests`
+/// each used to hand-roll their own private version of this builder. This is the shared home for it,
+/// following this directory's `MigrationTestDoubles.swift` precedent. `ProposalSpendsOrchardTests`,
+/// `SDKSynchronizerMigrationTests`, `SlipstreamSynchronizerMigrationTests`, and `MigrationLogicTests`
+/// keep their own narrower builders for now; they are not migrated here.
+enum FfiProposalFixtures {
+    /// A single proposed-change entry for a fixture step. Conforms to `ExpressibleByIntegerLiteral` so
+    /// call sites can spell change values as bare `UInt64` literals, defaulting to non-ephemeral change.
+    struct ChangeValue: ExpressibleByIntegerLiteral {
+        let value: UInt64
+        let isEphemeral: Bool
+
+        init(value: UInt64, isEphemeral: Bool = false) {
+            self.value = value
+            self.isEphemeral = isEphemeral
+        }
+
+        init(integerLiteral value: UInt64) {
+            self.init(value: value)
+        }
+    }
+
+    /// The inputs, proposed change, and fee for one step of a fixture proposal.
+    struct Step {
+        let inputs: [FfiProposedInput]
+        let changeValues: [ChangeValue]
+        let fee: UInt64
+
+        /// The designated initializer: takes fully-formed inputs, so any mix of `receivedOutput`,
+        /// `priorStepOutput`, and `priorStepChange` references can be expressed.
+        init(inputs: [FfiProposedInput], changeValues: [ChangeValue], fee: UInt64) {
+            self.inputs = inputs
+            self.changeValues = changeValues
+            self.fee = fee
+        }
+
+        /// Convenience for the common case where every input is a fresh wallet spend. Wraps each
+        /// value as a `receivedOutput` input and delegates to the designated initializer.
+        init(inputValues: [UInt64], changeValues: [ChangeValue], fee: UInt64) {
+            self.init(
+                inputs: inputValues.map { FfiProposalFixtures.receivedOutputInput($0) },
+                changeValues: changeValues,
+                fee: fee
+            )
+        }
+    }
+
+    /// An input that draws fresh value from a wallet note.
+    static func receivedOutputInput(_ value: UInt64) -> FfiProposedInput {
+        var receivedOutput = FfiReceivedOutput()
+        receivedOutput.value = value
+        var input = FfiProposedInput()
+        input.receivedOutput = receivedOutput
+        return input
+    }
+
+    /// An input that references a payment made by an earlier step of the same proposal.
+    static func priorStepOutputInput(stepIndex: UInt32, paymentIndex: UInt32) -> FfiProposedInput {
+        var priorStepOutput = FfiPriorStepOutput()
+        priorStepOutput.stepIndex = stepIndex
+        priorStepOutput.paymentIndex = paymentIndex
+        var input = FfiProposedInput()
+        input.priorStepOutput = priorStepOutput
+        return input
+    }
+
+    /// An input that references a change (or ephemeral) output produced by an earlier step of the
+    /// same proposal.
+    static func priorStepChangeInput(stepIndex: UInt32, changeIndex: UInt32) -> FfiProposedInput {
+        var priorStepChange = FfiPriorStepChange()
+        priorStepChange.stepIndex = stepIndex
+        priorStepChange.changeIndex = changeIndex
+        var input = FfiProposedInput()
+        input.priorStepChange = priorStepChange
+        return input
+    }
+
+    /// Builds a multi-step `FfiProposal` from step specs. This is the designated builder: every
+    /// other `FfiProposal`/`Proposal` builder below delegates to it.
+    static func makeFfiProposal(steps: [Step]) -> FfiProposal {
+        let ffiSteps: [FfiProposalStep] = steps.map { stepSpec in
+            var balance = FfiTransactionBalance()
+            balance.feeRequired = stepSpec.fee
+            balance.proposedChange = stepSpec.changeValues.map { changeSpec in
+                var change = FfiChangeValue()
+                change.value = changeSpec.value
+                change.isEphemeral = changeSpec.isEphemeral
+                return change
+            }
+
+            var step = FfiProposalStep()
+            step.inputs = stepSpec.inputs
+            step.balance = balance
+            return step
+        }
+
+        var ffiProposal = FfiProposal()
+        ffiProposal.steps = ffiSteps
+        return ffiProposal
+    }
+
+    /// Single-step convenience for tests that only care about a proposal's required fee, e.g. a
+    /// mocked rust-backend return value. Delegates to `makeFfiProposal(steps:)`.
+    static func makeFfiProposal(feeRequired: UInt64) -> FfiProposal {
+        makeFfiProposal(steps: [Step(inputs: [], changeValues: [], fee: feeRequired)])
+    }
+
+    /// Builds a multi-step `Proposal` from step specs. Delegates to `makeFfiProposal(steps:)`.
+    static func makeProposal(steps: [Step]) -> Proposal {
+        Proposal(inner: makeFfiProposal(steps: steps))
+    }
+}

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -1762,6 +1762,30 @@ class SynchronizerMock: Synchronizer {
         }
     }
 
+    // MARK: - proposeSendMax
+
+    var proposeSendMaxAccountUUIDRecipientMemoModeThrowableError: Error?
+    var proposeSendMaxAccountUUIDRecipientMemoModeCallsCount = 0
+    var proposeSendMaxAccountUUIDRecipientMemoModeCalled: Bool {
+        return proposeSendMaxAccountUUIDRecipientMemoModeCallsCount > 0
+    }
+    var proposeSendMaxAccountUUIDRecipientMemoModeReceivedArguments: (accountUUID: AccountUUID, recipient: Recipient, memo: Memo?, mode: MaxSpendMode)?
+    var proposeSendMaxAccountUUIDRecipientMemoModeReturnValue: Proposal!
+    var proposeSendMaxAccountUUIDRecipientMemoModeClosure: ((AccountUUID, Recipient, Memo?, MaxSpendMode) async throws -> Proposal)?
+
+    func proposeSendMax(accountUUID: AccountUUID, recipient: Recipient, memo: Memo?, mode: MaxSpendMode) async throws -> Proposal {
+        if let error = proposeSendMaxAccountUUIDRecipientMemoModeThrowableError {
+            throw error
+        }
+        proposeSendMaxAccountUUIDRecipientMemoModeCallsCount += 1
+        proposeSendMaxAccountUUIDRecipientMemoModeReceivedArguments = (accountUUID: accountUUID, recipient: recipient, memo: memo, mode: mode)
+        if let closure = proposeSendMaxAccountUUIDRecipientMemoModeClosure {
+            return try await closure(accountUUID, recipient, memo, mode)
+        } else {
+            return proposeSendMaxAccountUUIDRecipientMemoModeReturnValue
+        }
+    }
+
     // MARK: - proposeOrchardToIronwoodMigration
 
     var proposeOrchardToIronwoodMigrationAccountUUIDThrowableError: Error?

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -4643,6 +4643,30 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
         }
     }
 
+    // MARK: - proposeSendMaxTransfer
+
+    var proposeSendMaxTransferAccountUUIDToMemoModeThrowableError: Error?
+    var proposeSendMaxTransferAccountUUIDToMemoModeCallsCount = 0
+    var proposeSendMaxTransferAccountUUIDToMemoModeCalled: Bool {
+        return proposeSendMaxTransferAccountUUIDToMemoModeCallsCount > 0
+    }
+    var proposeSendMaxTransferAccountUUIDToMemoModeReceivedArguments: (accountUUID: AccountUUID, address: String, memo: MemoBytes?, mode: MaxSpendMode)?
+    var proposeSendMaxTransferAccountUUIDToMemoModeReturnValue: FfiProposal!
+    var proposeSendMaxTransferAccountUUIDToMemoModeClosure: ((AccountUUID, String, MemoBytes?, MaxSpendMode) async throws -> FfiProposal)?
+
+    func proposeSendMaxTransfer(accountUUID: AccountUUID, to address: String, memo: MemoBytes?, mode: MaxSpendMode) async throws -> FfiProposal {
+        if let error = proposeSendMaxTransferAccountUUIDToMemoModeThrowableError {
+            throw error
+        }
+        proposeSendMaxTransferAccountUUIDToMemoModeCallsCount += 1
+        proposeSendMaxTransferAccountUUIDToMemoModeReceivedArguments = (accountUUID: accountUUID, address: address, memo: memo, mode: mode)
+        if let closure = proposeSendMaxTransferAccountUUIDToMemoModeClosure {
+            return try await closure(accountUUID, address, memo, mode)
+        } else {
+            return proposeSendMaxTransferAccountUUIDToMemoModeReturnValue
+        }
+    }
+
     // MARK: - proposeOrchardToIronwoodMigration
 
     var proposeOrchardToIronwoodMigrationAccountUUIDThrowableError: Error?

--- a/Tests/TestUtils/SubmissionTestDoubles.swift
+++ b/Tests/TestUtils/SubmissionTestDoubles.swift
@@ -251,7 +251,7 @@ final class StubTransactionEncoder: TransactionEncoder {
     func proposeSendMax(
         accountUUID: AccountUUID,
         recipient: String,
-        memo: MemoBytes?,
+        memoBytes: MemoBytes?,
         mode: MaxSpendMode
     ) async throws -> Proposal {
         fatalError("Unused in test")

--- a/Tests/TestUtils/SubmissionTestDoubles.swift
+++ b/Tests/TestUtils/SubmissionTestDoubles.swift
@@ -248,6 +248,15 @@ final class StubTransactionEncoder: TransactionEncoder {
         fatalError("Unused in test")
     }
 
+    func proposeSendMax(
+        accountUUID: AccountUUID,
+        recipient: String,
+        memo: MemoBytes?,
+        mode: MaxSpendMode
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
     func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
         fatalError("Unused in test")
     }


### PR DESCRIPTION
Implements #1910: exposes the general send-max proposal through the public Swift API, so an app can offer a "send all" action without computing the spendable-minus-fee amount itself. Also fixes #1980: every `SlipstreamSynchronizer` proposal method now enforces the documented `notPrepared` contract.

## What this adds

- `MaxSpendMode` (`maxSpendable` / `everything`) — the Swift mirror of `FfiMaxSpendMode`, choosing whether the proposal targets only currently-spendable funds or all non-dust funds in the wallet. `everything` excludes dust notes valued at or below the ZIP-317 marginal fee from selection (they are neither spent nor cause a failure) and fails only if non-dust funds are unspendable or the wallet is unsynced. The FFI mapping (`ffiMode`) lives in the Rust bridge layer next to the `ConfirmationsPolicy` mapping, keeping `Model/` free of `libzcashlc`.
- `ZcashRustBackendWelding.proposeSendMaxTransfer(accountUUID:to:memo:mode:)` — binds `zcashlc_propose_send_max_transfer` for the public path, pinning `orchard_only` to `false` (the public send-max draws on every shielded pool: Sapling, Orchard, Ironwood — transparent funds are never selected; shield them first via `proposeShielding`). It coexists with the migration lane's `orchardOnly`-parameterized binding of the same FFI entry; both are thin wrappers over one shared private helper, so the FFI call, error mapping, and deserialization exist once. Failures — including a zero or fee-consumed spendable balance — surface as the existing `ZcashError.rustProposeSendMaxTransfer` (`ZRUST0129`).
- `Proposal.totalSpendValue()` — the total value a proposal spends before its fee, so the payable amount is `totalSpendValue() - totalFeeRequired()`. Ephemeral (ZIP-320) change outputs are excluded from the change deduction — they are consumed by a later step of the same proposal — so the formula also holds for multi-step proposals to TEX recipients. The Orchard→Ironwood immediate-migration path reuses this same computation instead of carrying a private duplicate.
- `Synchronizer.proposeSendMax(accountUUID:recipient:memo:mode:)` plus the matching `ClosureSynchronizer` / `CombineSynchronizer` facade methods, threaded through `TransactionEncoder` / `WalletTransactionEncoder`. Memo validation is a shared `Recipient` helper used by both `proposeTransfer` and `proposeSendMax` in both concrete synchronizers, and rejects memos to transparent **and TEX** recipients with the typed `synchronizerSendMemoToTransparentAddress` (for `proposeTransfer` + TEX this replaces the previous opaque rust error — see the `Fixed` entry in the changelog). Both concrete synchronizers gate proposals on prepared state: `SDKSynchronizer` via `throwIfUnprepared()`, and `SlipstreamSynchronizer` via its own `internalSyncStatus.isPrepared` guard (same idiom as its `start()`) — on every `propose*` method (`proposeTransfer`, `proposeShielding`, `proposeOrchardToIronwoodMigration`, `proposefulfillingPaymentURI`, and the new `proposeSendMax`; #1980) — so an unprepared call throws `synchronizerNotPrepared` instead of failing inside the FFI.
- Offline tests: `MaxSpendModeTests`, `ProposalTests` additions for `totalSpendValue()` (including the two-step ZIP-320 ephemeral shape and mixed ephemeral/real change), `SDKSynchronizerProposeSendMaxTests` covering the backend pass-through and the memo/prepared guards (transparent and TEX, for both `proposeSendMax` and `proposeTransfer`), and `SlipstreamSynchronizerSendMaxTests` / `SlipstreamSynchronizerGuardTests` covering the Slipstream prepared guards (one test per `propose*` method, each asserting the typed error and zero rust-backend calls). Proposal fixtures are built via a shared `FfiProposalFixtures` builder in `TestUtils`. Mocks regenerated with Sourcery 2.3.0.

`MIGRATING.md` documents the new protocol requirement (breaking for external `Synchronizer` conformers — the `CHANGELOG.md` entry sits under `Changed` accordingly, with the non-breaking `MaxSpendMode` / `totalSpendValue()` additions under `Added`).

No Rust changes — this is a Swift binding over an FFI entry point that already exists.

## Test plan

- `make check` (build + full `OfflineTests` suite): 890 tests, 0 failures. New coverage listed above; the send-max money math is pinned by `ProposalTests` (including the TEX/ephemeral shape that `totalSpendValue() - totalFeeRequired()` must survive) and the guard behavior by the three synchronizer test classes.
- `make lint`: no findings in the files this PR touches.
- Manual verification on testnet: create a wallet with a shielded balance, call `proposeSendMax(accountUUID:recipient:memo:mode:)` for a sapling/unified recipient, confirm the proposal's `totalSpendValue() - totalFeeRequired()` equals the amount received by the recipient after `createProposedTransactions` + submission, and confirm a transparent-only wallet yields `ZRUST0129` (nothing spendable) rather than a proposal.

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
