### PR TITLE
[#1855] Restore coinholder voting on zcash_voting 2.0 with Ironwood support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Changes are relative to `2.8.0-rc.3`.
   instead of producing a rejected transaction. Software and hardware delegation now converge on
   the same submission entry point.
 
+- `VotingRustBackend.recoverableShareIndices(commitmentBundleJson:)` lists the share indices a
+  persisted vote recovery bundle can actually rebuild, via `zcash_voting::share::recover_payloads`'s
+  own single-share slicing. Crash recovery previously guessed a share count from `singleShare`
+  alone (`singleShare ? 1 : numOptions`), which under-delivers whenever the built share count
+  differs from the option count — four of sixteen built shares on a four-option proposal, in the
+  case that found this. The crate's recovered payloads are now the source of truth for which
+  indices to resubmit.
+
 ## Changed
 
 - Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
+- Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to
+  1.0.0). rc.4 made the PIR layout an explicit client/server handshake, so
+  `VotingRustBackend.precomputeDelegationPir(...)` and `buildAndProveDelegation(...)` take a new
+  `pirLayout: VotingPirLayout` — the `pir_depth`/`tier0_layers`/`tier1_layers` triple from the
+  round's resolved dynamic voting config. It defaults to `VotingPirLayout.unknown`, the crate's own
+  `PirLayout::UNKNOWN` sentinel, which `zcash_voting` rejects: a caller that does not pass a
+  resolved layout fails closed before any private query rather than querying with a guessed
+  geometry.
+
 - The migration sync gate is now BEHAVIOR-BASED, and its post-broadcast privacy buffer is gone
   along with `Synchronizer.migrationPrivacySyncBufferDuration` (the protocol requirement and its
   protocol-extension default): any reference stops compiling, and there is nothing to replace it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ Changes are relative to `2.8.0-rc.3`.
   network — a modified-mainnet chain votes with mainnet hotkeys and address
   HRPs — so `open` fails if that network has not been configured yet.
 
+- Two thin passthroughs to `zcash_voting` operations the SDK previously made callers assemble by
+  hand. `VotingRustBackend.confirmVoteSubmission(roundId:bundleIndex:proposalId:txHash:eventsJson:)`
+  hands the chain's confirmation events to the crate, which parses them, records the transaction
+  hash, advances the vote-authority-note position and records the vote-commitment tree position in
+  one database transaction, returning both as `VotingVoteConfirmation` — replacing a caller-side
+  `leaf_index` string split and a two-write window in which a crash could leave the two positions
+  disagreeing. `VotingRustBackend.recoverWireJson(commitmentBundleJson:proposalId:shareIndex:voteCommitmentTreePosition:submitAt:)`
+  rebuilds one helper-server payload from the persisted recovery bundle with the confirmed position
+  late-bound into it, without re-proving or committing again; the returned string is the helper
+  request body verbatim.
+
 ## Changed
 
 - Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Changes are relative to `2.8.0-rc.3`.
   late-bound into it, without re-proving or committing again; the returned string is the helper
   request body verbatim.
 
+- `ZcashSDK.nu63ConsensusBranchID` publishes the NU6.3 ("Ironwood") consensus branch ID,
+  `0x37a5_165b`. It was already used internally by the server-validation path; it is public now so
+  hosts that must name the era — voting delegations are rejected outright when built for the wrong
+  branch — take it from the SDK rather than copying the literal.
+
 ## Changed
 
 - Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ Changes are relative to `2.8.0-rc.3`.
   resolved layout fails closed before any private query rather than querying with a guessed
   geometry.
 
+- The voting FFI no longer maintains its own copies of `zcash_voting`'s wire formats. Payloads bound
+  for the vote chain and the helper servers are serialized by the crate and handed across the
+  boundary verbatim, which makes two rc.4 wire corrections automatic rather than hand-written:
+  `VotingDelegationSubmission` gains `tx1Effects` (and loses the wire-level `sighash`), and helper
+  payloads no longer carry every helper's share. Concretely: `VotingDelegationSubmission`'s byte
+  fields are now base64 `String`s matching the crate's encoding; `VotingWireEncryptedShare`'s
+  `ciphertext1`/`ciphertext2` are base64 `String`s; `VotingSharePayload` is removed; and
+  `VotingVoteCommit` no longer carries `sharePayloads`, because payloads built before the vote's
+  tree position is confirmed are provisional and must not be submitted.
+
 - The migration sync gate is now BEHAVIOR-BASED, and its post-broadcast privacy buffer is gone
   along with `Synchronizer.migrationPrivacySyncBufferDuration` (the protocol requirement and its
   protocol-extension default): any reference stops compiling, and there is nothing to replace it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,18 @@ Changes are relative to `2.8.0-rc.3`.
   list and so did nothing at all. It now drives the same resubmission core from its poll loop —
   a check at most once a minute while the engine is syncing or synced, with the re-broadcast
   itself throttled exactly as it always was. [#1975]
+- Voting delegation reads the **Ironwood** note-commitment tree, not the Orchard one. Voting notes
+  live in the Ironwood pool and a round's `nc_root` is the Ironwood tree's root at the snapshot
+  height, but `zcashlc_voting_generate_note_witnesses` decoded the Orchard tree out of the cached
+  `TreeState`, validated that Orchard root against the round's Ironwood `nc_root`, and generated
+  witnesses from the wallet's Orchard commitment tree; `VotingRustBackend.extractNcRoot(treeState:)`
+  computed the Orchard root too. The two pools are tracked separately and their roots never
+  coincide, so every delegation failed with `cached TreeState orchard root does not match round
+  nc_root` — on every chain, against every server, for every round. Witness generation now goes
+  through `zcash_voting`'s own Ironwood-aware path, which additionally rejects a wallet database
+  whose network differs from the round's and a snapshot height that is not NU6.3, and `extractNcRoot`
+  returns the Ironwood root. Two regression tests seed a `TreeState` carrying *both* pools and
+  assert the Ironwood one wins, so the wrong-pool read cannot return unnoticed.
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ Changes are relative to `2.8.0-rc.3`.
   hosts that must name the era — voting delegations are rejected outright when built for the wrong
   branch — take it from the SDK rather than copying the literal.
 
+- `VotingRustBackend.signDelegationRequest(roundId:bundleIndex:keys:seed:)` lets a software
+  wallet produce the SpendAuth signature a delegation submission needs. `zcash_voting 2.0` no
+  longer derives account keys or signs for its callers, which left
+  `getDelegationSubmission(roundId:bundleIndex:signature:sighash:)` reachable only by hardware
+  signers; this is the crate's own prescribed software path — it loads the bundle's signing
+  request, derives the account Orchard SpendAuth key from the wallet seed, randomizes it with
+  the request's spend-auth randomizer and signs the stored ZIP-244 sighash, returning the
+  detached signature and that sighash as `VotingDelegationSignature`. The seed is borrowed for
+  the call and never persisted, logged or handed to `zcash_voting`; the signature is checked
+  against the seed fingerprint the bundle was built for, so signing with the wrong seed fails
+  instead of producing a rejected transaction. Software and hardware delegation now converge on
+  the same submission entry point.
+
 ## Changed
 
 - Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,8 +20,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
-"crypto-common 0.1.7",
-"generic-array",
+ "crypto-common 0.1.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -30,10 +30,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
-"cfg-if",
-"cipher",
-"cpufeatures",
-"zeroize",
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -42,7 +42,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
-"memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -57,12 +57,12 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7fb4ac7c881e54a8e7015e399b6112a2a5bc958b6c89ac510840ff20273b31"
 dependencies = [
-"amplify_derive",
-"amplify_num",
-"ascii",
-"getrandom 0.2.17",
-"getrandom 0.3.4",
-"wasm-bindgen",
+ "amplify_derive",
+ "amplify_num",
+ "ascii",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -71,10 +71,10 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a6309e6b8d89b36b9f959b7a8fa093583b94922a0f6438a24fb08936de4d428"
 dependencies = [
-"amplify_syn",
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "amplify_syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -83,7 +83,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afed304556696656d2d71495e1e5f2c4b524a3fb6eb0f2f3778ffc482a40b8a8"
 dependencies = [
-"wasm-bindgen",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -92,9 +92,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7736fb8d473c0d83098b5bac44df6a561e20470375cd8bcae30516dc889fd62a"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
-"libc",
+ "libc",
 ]
 
 [[package]]
@@ -118,13 +118,13 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
-"anstyle",
-"anstyle-parse",
-"anstyle-query",
-"anstyle-wincon",
-"colorchoice",
-"is_terminal_polyfill",
-"utf8parse",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
-"utf8parse",
+ "utf8parse",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
-"windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,9 +157,9 @@ version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
-"anstyle",
-"once_cell_polyfill",
-"windows-sys 0.61.2",
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -186,49 +186,49 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a79ca5ce63b36033a5ccbfbcc7f919cbd93db61708543aa5e2e4917856205e7"
 dependencies = [
-"async-trait",
-"cfg-if",
-"derive-deftly",
-"derive_builder_fork_arti",
-"derive_more",
-"educe",
-"fs-mistrust",
-"futures",
-"hostname-validator",
-"humantime",
-"humantime-serde",
-"libc",
-"once_cell",
-"postage",
-"rand 0.9.5",
-"safelog",
-"serde",
-"thiserror 2.0.19",
-"time",
-"tor-async-utils",
-"tor-basic-utils",
-"tor-chanmgr",
-"tor-circmgr",
-"tor-config",
-"tor-config-path",
-"tor-dircommon",
-"tor-dirmgr",
-"tor-error",
-"tor-guardmgr",
-"tor-hsclient",
-"tor-hscrypto",
-"tor-keymgr",
-"tor-linkspec",
-"tor-llcrypto",
-"tor-memquota",
-"tor-netdir",
-"tor-netdoc",
-"tor-persist",
-"tor-proto",
-"tor-protover",
-"tor-rtcompat",
-"tracing",
-"void",
+ "async-trait",
+ "cfg-if",
+ "derive-deftly",
+ "derive_builder_fork_arti",
+ "derive_more",
+ "educe",
+ "fs-mistrust",
+ "futures",
+ "hostname-validator",
+ "humantime",
+ "humantime-serde",
+ "libc",
+ "once_cell",
+ "postage",
+ "rand 0.9.5",
+ "safelog",
+ "serde",
+ "thiserror 2.0.19",
+ "time",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-chanmgr",
+ "tor-circmgr",
+ "tor-config",
+ "tor-config-path",
+ "tor-dircommon",
+ "tor-dirmgr",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+ "void",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
-"libloading",
+ "libloading",
 ]
 
 [[package]]
@@ -252,13 +252,13 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
-"asn1-rs-derive",
-"asn1-rs-impl",
-"displaydoc",
-"nom",
-"num-traits",
-"rusticata-macros",
-"thiserror 2.0.19",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -267,10 +267,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
-"synstructure",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -279,9 +279,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -296,14 +296,14 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
-"flate2",
-"futures-core",
-"futures-io",
-"memchr",
-"pin-project-lite",
-"xz2",
-"zstd",
-"zstd-safe",
+ "flate2",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+ "xz2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -312,9 +312,9 @@ version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 3.0.3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -323,13 +323,13 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a982d2f86de6137cc05c9db9a915a19886c97911f9790d04f174cede74be01a5"
 dependencies = [
-"blanket",
-"futures-core",
-"futures-task",
-"futures-util",
-"pin-project",
-"rustc_version",
-"tokio",
+ "blanket",
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "pin-project",
+ "rustc_version",
+ "tokio",
 ]
 
 [[package]]
@@ -338,11 +338,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
-"bytes",
-"futures-sink",
-"futures-util",
-"memchr",
-"pin-project-lite",
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
-"bytemuck",
+ "bytemuck",
 ]
 
 [[package]]
@@ -366,7 +366,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
-"critical-section",
+ "critical-section",
 ]
 
 [[package]]
@@ -387,23 +387,23 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
-"axum-core",
-"bytes",
-"futures-util",
-"http",
-"http-body",
-"http-body-util",
-"itoa",
-"matchit",
-"memchr",
-"mime",
-"percent-encoding",
-"pin-project-lite",
-"serde_core",
-"sync_wrapper",
-"tower",
-"tower-layer",
-"tower-service",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -412,16 +412,16 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
-"bytes",
-"futures-core",
-"http",
-"http-body",
-"http-body-util",
-"mime",
-"pin-project-lite",
-"sync_wrapper",
-"tower-layer",
-"tower-service",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -454,19 +454,19 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
 dependencies = [
-"bitvec",
-"blake2s_simd",
-"byteorder",
-"crossbeam-channel",
-"ff",
-"group",
-"lazy_static",
-"log",
-"num_cpus",
-"pairing",
-"rand_core 0.6.4",
-"rayon",
-"subtle",
+ "bitvec",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "ff",
+ "group",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "pairing",
+ "rand_core 0.6.4",
+ "rayon",
+ "subtle",
 ]
 
 [[package]]
@@ -475,8 +475,8 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
-"serde",
-"unty",
+ "serde",
+ "unty",
 ]
 
 [[package]]
@@ -485,18 +485,18 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
-"bitflags",
-"cexpr",
-"clang-sys",
-"itertools 0.13.0",
-"log",
-"prettyplease 0.2.37",
-"proc-macro2",
-"quote",
-"regex",
-"rustc-hash 2.1.3",
-"shlex 1.3.0",
-"syn 2.0.119",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -505,14 +505,14 @@ version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
 dependencies = [
-"bs58",
-"hmac 0.13.0-pre.4",
-"rand_core 0.6.4",
-"ripemd 0.2.0-pre.4",
-"secp256k1",
-"sha2 0.11.0-pre.4",
-"subtle",
-"zeroize",
+ "bs58",
+ "hmac 0.13.0-pre.4",
+ "rand_core 0.6.4",
+ "ripemd 0.2.0-pre.4",
+ "secp256k1",
+ "sha2 0.11.0-pre.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -521,7 +521,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
-"bit-vec",
+ "bit-vec",
 ]
 
 [[package]]
@@ -542,7 +542,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
-"bitcoin-private",
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -557,10 +557,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
-"funty",
-"radium",
-"tap",
-"wyz",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -569,9 +569,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
-"arrayref",
-"arrayvec",
-"constant_time_eq",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -580,9 +580,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
-"arrayref",
-"arrayvec",
-"constant_time_eq",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -591,9 +591,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
-"generic-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -611,7 +611,7 @@ version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd016a0ddc7cb13661bf5576073ce07330a693f8608a1320b4e20561cc12cdc"
 dependencies = [
-"hybrid-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
-"objc2",
+ "objc2",
 ]
 
 [[package]]
@@ -629,11 +629,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
-"ff",
-"group",
-"pairing",
-"rand_core 0.6.4",
-"subtle",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -642,7 +642,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
-"thiserror 2.0.19",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -651,8 +651,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
-"sha2 0.10.9",
-"tinyvec",
+ "sha2 0.10.9",
+ "tinyvec",
 ]
 
 [[package]]
@@ -661,9 +661,9 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
-"memchr",
-"regex-automata",
-"serde_core",
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
-"bytemuck_derive",
+ "bytemuck_derive",
 ]
 
 [[package]]
@@ -693,9 +693,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -728,7 +728,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
-"cipher",
+ "cipher",
 ]
 
 [[package]]
@@ -737,17 +737,17 @@ version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
-"clap",
-"heck 0.5.0",
-"indexmap 2.14.0",
-"log",
-"proc-macro2",
-"quote",
-"serde",
-"serde_json",
-"syn 2.0.119",
-"tempfile",
-"toml 0.9.12+spec-1.1.0",
+ "clap",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -756,10 +756,10 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
-"find-msvc-tools",
-"jobserver",
-"libc",
-"shlex 2.0.1",
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
-"nom",
+ "nom",
 ]
 
 [[package]]
@@ -789,9 +789,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
-"cfg-if",
-"cipher",
-"cpufeatures",
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -800,11 +800,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
-"aead",
-"chacha20",
-"cipher",
-"poly1305",
-"zeroize",
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -813,10 +813,10 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
-"iana-time-zone",
-"num-traits",
-"serde",
-"windows-link 0.2.1",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -825,9 +825,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
-"ciborium-io",
-"ciborium-ll",
-"serde",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
 ]
 
 [[package]]
@@ -842,8 +842,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
-"ciborium-io",
-"half",
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -852,9 +852,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
-"crypto-common 0.1.7",
-"inout",
-"zeroize",
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -863,9 +863,9 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
-"glob",
-"libc",
-"libloading",
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
-"clap_builder",
+ "clap_builder",
 ]
 
 [[package]]
@@ -883,10 +883,10 @@ version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
-"anstream",
-"anstyle",
-"clap_lex",
-"strsim 0.11.1",
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -901,9 +901,9 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
 dependencies = [
-"libc",
-"wasix",
-"wasm-bindgen",
+ "libc",
+ "wasix",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -912,7 +912,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
-"thiserror 2.0.19",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -921,9 +921,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
-"serde",
-"termcolor",
-"unicode-width",
+ "serde",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
-"crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
-"unicode-segmentation",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
-"futures",
+ "futures",
 ]
 
 [[package]]
@@ -995,7 +995,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
-"libc",
+ "libc",
 ]
 
 [[package]]
@@ -1004,7 +1004,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
-"crc-catalog",
+ "crc-catalog",
 ]
 
 [[package]]
@@ -1019,7 +1019,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
-"cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1028,21 +1028,21 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
-"anes",
-"cast",
-"ciborium",
-"clap",
-"criterion-plot",
-"itertools 0.13.0",
-"num-traits",
-"oorandom",
-"plotters",
-"rayon",
-"regex",
-"serde",
-"serde_json",
-"tinytemplate",
-"walkdir",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
@@ -1051,8 +1051,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f82e634fea1e2312dc41e6c0ca7444c5d6e7a1ccf3cf4b8de559831c3dcc271"
 dependencies = [
-"cfg-if",
-"criterion",
+ "cfg-if",
+ "criterion",
 ]
 
 [[package]]
@@ -1061,8 +1061,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
-"cast",
-"itertools 0.13.0",
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
-"crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1086,8 +1086,8 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
-"crossbeam-epoch",
-"crossbeam-utils",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
-"crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
-"crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1126,10 +1126,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
-"generic-array",
-"rand_core 0.6.4",
-"subtle",
-"zeroize",
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1138,8 +1138,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
-"generic-array",
-"typenum",
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1148,7 +1148,7 @@ version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
 dependencies = [
-"hybrid-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1157,7 +1157,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
-"cipher",
+ "cipher",
 ]
 
 [[package]]
@@ -1166,14 +1166,14 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
-"cfg-if",
-"cpufeatures",
-"curve25519-dalek-derive",
-"digest 0.10.7",
-"fiat-crypto",
-"rustc_version",
-"subtle",
-"zeroize",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1182,9 +1182,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1193,7 +1193,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
-"petgraph 0.7.1",
+ "petgraph 0.7.1",
 ]
 
 [[package]]
@@ -1202,8 +1202,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
-"darling_core 0.14.4",
-"darling_macro 0.14.4",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1212,8 +1212,8 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
-"darling_core 0.21.3",
-"darling_macro 0.21.3",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1222,12 +1222,12 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
-"fnv",
-"ident_case",
-"proc-macro2",
-"quote",
-"strsim 0.10.0",
-"syn 1.0.109",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1236,12 +1236,12 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
-"fnv",
-"ident_case",
-"proc-macro2",
-"quote",
-"strsim 0.11.1",
-"syn 2.0.119",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1250,9 +1250,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
-"darling_core 0.14.4",
-"quote",
-"syn 1.0.109",
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1261,9 +1261,9 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
-"darling_core 0.21.3",
-"quote",
-"syn 2.0.119",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1284,9 +1284,9 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
-"const-oid",
-"pem-rfc7468",
-"zeroize",
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -1295,12 +1295,12 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
-"asn1-rs",
-"cookie-factory",
-"displaydoc",
-"nom",
-"num-traits",
-"rusticata-macros",
+ "asn1-rs",
+ "cookie-factory",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1309,8 +1309,8 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
-"powerfmt",
-"serde",
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1319,8 +1319,8 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
-"derive-deftly-macros",
-"heck 0.5.0",
+ "derive-deftly-macros",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1329,16 +1329,16 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
-"heck 0.5.0",
-"indexmap 2.14.0",
-"itertools 0.15.0",
-"proc-macro-crate",
-"proc-macro2",
-"quote",
-"sha3",
-"strum",
-"syn 2.0.119",
-"void",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "itertools 0.15.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "strum",
+ "syn 2.0.119",
+ "void",
 ]
 
 [[package]]
@@ -1347,9 +1347,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1358,10 +1358,10 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c1b715c79be6328caa9a5e1a387a196ea503740f0722ec3dd8f67a9e72314d"
 dependencies = [
-"darling 0.14.4",
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1370,7 +1370,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3eae24d595f4d0ecc90a9a5a6d11c2bd8dafe2375ec4a1ec63250e5ade7d228"
 dependencies = [
-"derive_builder_macro_fork_arti",
+ "derive_builder_macro_fork_arti",
 ]
 
 [[package]]
@@ -1379,8 +1379,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69887769a2489cd946bf782eb2b1bb2cb7bc88551440c94a765d4f040c08ebf3"
 dependencies = [
-"derive_builder_core_fork_arti",
-"syn 1.0.109",
+ "derive_builder_core_fork_arti",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
-"derive_more-impl",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1398,12 +1398,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
-"convert_case",
-"proc-macro2",
-"quote",
-"rustc_version",
-"syn 2.0.119",
-"unicode-xid",
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1412,10 +1412,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
-"block-buffer 0.10.4",
-"const-oid",
-"crypto-common 0.1.7",
-"subtle",
+ "block-buffer 0.10.4",
+ "const-oid",
+ "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1424,9 +1424,9 @@ version = "0.11.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
 dependencies = [
-"block-buffer 0.11.0-rc.3",
-"crypto-common 0.2.0-rc.1",
-"subtle",
+ "block-buffer 0.11.0-rc.3",
+ "crypto-common 0.2.0-rc.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1435,7 +1435,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
-"dirs-sys",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1444,7 +1444,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
-"dirs-sys",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1453,10 +1453,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
-"libc",
-"option-ext",
-"redox_users",
-"windows-sys 0.61.2",
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1465,8 +1465,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
-"bitflags",
-"objc2",
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1475,9 +1475,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1486,7 +1486,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
-"libloading",
+ "libloading",
 ]
 
 [[package]]
@@ -1495,7 +1495,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
-"litrs",
+ "litrs",
 ]
 
 [[package]]
@@ -1516,7 +1516,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb33e6854ea615b65faf9c40d4ea9c4de9e9fa5d6772ad6ce57950a6da3957d"
 dependencies = [
-"dynosaur_derive",
+ "dynosaur_derive",
 ]
 
 [[package]]
@@ -1525,9 +1525,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac0893f103ae7bf50181323d748d505f27b6255777c28b502030bdaf8749f4c"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1536,12 +1536,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
-"der",
-"digest 0.10.7",
-"elliptic-curve",
-"rfc6979",
-"signature",
-"spki",
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1550,8 +1550,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
-"pkcs8",
-"signature",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -1560,14 +1560,14 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
-"curve25519-dalek",
-"ed25519",
-"merlin",
-"rand_core 0.6.4",
-"serde",
-"sha2 0.10.9",
-"subtle",
-"zeroize",
+ "curve25519-dalek",
+ "ed25519",
+ "merlin",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1576,10 +1576,10 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
-"enum-ordinalize",
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1588,14 +1588,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3c9c0416f224ce25ea2b710bf8abd4e5e41e41fe8e75685ae1519d5d5d2276"
 dependencies = [
-"base64",
-"ens-normalize-rs",
-"hex",
-"nom",
-"percent-encoding",
-"primitive-types",
-"sha3",
-"snafu",
+ "base64",
+ "ens-normalize-rs",
+ "hex",
+ "nom",
+ "percent-encoding",
+ "primitive-types",
+ "sha3",
+ "snafu",
 ]
 
 [[package]]
@@ -1610,17 +1610,17 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
-"base16ct",
-"crypto-bigint",
-"digest 0.10.7",
-"ff",
-"generic-array",
-"group",
-"pkcs8",
-"rand_core 0.6.4",
-"sec1",
-"subtle",
-"zeroize",
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1641,17 +1641,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0712f972f7320be5977fb2f4be0312ab3e5b1e8906cb9b3ee5f988ef4dc9590f"
 dependencies = [
-"anyhow",
-"itertools 0.13.0",
-"lazy_static",
-"regex",
-"serde",
-"serde-aux",
-"serde_json",
-"serde_plain",
-"serde_with",
-"thiserror 2.0.19",
-"unicode-normalization",
+ "anyhow",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "serde_plain",
+ "serde_with",
+ "thiserror 2.0.19",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1660,11 +1660,11 @@ version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
-"num-bigint",
-"num-traits",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1673,10 +1673,10 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
-"once_cell",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1684,8 +1684,8 @@ name = "equihash"
 version = "0.3.0"
 source = "git+https://github.com/zcash/librustzcash?rev=13ce6c4ef57a6c7e8837d797d85112ae16ac7455#13ce6c4ef57a6c7e8837d797d85112ae16ac7455"
 dependencies = [
-"blake2b_simd",
-"corez",
+ "blake2b_simd",
+ "corez",
 ]
 
 [[package]]
@@ -1700,8 +1700,8 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
-"libc",
-"windows-sys 0.61.2",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1710,9 +1710,9 @@ version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
-"concurrent-queue",
-"parking",
-"pin-project-lite",
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1720,7 +1720,7 @@ name = "f4jumble"
 version = "0.1.1"
 source = "git+https://github.com/zcash/librustzcash?rev=13ce6c4ef57a6c7e8837d797d85112ae16ac7455#13ce6c4ef57a6c7e8837d797d85112ae16ac7455"
 dependencies = [
-"blake2b_simd",
+ "blake2b_simd",
 ]
 
 [[package]]
@@ -1747,9 +1747,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
-"bitvec",
-"rand_core 0.6.4",
-"subtle",
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1758,9 +1758,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06bad5d1e3a9cfc3825643e055eb7f1fc1b1d52d1543c8ddb9107abd6497f2e"
 dependencies = [
-"anyhow",
-"libc",
-"thiserror 1.0.69",
+ "anyhow",
+ "libc",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1775,11 +1775,11 @@ version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
-"atomic 0.6.1",
-"serde",
-"toml 0.8.23",
-"uncased",
-"version_check",
+ "atomic 0.6.1",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -1788,8 +1788,8 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
-"cfg-if",
-"libc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1804,7 +1804,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
-"static_assertions",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1825,8 +1825,8 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
-"crc32fast",
-"miniz_oxide",
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1841,10 +1841,10 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
-"futures-core",
-"futures-sink",
-"nanorand",
-"spin",
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -1871,12 +1871,12 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
 dependencies = [
-"cbc",
-"cipher",
-"libm",
-"num-bigint",
-"num-integer",
-"num-traits",
+ "cbc",
+ "cipher",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1885,20 +1885,20 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
 dependencies = [
-"byteorder",
-"const-crc32-nostd",
-"derive-getters",
-"document-features",
-"hex",
-"itertools 0.14.0",
-"postcard",
-"rand_core 0.6.4",
-"serde",
-"serdect",
-"thiserror 2.0.19",
-"visibility",
-"zeroize",
-"zeroize_derive",
+ "byteorder",
+ "const-crc32-nostd",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.19",
+ "visibility",
+ "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -1907,11 +1907,11 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
 dependencies = [
-"derive-getters",
-"document-features",
-"frost-core",
-"hex",
-"rand_core 0.6.4",
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1920,13 +1920,13 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a157b06319bb4868718fd20177a0d3373d465e429d89cd0ee493d9f5918902"
 dependencies = [
-"derive_builder_fork_arti",
-"dirs",
-"libc",
-"pwd-grp",
-"serde",
-"thiserror 2.0.19",
-"walkdir",
+ "derive_builder_fork_arti",
+ "dirs",
+ "libc",
+ "pwd-grp",
+ "serde",
+ "thiserror 2.0.19",
+ "walkdir",
 ]
 
 [[package]]
@@ -1935,8 +1935,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
-"libc",
-"winapi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1951,13 +1951,13 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
-"futures-channel",
-"futures-core",
-"futures-executor",
-"futures-io",
-"futures-sink",
-"futures-task",
-"futures-util",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1966,8 +1966,8 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
-"futures-core",
-"futures-sink",
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1982,9 +1982,9 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
-"futures-core",
-"futures-task",
-"futures-util",
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1999,9 +1999,9 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2010,9 +2010,9 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
-"futures-io",
-"rustls",
-"rustls-pki-types",
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2033,15 +2033,15 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
-"futures-channel",
-"futures-core",
-"futures-io",
-"futures-macro",
-"futures-sink",
-"futures-task",
-"memchr",
-"pin-project-lite",
-"slab",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -2050,9 +2050,9 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
-"typenum",
-"version_check",
-"zeroize",
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2061,11 +2061,11 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
-"cfg-if",
-"js-sys",
-"libc",
-"wasi",
-"wasm-bindgen",
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2074,12 +2074,12 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
-"cfg-if",
-"js-sys",
-"libc",
-"r-efi 5.3.0",
-"wasip2",
-"wasm-bindgen",
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2088,9 +2088,9 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
-"cfg-if",
-"libc",
-"r-efi 6.0.0",
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -2099,9 +2099,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2110,9 +2110,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
-"khronos_api",
-"log",
-"xml-rs",
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2133,10 +2133,10 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
-"js-sys",
-"slotmap",
-"wasm-bindgen",
-"web-sys",
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
-"gl_generator",
+ "gl_generator",
 ]
 
 [[package]]
@@ -2154,12 +2154,12 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
-"ash",
-"hashbrown 0.16.1",
-"log",
-"presser",
-"thiserror 2.0.19",
-"windows 0.61.3",
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.19",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2168,9 +2168,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
-"bitflags",
-"gpu-descriptor-types",
-"hashbrown 0.15.5",
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
-"bitflags",
+ "bitflags",
 ]
 
 [[package]]
@@ -2188,10 +2188,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
-"ff",
-"memuse",
-"rand_core 0.6.4",
-"subtle",
+ "ff",
+ "memuse",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2200,17 +2200,17 @@ version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
-"atomic-waker",
-"bytes",
-"fnv",
-"futures-core",
-"futures-sink",
-"http",
-"indexmap 2.14.0",
-"slab",
-"tokio",
-"tokio-util",
-"tracing",
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2219,10 +2219,10 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
-"cfg-if",
-"crunchy",
-"num-traits",
-"zerocopy",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2231,18 +2231,18 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
-"arrayvec",
-"bitvec",
-"ff",
-"group",
-"halo2_poseidon",
-"halo2_proofs",
-"lazy_static",
-"pasta_curves",
-"rand 0.8.7",
-"sinsemilla",
-"subtle",
-"uint",
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "lazy_static",
+ "pasta_curves",
+ "rand 0.8.7",
+ "sinsemilla",
+ "subtle",
+ "uint",
 ]
 
 [[package]]
@@ -2257,10 +2257,10 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
 dependencies = [
-"bitvec",
-"ff",
-"group",
-"pasta_curves",
+ "bitvec",
+ "ff",
+ "group",
+ "pasta_curves",
 ]
 
 [[package]]
@@ -2269,15 +2269,15 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f63a999d9223fa9d3b9db3031fedc316e6039a0ae0f67394408b16ef670c69f"
 dependencies = [
-"blake2b_simd",
-"ff",
-"group",
-"halo2_legacy_pdqsort",
-"indexmap 1.9.3",
-"maybe-rayon",
-"pasta_curves",
-"rand_core 0.6.4",
-"tracing",
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_legacy_pdqsort",
+ "indexmap 1.9.3",
+ "maybe-rayon",
+ "pasta_curves",
+ "rand_core 0.6.4",
+ "tracing",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
-"byteorder",
+ "byteorder",
 ]
 
 [[package]]
@@ -2301,7 +2301,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
-"foldhash 0.1.5",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2310,9 +2310,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
-"allocator-api2",
-"equivalent",
-"foldhash 0.2.0",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2327,7 +2327,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
-"hashbrown 0.15.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2336,12 +2336,12 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
-"atomic-polyfill",
-"hash32",
-"rustc_version",
-"serde",
-"spin",
-"stable_deref_trait",
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2380,7 +2380,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
-"hmac 0.12.1",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2389,7 +2389,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
-"digest 0.10.7",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2398,7 +2398,7 @@ version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
 dependencies = [
-"digest 0.11.0-pre.9",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -2407,7 +2407,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
-"windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2422,8 +2422,8 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
-"bytes",
-"itoa",
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
@@ -2432,8 +2432,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
-"bytes",
-"http",
+ "bytes",
+ "http",
 ]
 
 [[package]]
@@ -2442,11 +2442,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
-"bytes",
-"futures-core",
-"http",
-"http-body",
-"pin-project-lite",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2473,8 +2473,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
-"humantime",
-"serde",
+ "humantime",
+ "serde",
 ]
 
 [[package]]
@@ -2483,7 +2483,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
 dependencies = [
-"typenum",
+ "typenum",
 ]
 
 [[package]]
@@ -2492,20 +2492,20 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
-"atomic-waker",
-"bytes",
-"futures-channel",
-"futures-core",
-"h2",
-"http",
-"http-body",
-"httparse",
-"httpdate",
-"itoa",
-"pin-project-lite",
-"smallvec",
-"tokio",
-"want",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2514,14 +2514,14 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
-"http",
-"hyper",
-"hyper-util",
-"rustls",
-"tokio",
-"tokio-rustls",
-"tower-service",
-"webpki-roots",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2530,11 +2530,11 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
-"hyper",
-"hyper-util",
-"pin-project-lite",
-"tokio",
-"tower-service",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2543,18 +2543,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
-"bytes",
-"futures-channel",
-"futures-util",
-"http",
-"http-body",
-"hyper",
-"libc",
-"pin-project-lite",
-"socket2",
-"tokio",
-"tower-service",
-"tracing",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2563,13 +2563,13 @@ version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
-"android_system_properties",
-"core-foundation-sys",
-"iana-time-zone-haiku",
-"js-sys",
-"log",
-"wasm-bindgen",
-"windows-core 0.62.2",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2578,7 +2578,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
-"cc",
+ "cc",
 ]
 
 [[package]]
@@ -2589,16 +2589,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imt-tree"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
+checksum = "0aad3e3ab5a46f4a08d00f5525b86cd0d5204cba64ba68f46e20a590e1808aec"
 dependencies = [
-"anyhow",
-"ff",
-"halo2_gadgets",
-"hex",
-"pasta_curves",
-"rayon",
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
 ]
 
 [[package]]
@@ -2607,7 +2607,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
-"either",
+ "either",
 ]
 
 [[package]]
@@ -2616,9 +2616,9 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
-"autocfg",
-"hashbrown 0.12.3",
-"serde",
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2627,10 +2627,10 @@ version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
-"equivalent",
-"hashbrown 0.17.1",
-"serde",
-"serde_core",
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2639,9 +2639,9 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
-"bitflags",
-"inotify-sys",
-"libc",
+ "bitflags",
+ "inotify-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2650,7 +2650,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
-"libc",
+ "libc",
 ]
 
 [[package]]
@@ -2659,7 +2659,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
-"generic-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -2668,7 +2668,7 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
-"rustversion",
+ "rustversion",
 ]
 
 [[package]]
@@ -2683,7 +2683,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
-"either",
+ "either",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
-"either",
+ "either",
 ]
 
 [[package]]
@@ -2701,7 +2701,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
-"either",
+ "either",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
-"either",
+ "either",
 ]
 
 [[package]]
@@ -2725,7 +2725,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
-"jni-sys 0.4.1",
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -2734,7 +2734,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
 dependencies = [
-"jni-sys-macros",
+ "jni-sys-macros",
 ]
 
 [[package]]
@@ -2743,8 +2743,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
-"quote",
-"syn 2.0.119",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2753,8 +2753,8 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
-"getrandom 0.4.3",
-"libc",
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -2763,9 +2763,9 @@ version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
-"cfg-if",
-"futures-util",
-"wasm-bindgen",
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2774,12 +2774,12 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
-"bitvec",
-"bls12_381",
-"ff",
-"group",
-"rand_core 0.6.4",
-"subtle",
+ "bitvec",
+ "bls12_381",
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2788,7 +2788,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
-"cpufeatures",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2797,11 +2797,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a08a7e0ccd113dac19485c5c0fe87c70b663f896c48e4493814e446175078d4"
 dependencies = [
-"bitcoin_hashes",
-"crc",
-"minicbor",
-"phf 0.11.3",
-"rand_xoshiro",
+ "bitcoin_hashes",
+ "crc",
+ "minicbor",
+ "phf 0.11.3",
+ "rand_xoshiro",
 ]
 
 [[package]]
@@ -2810,9 +2810,9 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
-"libc",
-"libloading",
-"pkg-config",
+ "libc",
+ "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2827,7 +2827,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
-"windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2836,8 +2836,8 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
-"kqueue-sys",
-"libc",
+ "kqueue-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2846,8 +2846,8 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
-"bitflags",
-"libc",
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -2856,7 +2856,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
-"spin",
+ "spin",
 ]
 
 [[package]]
@@ -2871,11 +2871,11 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85f7ef5c7e3c2ed51f0fbc40e016c66558b699f16593521f30b98713bbb99cb8"
 dependencies = [
-"adler32",
-"crc32fast",
-"dary_heap",
-"libflate_lz77",
-"no_std_io2",
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -2884,9 +2884,9 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
-"hashbrown 0.16.1",
-"no_std_io2",
-"rle-decode-fast",
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
 ]
 
 [[package]]
@@ -2895,8 +2895,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
-"cfg-if",
-"windows-link 0.2.1",
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2911,7 +2911,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
-"libc",
+ "libc",
 ]
 
 [[package]]
@@ -2920,74 +2920,74 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
-"cc",
-"pkg-config",
-"vcpkg",
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "libzcashlc"
 version = "2.8.0-rc.2"
 dependencies = [
-"anyhow",
-"bindgen",
-"bitflags",
-"bytes",
-"cbindgen",
-"cc",
-"cfg-if",
-"eip681",
-"ff",
-"ffi_helpers",
-"fs-mistrust",
-"hex",
-"http",
-"http-body-util",
-"incrementalmerkletree",
-"log-panics",
-"nonempty",
-"once_cell",
-"orchard",
-"pasta_curves",
-"pczt",
-"prost 0.14.4",
-"rand 0.8.7",
-"rayon",
-"rusqlite",
-"rust_decimal",
-"sapling-crypto",
-"schemerz",
-"schemerz-rusqlite",
-"secrecy",
-"serde",
-"serde_json",
-"sharded-slab",
-"shardtree",
-"tempfile",
-"tokio",
-"tonic",
-"tor-rtcompat",
-"tracing",
-"tracing-subscriber",
-"ur",
-"ur-registry",
-"uuid",
-"xz2",
-"zcash_address",
-"zcash_client_backend",
-"zcash_client_sqlite",
-"zcash_keys",
-"zcash_note_encryption",
-"zcash_pool_migration",
-"zcash_primitives",
-"zcash_proofs",
-"zcash_protocol",
-"zcash_script",
-"zcash_transparent",
-"zcash_voting",
-"zeroize",
-"zip32",
-"zodl-slipstream",
+ "anyhow",
+ "bindgen",
+ "bitflags",
+ "bytes",
+ "cbindgen",
+ "cc",
+ "cfg-if",
+ "eip681",
+ "ff",
+ "ffi_helpers",
+ "fs-mistrust",
+ "hex",
+ "http",
+ "http-body-util",
+ "incrementalmerkletree",
+ "log-panics",
+ "nonempty",
+ "once_cell",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "prost 0.14.4",
+ "rand 0.8.7",
+ "rayon",
+ "rusqlite",
+ "rust_decimal",
+ "sapling-crypto",
+ "schemerz",
+ "schemerz-rusqlite",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "shardtree",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tor-rtcompat",
+ "tracing",
+ "tracing-subscriber",
+ "ur",
+ "ur-registry",
+ "uuid",
+ "xz2",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
+ "zcash_keys",
+ "zcash_note_encryption",
+ "zcash_pool_migration",
+ "zcash_primitives",
+ "zcash_proofs",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+ "zcash_voting",
+ "zeroize",
+ "zip32",
+ "zodl-slipstream",
 ]
 
 [[package]]
@@ -3014,7 +3014,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
-"scopeguard",
+ "scopeguard",
 ]
 
 [[package]]
@@ -3029,7 +3029,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
-"log",
+ "log",
 ]
 
 [[package]]
@@ -3038,9 +3038,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
 dependencies = [
-"cc",
-"libc",
-"pkg-config",
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3049,7 +3049,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
-"regex-automata",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3064,8 +3064,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
-"cfg-if",
-"rayon",
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3080,7 +3080,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
-"libc",
+ "libc",
 ]
 
 [[package]]
@@ -3095,10 +3095,10 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
-"byteorder",
-"keccak",
-"rand_core 0.6.4",
-"zeroize",
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -3113,7 +3113,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
 dependencies = [
-"minicbor-derive",
+ "minicbor-derive",
 ]
 
 [[package]]
@@ -3122,9 +3122,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3139,8 +3139,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
-"adler2",
-"simd-adler32",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3149,10 +3149,10 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
-"libc",
-"log",
-"wasi",
-"windows-sys 0.61.2",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3173,24 +3173,24 @@ version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
-"arrayvec",
-"bit-set",
-"bitflags",
-"cfg-if",
-"cfg_aliases",
-"codespan-reporting",
-"half",
-"hashbrown 0.16.1",
-"hexf-parse",
-"indexmap 2.14.0",
-"libm",
-"log",
-"num-traits",
-"once_cell",
-"rustc-hash 1.1.0",
-"spirv",
-"thiserror 2.0.19",
-"unicode-ident",
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap 2.14.0",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.19",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3199,7 +3199,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
-"getrandom 0.2.17",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3208,7 +3208,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
-"jni-sys 0.3.1",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3217,7 +3217,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
-"memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -3226,8 +3226,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
-"memchr",
-"minimal-lexical",
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3248,15 +3248,15 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
-"bitflags",
-"inotify",
-"kqueue",
-"libc",
-"log",
-"mio",
-"notify-types",
-"walkdir",
-"windows-sys 0.60.2",
+ "bitflags",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3265,7 +3265,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
-"bitflags",
+ "bitflags",
 ]
 
 [[package]]
@@ -3274,7 +3274,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
-"winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -3283,7 +3283,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
-"windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3292,8 +3292,8 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
-"num-integer",
-"num-traits",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3302,14 +3302,14 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
-"lazy_static",
-"libm",
-"num-integer",
-"num-iter",
-"num-traits",
-"rand 0.8.7",
-"smallvec",
-"zeroize",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -3324,7 +3324,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
-"num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -3333,8 +3333,8 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
-"num-integer",
-"num-traits",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3343,8 +3343,8 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
-"autocfg",
-"libm",
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3353,8 +3353,8 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
-"hermit-abi",
-"libc",
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3363,8 +3363,8 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
-"num_enum_derive",
-"rustversion",
+ "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
@@ -3373,10 +3373,10 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
-"proc-macro-crate",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3385,7 +3385,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
-"objc2-encode",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -3394,9 +3394,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
-"bitflags",
-"dispatch2",
-"objc2",
+ "bitflags",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -3411,9 +3411,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
-"bitflags",
-"objc2",
-"objc2-core-foundation",
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3422,8 +3422,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
-"libc",
-"objc2-core-foundation",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3432,10 +3432,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
-"bitflags",
-"block2",
-"objc2",
-"objc2-foundation",
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3444,11 +3444,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
-"bitflags",
-"objc2",
-"objc2-core-foundation",
-"objc2-foundation",
-"objc2-metal",
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3469,7 +3469,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5480ab52bd005e9f14e3071d0227bfa204e16a496a719c58bfa013f880b41593"
 dependencies = [
-"futures",
+ "futures",
 ]
 
 [[package]]
@@ -3496,34 +3496,34 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
 dependencies = [
-"aes",
-"bitvec",
-"blake2b_simd",
-"corez",
-"ff",
-"fpe",
-"getset",
-"group",
-"halo2_gadgets",
-"halo2_poseidon",
-"halo2_proofs",
-"hex",
-"incrementalmerkletree",
-"lazy_static",
-"memuse",
-"nonempty",
-"pasta_curves",
-"rand 0.8.7",
-"rand_core 0.6.4",
-"reddsa",
-"serde",
-"sinsemilla",
-"subtle",
-"tracing",
-"visibility",
-"zcash_note_encryption",
-"zcash_spec",
-"zip32",
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
 ]
 
 [[package]]
@@ -3532,7 +3532,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
-"num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -3541,7 +3541,7 @@ version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
-"num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -3550,7 +3550,7 @@ version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 dependencies = [
-"memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -3559,10 +3559,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
-"ecdsa",
-"elliptic-curve",
-"primeorder",
-"sha2 0.10.9",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3571,10 +3571,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
-"ecdsa",
-"elliptic-curve",
-"primeorder",
-"sha2 0.10.9",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3583,12 +3583,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
-"base16ct",
-"ecdsa",
-"elliptic-curve",
-"primeorder",
-"rand_core 0.6.4",
-"sha2 0.10.9",
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3597,7 +3597,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
-"group",
+ "group",
 ]
 
 [[package]]
@@ -3612,8 +3612,8 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
-"lock_api",
-"parking_lot_core",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3622,11 +3622,11 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
-"cfg-if",
-"libc",
-"redox_syscall",
-"smallvec",
-"windows-link 0.2.1",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3635,13 +3635,13 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
-"blake2b_simd",
-"ff",
-"group",
-"lazy_static",
-"rand 0.8.7",
-"static_assertions",
-"subtle",
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.8.7",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -3661,27 +3661,27 @@ name = "pczt"
 version = "0.9.3"
 source = "git+https://github.com/zcash/librustzcash?rev=13ce6c4ef57a6c7e8837d797d85112ae16ac7455#13ce6c4ef57a6c7e8837d797d85112ae16ac7455"
 dependencies = [
-"blake2b_simd",
-"bls12_381",
-"document-features",
-"ff",
-"getset",
-"jubjub",
-"nonempty",
-"orchard",
-"pasta_curves",
-"postcard",
-"rand_core 0.6.4",
-"redjubjub",
-"sapling-crypto",
-"secp256k1",
-"serde",
-"serde_with",
-"zcash_note_encryption",
-"zcash_primitives",
-"zcash_protocol",
-"zcash_script",
-"zcash_transparent",
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -3690,7 +3690,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
-"base64ct",
+ "base64ct",
 ]
 
 [[package]]
@@ -3705,8 +3705,8 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
-"fixedbitset 0.4.2",
-"indexmap 2.14.0",
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3715,8 +3715,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
-"fixedbitset 0.5.7",
-"indexmap 2.14.0",
+ "fixedbitset 0.5.7",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3725,9 +3725,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
-"fixedbitset 0.5.7",
-"hashbrown 0.15.5",
-"indexmap 2.14.0",
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3736,8 +3736,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
-"phf_macros 0.11.3",
-"phf_shared 0.11.3",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3746,9 +3746,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
-"phf_macros 0.13.1",
-"phf_shared 0.13.1",
-"serde",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3757,8 +3757,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
-"phf_shared 0.11.3",
-"rand 0.8.7",
+ "phf_shared 0.11.3",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3767,8 +3767,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
-"fastrand",
-"phf_shared 0.13.1",
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3777,11 +3777,11 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
-"phf_generator 0.11.3",
-"phf_shared 0.11.3",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3790,11 +3790,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
-"phf_generator 0.13.1",
-"phf_shared 0.13.1",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
-"siphasher",
+ "siphasher",
 ]
 
 [[package]]
@@ -3812,7 +3812,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
-"siphasher",
+ "siphasher",
 ]
 
 [[package]]
@@ -3821,7 +3821,7 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
-"pin-project-internal",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -3830,9 +3830,9 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3843,34 +3843,34 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.4.0-rc.2"
+version = "0.4.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666111370cf8a3fb2fa41a2442accc9d283226c1229828ff92c253dda1eb51e3"
+checksum = "25d28b9974a13bdde2f90c614e3e399ec260165554fd1077b07290c73b075cc3"
 dependencies = [
-"anyhow",
-"ff",
-"futures",
-"hex",
-"imt-tree",
-"log",
-"pasta_curves",
-"pir-types",
-"serde_json",
-"tokio",
-"valar-ypir",
+ "anyhow",
+ "ff",
+ "futures",
+ "hex",
+ "imt-tree",
+ "log",
+ "pasta_curves",
+ "pir-types",
+ "serde_json",
+ "tokio",
+ "valar-ypir",
 ]
 
 [[package]]
 name = "pir-types"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a9ba9677931ac73da6d7726af28357da8f2e3d635a3e186c92a7f41382fe3e"
+checksum = "81a363975b44d002bfa04c2003bdcd1b4564cd54bbd99bc0862140bc86865580"
 dependencies = [
-"anyhow",
-"ff",
-"imt-tree",
-"pasta_curves",
-"serde",
+ "anyhow",
+ "ff",
+ "imt-tree",
+ "pasta_curves",
+ "serde",
 ]
 
 [[package]]
@@ -3879,9 +3879,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
-"der",
-"pkcs8",
-"spki",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -3890,8 +3890,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
-"der",
-"spki",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3906,11 +3906,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
-"num-traits",
-"plotters-backend",
-"plotters-svg",
-"wasm-bindgen",
-"web-sys",
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3925,7 +3925,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
-"plotters-backend",
+ "plotters-backend",
 ]
 
 [[package]]
@@ -3940,9 +3940,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
-"cpufeatures",
-"opaque-debug",
-"universal-hash",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3957,7 +3957,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
-"portable-atomic",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3966,13 +3966,13 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3fb618632874fb76937c2361a7f22afd393c982a2165595407edc75b06d3c1"
 dependencies = [
-"atomic 0.5.3",
-"crossbeam-queue",
-"futures",
-"parking_lot",
-"pin-project",
-"static_assertions",
-"thiserror 1.0.69",
+ "atomic 0.5.3",
+ "crossbeam-queue",
+ "futures",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3981,11 +3981,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
-"cobs",
-"embedded-io 0.4.0",
-"embedded-io 0.6.1",
-"heapless",
-"serde",
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
-"zerocopy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4015,8 +4015,8 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
-"proc-macro2",
-"syn 1.0.109",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4025,8 +4025,8 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
-"proc-macro2",
-"syn 2.0.119",
+ "proc-macro2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4035,7 +4035,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
-"elliptic-curve",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4044,8 +4044,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
-"fixed-hash",
-"uint",
+ "fixed-hash",
+ "uint",
 ]
 
 [[package]]
@@ -4054,9 +4054,9 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
-"equivalent",
-"indexmap 2.14.0",
-"serde",
+ "equivalent",
+ "indexmap 2.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -4065,7 +4065,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
-"toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4074,7 +4074,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
-"unicode-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4089,8 +4089,8 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
-"bytes",
-"prost-derive 0.11.9",
+ "bytes",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -4099,8 +4099,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
-"bytes",
-"prost-derive 0.14.4",
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4109,20 +4109,20 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
-"bytes",
-"heck 0.4.1",
-"itertools 0.10.5",
-"lazy_static",
-"log",
-"multimap 0.8.3",
-"petgraph 0.6.5",
-"prettyplease 0.1.25",
-"prost 0.11.9",
-"prost-types 0.11.9",
-"regex",
-"syn 1.0.109",
-"tempfile",
-"which 4.4.2",
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap 0.8.3",
+ "petgraph 0.6.5",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -4131,17 +4131,17 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
-"heck 0.5.0",
-"itertools 0.14.0",
-"log",
-"multimap 0.10.1",
-"petgraph 0.8.3",
-"prettyplease 0.2.37",
-"prost 0.14.4",
-"prost-types 0.14.4",
-"regex",
-"syn 2.0.119",
-"tempfile",
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap 0.10.1",
+ "petgraph 0.8.3",
+ "prettyplease 0.2.37",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
 ]
 
 [[package]]
@@ -4150,11 +4150,11 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
-"anyhow",
-"itertools 0.10.5",
-"proc-macro2",
-"quote",
-"syn 1.0.109",
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4163,11 +4163,11 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
-"anyhow",
-"itertools 0.14.0",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4176,7 +4176,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
-"prost 0.11.9",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -4185,7 +4185,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
-"prost 0.14.4",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4194,10 +4194,10 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e2023f41b5fcb7c30eb5300a5733edfaa9e0e0d502d51b586f65633fd39e40c"
 dependencies = [
-"derive-deftly",
-"libc",
-"paste",
-"thiserror 2.0.19",
+ "derive-deftly",
+ "libc",
+ "paste",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4206,7 +4206,7 @@ version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
-"proc-macro2",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -4233,9 +4233,9 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
-"libc",
-"rand_chacha 0.3.1",
-"rand_core 0.6.4",
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4244,8 +4244,8 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
-"rand_chacha 0.9.0",
-"rand_core 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4254,8 +4254,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
-"ppv-lite86",
-"rand_core 0.6.4",
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4264,8 +4264,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
-"ppv-lite86",
-"rand_core 0.9.5",
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4274,7 +4274,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
-"getrandom 0.2.17",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4283,7 +4283,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
-"getrandom 0.3.4",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4292,8 +4292,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
-"num-traits",
-"rand 0.8.7",
+ "num-traits",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4302,9 +4302,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16df48f071248e67b8fc5e866d9448d45c08ad8b672baaaf796e2f15e606ff0"
 dependencies = [
-"libc",
-"rand_core 0.9.5",
-"winapi",
+ "libc",
+ "rand_core 0.9.5",
+ "winapi",
 ]
 
 [[package]]
@@ -4313,7 +4313,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
-"rand_core 0.6.4",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4334,10 +4334,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
-"objc2",
-"objc2-core-foundation",
-"objc2-foundation",
-"objc2-quartz-core",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -4346,8 +4346,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
-"either",
-"rayon-core",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
@@ -4356,8 +4356,8 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
-"crossbeam-deque",
-"crossbeam-utils",
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4366,7 +4366,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
 dependencies = [
-"rand_core 0.6.4",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4375,17 +4375,17 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
 dependencies = [
-"blake2b_simd",
-"byteorder",
-"frost-rerandomized",
-"group",
-"hex",
-"jubjub",
-"pasta_curves",
-"rand_core 0.6.4",
-"serde",
-"thiserror 2.0.19",
-"zeroize",
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror 2.0.19",
+ "zeroize",
 ]
 
 [[package]]
@@ -4394,10 +4394,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
 dependencies = [
-"rand_core 0.6.4",
-"reddsa",
-"thiserror 1.0.69",
-"zeroize",
+ "rand_core 0.6.4",
+ "reddsa",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -4406,7 +4406,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
-"bitflags",
+ "bitflags",
 ]
 
 [[package]]
@@ -4415,9 +4415,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
-"getrandom 0.2.17",
-"libredox",
-"thiserror 2.0.19",
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4426,7 +4426,7 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
-"ref-cast-impl",
+ "ref-cast-impl",
 ]
 
 [[package]]
@@ -4435,9 +4435,9 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 3.0.3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4446,10 +4446,10 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
-"aho-corasick",
-"memchr",
-"regex-automata",
-"regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4458,9 +4458,9 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
-"aho-corasick",
-"memchr",
-"regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4487,8 +4487,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
-"hmac 0.12.1",
-"subtle",
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4497,12 +4497,12 @@ version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
-"cc",
-"cfg-if",
-"getrandom 0.2.17",
-"libc",
-"untrusted",
-"windows-sys 0.52.0",
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4511,7 +4511,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
-"digest 0.10.7",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4520,7 +4520,7 @@ version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48cf93482ea998ad1302c42739bc73ab3adc574890c373ec89710e219357579"
 dependencies = [
-"digest 0.11.0-pre.9",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -4535,19 +4535,19 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
-"const-oid",
-"digest 0.10.7",
-"num-bigint-dig",
-"num-integer",
-"num-traits",
-"pkcs1",
-"pkcs8",
-"rand_core 0.6.4",
-"sha2 0.10.9",
-"signature",
-"spki",
-"subtle",
-"zeroize",
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4556,14 +4556,14 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
-"bitflags",
-"fallible-iterator",
-"fallible-streaming-iterator",
-"hashlink",
-"libsqlite3-sys",
-"smallvec",
-"time",
-"uuid",
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -4572,10 +4572,10 @@ version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
-"arrayvec",
-"num-traits",
-"serde",
-"wasm-bindgen",
+ "arrayvec",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
-"semver",
+ "semver",
 ]
 
 [[package]]
@@ -4605,7 +4605,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
-"nom",
+ "nom",
 ]
 
 [[package]]
@@ -4614,11 +4614,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
-"bitflags",
-"errno",
-"libc",
-"linux-raw-sys 0.4.15",
-"windows-sys 0.52.0",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4627,11 +4627,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
-"bitflags",
-"errno",
-"libc",
-"linux-raw-sys 0.12.1",
-"windows-sys 0.61.2",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4640,13 +4640,13 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
-"log",
-"once_cell",
-"ring",
-"rustls-pki-types",
-"rustls-webpki",
-"subtle",
-"zeroize",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4655,7 +4655,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
-"zeroize",
+ "zeroize",
 ]
 
 [[package]]
@@ -4664,9 +4664,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
-"ring",
-"rustls-pki-types",
-"untrusted",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4681,11 +4681,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b0880210c750d9189aa2d1ef94075a5500ccd9e7e98ad868e017c17c4a4bc"
 dependencies = [
-"derive_more",
-"educe",
-"either",
-"fluid-let",
-"thiserror 2.0.19",
+ "derive_more",
+ "educe",
+ "either",
+ "fluid-let",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4694,7 +4694,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
-"winapi-util",
+ "winapi-util",
 ]
 
 [[package]]
@@ -4703,7 +4703,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
 dependencies = [
-"regex",
+ "regex",
 ]
 
 [[package]]
@@ -4712,31 +4712,31 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
-"aes",
-"bellman",
-"bitvec",
-"blake2b_simd",
-"blake2s_simd",
-"bls12_381",
-"corez",
-"document-features",
-"ff",
-"fpe",
-"getset",
-"group",
-"hex",
-"incrementalmerkletree",
-"jubjub",
-"lazy_static",
-"memuse",
-"rand 0.8.7",
-"rand_core 0.6.4",
-"redjubjub",
-"subtle",
-"tracing",
-"zcash_note_encryption",
-"zcash_spec",
-"zip32",
+ "aes",
+ "bellman",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "corez",
+ "document-features",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
 ]
 
 [[package]]
@@ -4745,10 +4745,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
-"dyn-clone",
-"ref-cast",
-"serde",
-"serde_json",
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4757,10 +4757,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
-"dyn-clone",
-"ref-cast",
-"serde",
-"serde_json",
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4769,11 +4769,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e82960ac11ccabd77d53c933532612079e01205b5873ec5095f4b3426493434"
 dependencies = [
-"daggy",
-"indexmap 1.9.3",
-"log",
-"thiserror 1.0.69",
-"uuid",
+ "daggy",
+ "indexmap 1.9.3",
+ "log",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -4782,9 +4782,9 @@ version = "0.370.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6df8a13fb3b7914f94ac6579bd5e76b9292f135886e6becc3525f9e5116827"
 dependencies = [
-"rusqlite",
-"schemerz",
-"uuid",
+ "rusqlite",
+ "schemerz",
+ "uuid",
 ]
 
 [[package]]
@@ -4799,12 +4799,12 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
-"base16ct",
-"der",
-"generic-array",
-"pkcs8",
-"subtle",
-"zeroize",
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4813,7 +4813,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
-"secp256k1-sys",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -4822,7 +4822,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
-"cc",
+ "cc",
 ]
 
 [[package]]
@@ -4831,7 +4831,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
-"zeroize",
+ "zeroize",
 ]
 
 [[package]]
@@ -4846,8 +4846,8 @@ version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
-"serde_core",
-"serde_derive",
+ "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4856,10 +4856,10 @@ version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
 dependencies = [
-"chrono",
-"serde",
-"serde-value",
-"serde_json",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
 ]
 
 [[package]]
@@ -4868,8 +4868,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
-"ordered-float 2.10.1",
-"serde",
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -4878,7 +4878,7 @@ version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
-"serde_derive",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4887,9 +4887,9 @@ version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
-"proc-macro2",
-"quote",
-"syn 3.0.3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4898,8 +4898,8 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
 dependencies = [
-"serde",
-"serde_core",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4908,11 +4908,11 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
-"itoa",
-"memchr",
-"serde",
-"serde_core",
-"zmij",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4921,7 +4921,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
-"serde",
+ "serde",
 ]
 
 [[package]]
@@ -4930,7 +4930,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
-"serde",
+ "serde",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
-"serde_core",
+ "serde_core",
 ]
 
 [[package]]
@@ -4948,17 +4948,17 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
-"base64",
-"chrono",
-"hex",
-"indexmap 1.9.3",
-"indexmap 2.14.0",
-"schemars 0.9.0",
-"schemars 1.2.1",
-"serde_core",
-"serde_json",
-"serde_with_macros",
-"time",
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -4967,10 +4967,10 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
-"darling 0.21.3",
-"proc-macro2",
-"quote",
-"syn 2.0.119",
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4979,8 +4979,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
-"base16ct",
-"serde",
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -4989,9 +4989,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
-"cfg-if",
-"cpufeatures",
-"digest 0.10.7",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5000,9 +5000,9 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
-"cfg-if",
-"cpufeatures",
-"digest 0.10.7",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5011,9 +5011,9 @@ version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
-"cfg-if",
-"cpufeatures",
-"digest 0.11.0-pre.9",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -5022,8 +5022,8 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
-"digest 0.10.7",
-"keccak",
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -5032,7 +5032,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
-"lazy_static",
+ "lazy_static",
 ]
 
 [[package]]
@@ -5041,10 +5041,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
-"bitflags",
-"either",
-"incrementalmerkletree",
-"tracing",
+ "bitflags",
+ "either",
+ "incrementalmerkletree",
+ "tracing",
 ]
 
 [[package]]
@@ -5053,9 +5053,9 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
-"bstr",
-"dirs",
-"os_str_bytes",
+ "bstr",
+ "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -5076,8 +5076,8 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
-"errno",
-"libc",
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -5086,8 +5086,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
-"digest 0.10.7",
-"rand_core 0.6.4",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5102,9 +5102,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
 dependencies = [
-"group",
-"pasta_curves",
-"subtle",
+ "group",
+ "pasta_curves",
+ "subtle",
 ]
 
 [[package]]
@@ -5118,60 +5118,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slipstream-core"
-version = "0.6.4"
-source = "git+https://github.com/zodl-inc/slipstream-internal.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
-dependencies = [
- "ff",
- "futures-util",
- "group",
- "incrementalmerkletree",
- "orchard",
- "pasta_curves",
- "prost 0.14.4",
- "rand 0.8.7",
- "rayon",
- "rusqlite",
- "sapling-crypto",
- "schemerz",
- "schemerz-rusqlite",
- "secrecy",
- "shardtree",
- "sinsemilla",
- "slipstream-gpuhash",
- "thiserror 2.0.19",
- "tokio",
- "tonic",
- "tonic-prost",
- "tracing",
- "uuid",
- "zcash_address",
- "zcash_client_backend",
- "zcash_client_sqlite",
- "zcash_keys",
- "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
- "zcash_script",
- "zcash_transparent",
- "zip32",
-]
-
-[[package]]
-name = "slipstream-gpuhash"
-version = "0.0.1"
-source = "git+https://github.com/zodl-inc/slipstream-internal.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
-dependencies = [
- "bytemuck",
- "ff",
- "group",
- "pasta_curves",
- "pollster",
- "sinsemilla",
- "wgpu",
-]
 
 [[package]]
 name = "slotmap"
@@ -7123,9 +7069,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d09351e41a71fdad388bd51417e3acc6e7b530ba364dd38296e79bf6ab41f6"
+checksum = "df3e4675e494f06faa7a5e571c69ec9e74142a2d222384696ba3d313a938b11e"
 dependencies = [
  "anyhow",
  "ff",
@@ -7140,9 +7086,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4406af8a4eedbc0cdedb94d4dba44dd402f229c48d982c2e7e59155edd213b8b"
+checksum = "ab9bf6de4d2870aff92b3388df3572d186b1bf64fda3cee623e220d3874f7665"
 dependencies = [
  "base64",
  "ff",
@@ -8270,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347b11528e9960a4ba868483f3e12b1306a3ae59d44fe40978185a2914f915dc"
+checksum = "dcb38f2178857e07f0d832c701ee0fb5b752660a12ccc89df3efcae6a5ee8c42"
 dependencies = [
  "anyhow",
  "base64",
@@ -8494,3 +8440,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "slipstream-core"
+version = "0.6.4"
+source = "git+https://github.com/zodl-inc/slipstream-internal.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Zcash voting
-zcash_voting = { version = "2.0.0-rc.3" }
+zcash_voting = { version = "=2.0.0-rc.5" }
 zeroize = "1"
 
 # Used by the pool-migration engine as well as by voting.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,31 @@
 # Migrating from previous versions to _Unreleased_
 
+## Voting wire payloads are produced by `zcash_voting`, not by the SDK
+
+`VotingSharePayload` is removed and `VotingVoteCommit.sharePayloads` is gone with it. Helper-server
+payloads are now obtained after confirmation, one per share index:
+
+```swift
+let bundle = try backend.getCommitmentBundle(
+    roundId: roundId, bundleIndex: bundleIndex, proposalId: proposalId
+)
+let payload = try VotingRustBackend.recoverWireJson(
+    commitmentBundleJson: bundle!.bundleJson,
+    proposalId: proposalId,
+    shareIndex: shareIndex,
+    voteCommitmentTreePosition: confirmation.voteCommitmentTreePosition,
+    submitAt: submitAt
+)
+```
+
+`payload` is the helper request body verbatim — do not decode, re-shape or re-encode it.
+
+`VotingDelegationSubmission` and `VotingWireEncryptedShare` are now decoded from the crate's own
+wire structs, so their byte fields are base64 `String`s rather than `[UInt8]`, `sighash` is gone
+from the delegation submission (the vote chain derives the signing digest itself), and
+`tx1Effects` is present. A host that base64-encoded these fields itself before putting them on the
+wire must stop and send the strings as they arrive.
+
 ## The SDK-side migration state machine is removed — `migrationAdvanceStep` replaces it
 
 The public 5-state `MigrationState` enum, `MigrationAttentionReason`, and

--- a/Sources/ZcashLightClientKit/Block/Actions/ValidateServerAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/ValidateServerAction.swift
@@ -22,10 +22,6 @@ final class ValidateServerAction {
 }
 
 extension ValidateServerAction: Action {
-    /// The consensus branch ID of NU6.3 ("Ironwood"). When the chain is on this branch, the
-    /// connected server must serve Ironwood data — see the tree-state check in `run` below.
-    static let nu63ConsensusBranchID: ConsensusBranchID = 0x37a5_165b
-
     var removeBlocksCacheWhenFailed: Bool { false }
 
     func run(with context: ActionContext, didUpdate: @escaping (CompactBlockProcessor.Event) async -> Void) async throws -> ActionContext {
@@ -82,7 +78,7 @@ extension ValidateServerAction: Action {
             //
             // A custom network reports a nonstandard branch id that can never equal the NU6.3 one, so
             // this probe belongs with the other branch-id-derived checks it is gated behind.
-            if remoteBranchID == Self.nu63ConsensusBranchID {
+            if remoteBranchID == ZcashSDK.nu63ConsensusBranchID {
                 var tipBlock = BlockID()
                 tipBlock.height = info.blockHeight
                 let treeState = try await service.getTreeState(tipBlock, mode: await sdkFlags.ifTor(.defaultTor))

--- a/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
+++ b/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
@@ -138,6 +138,16 @@ class ZcashRegtest: ZcashNetwork {
 Constants of ZcashLightClientKit. this constants don't
 */
 public enum ZcashSDK {
+    /// The consensus branch ID of NU6.3 ("Ironwood").
+    ///
+    /// Published so hosts that must name the active consensus era read it from
+    /// the SDK instead of hardcoding the literal. The voting stack is the case
+    /// that forced this: `zcash_voting` rejects a delegation built for any other
+    /// branch, so a stale hardcoded era does not degrade — every delegation fails
+    /// at construction. A constant that moves with the SDK cannot go stale
+    /// silently at the next network upgrade the way a copied literal does.
+    public static let nu63ConsensusBranchID: ConsensusBranchID = 0x37a5_165b
+
     /// The number of zatoshi that equal 1 ZEC.
     public static let zatoshiPerZEC: BlockHeight = 100_000_000
 

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -135,12 +135,17 @@ extension VotingRustBackend {
     /// `pirEndpoints` are probed in parallel via `pirResolver`. The first
     /// endpoint whose served snapshot height equals `expectedSnapshotHeight`
     /// exactly is used. See `PirSnapshotResolver` for the failure semantics.
+    ///
+    /// `pirLayout` must come from the round's resolved dynamic voting config.
+    /// `zcash_voting` fails the config/server layout handshake closed before any
+    /// private query, and rejects the `.unknown` default outright.
     public func precomputeDelegationPir(
         roundId: String,
         bundleIndex: UInt32,
         notes: [VotingNoteInfo],
         pirEndpoints: [String],
         expectedSnapshotHeight: UInt64,
+        pirLayout: VotingPirLayout = .unknown,
         pirResolver: PirSnapshotResolver = PirSnapshotResolver()
     ) async throws -> VotingDelegationPirPrecomputeResult {
         try requireOpenDatabase()
@@ -170,7 +175,10 @@ extension VotingRustBackend {
                             notesBuf.baseAddress,
                             UInt(notesBuf.count),
                             urlBuf.baseAddress,
-                            UInt(urlBuf.count)
+                            UInt(urlBuf.count),
+                            pirLayout.pirDepth,
+                            pirLayout.tier0Layers,
+                            pirLayout.tier1Layers
                         )
                     }
                 }
@@ -1523,6 +1531,7 @@ extension VotingRustBackend {
         _ params: VotingDelegationProofParams,
         pirEndpoints: [String],
         expectedSnapshotHeight: UInt64,
+        pirLayout: VotingPirLayout = .unknown,
         pirResolver: PirSnapshotResolver = PirSnapshotResolver(),
         progress: (@Sendable (Double) -> Void)? = nil
     ) async throws -> VotingDelegationProofResult {
@@ -1547,6 +1556,7 @@ extension VotingRustBackend {
             try syncBuildAndProveDelegation(
                 params,
                 pirServerUrl: pirServerUrl,
+                pirLayout: pirLayout,
                 progress: progress
             )
         }.value
@@ -1789,6 +1799,7 @@ private extension VotingRustBackend {
     func syncBuildAndProveDelegation(
         _ params: VotingDelegationProofParams,
         pirServerUrl: String,
+        pirLayout: VotingPirLayout,
         progress: (@Sendable (Double) -> Void)?
     ) throws -> VotingDelegationProofResult {
         let keys = params.keys
@@ -1833,6 +1844,9 @@ private extension VotingRustBackend {
                                             UInt(nameBuf.count),
                                             urlBuf.baseAddress,
                                             UInt(urlBuf.count),
+                                            pirLayout.pirDepth,
+                                            pirLayout.tier0Layers,
+                                            pirLayout.tier1Layers,
                                             trampoline,
                                             progressContext
                                         )

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -690,8 +690,11 @@ extension VotingRustBackend {
         }
     }
 
-    /// Extract the 32-byte Orchard note-commitment-tree root from a
+    /// Extract the 32-byte Ironwood note-commitment-tree root from a
     /// protobuf-encoded `TreeState`.
+    ///
+    /// Voting rounds anchor to the Ironwood pool, so a round's `nc_root` is the
+    /// Ironwood tree's root at the snapshot height — not the Orchard tree's.
     public static func extractNcRoot(treeState: [UInt8]) throws -> [UInt8] {
         try staticBoxedSliceFFI(fallback: "`extract_nc_root` failed") {
             treeState.withUnsafeBufferPointer { buf in

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -414,6 +414,63 @@ extension VotingRustBackend {
             }
         }
     }
+
+    /// Record a confirmed cast-vote transaction in one atomic step.
+    ///
+    /// `zcash_voting` parses the confirmation events, records the transaction
+    /// hash, advances the vote-authority-note position and records the
+    /// vote-commitment tree position inside a single database transaction, then
+    /// returns both positions. Callers must not parse the events themselves:
+    /// splitting the `leaf_index` attribute by hand is exactly the duplicated
+    /// state this entry point exists to delete.
+    ///
+    /// `eventsJson` is the confirmation-events array the wallet's chain client
+    /// already fetches, serialized as JSON — a list of
+    /// `{"type": …, "attributes": [{"key": …, "value": …}]}` objects.
+    ///
+    /// Repeating the call with the same transaction hash and position is
+    /// accepted; a stale confirmation cannot rewind a position that a later one
+    /// already advanced.
+    public func confirmVoteSubmission(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        txHash: String,
+        eventsJson: String
+    ) throws -> VotingVoteConfirmation {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let txHashBytes = [UInt8](txHash.utf8)
+        let eventsBytes = [UInt8](eventsJson.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                txHashBytes.withUnsafeBufferPointer { txBuf in
+                    eventsBytes.withUnsafeBufferPointer { evBuf in
+                        zcashlc_voting_confirm_vote_submission(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            proposalId,
+                            txBuf.baseAddress,
+                            UInt(txBuf.count),
+                            evBuf.baseAddress,
+                            UInt(evBuf.count)
+                        )
+                    }
+                }
+            }
+
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`confirm_vote_submission` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
 }
 
 // MARK: - Share tracking (static)
@@ -460,6 +517,46 @@ extension VotingRustBackend {
         }
         defer { zcashlc_string_free(ptr) }
         return String(cString: ptr)
+    }
+
+    /// Rebuild one helper-server share payload as `zcash_voting`'s own wire JSON.
+    ///
+    /// The crate parses the persisted recovery bundle, selects the requested
+    /// share, late-binds the confirmed vote-commitment-tree position and the
+    /// scheduled submission time, and serializes the payload itself. Nothing is
+    /// re-proved and nothing is committed a second time.
+    ///
+    /// - Parameters:
+    ///   - commitmentBundleJson: ``VotingStoredCommitmentBundle/bundleJson`` from
+    ///     `getCommitmentBundle(roundId:bundleIndex:proposalId:)`.
+    ///   - voteCommitmentTreePosition: the confirmed position, from
+    ///     ``VotingVoteConfirmation/voteCommitmentTreePosition``.
+    /// - Returns: the helper request body. POST it verbatim; do not decode,
+    ///   re-shape or re-encode it.
+    /// - Throws: `VotingRustBackendError.rustError` if the bundle JSON is
+    ///   malformed, its proposal does not match `proposalId`, or the share index
+    ///   is not present in it.
+    public static func recoverWireJson(
+        commitmentBundleJson: String,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        voteCommitmentTreePosition: UInt64,
+        submitAt: UInt64
+    ) throws -> String {
+        let bundleBytes = [UInt8](commitmentBundleJson.utf8)
+        let payload = try staticBoxedSliceFFI(fallback: "`recover_wire_json` failed") {
+            bundleBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_recover_wire_json(
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    proposalId,
+                    shareIndex,
+                    voteCommitmentTreePosition,
+                    submitAt
+                )
+            }
+        }
+        return String(decoding: payload, as: UTF8.self)
     }
 }
 

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1532,6 +1532,101 @@ extension VotingRustBackend {
         }
     }
 
+    /// Sign one delegation bundle's PCZT sighash with this account's own Orchard
+    /// SpendAuth key.
+    ///
+    /// `zcash_voting` 2.0 stopped deriving account keys and signing for its
+    /// callers, and prescribes this replacement for software wallets: load the
+    /// bundle's signing request (account index, network, seed fingerprint,
+    /// sighash and spend-auth randomizer), derive the account SpendAuth key from
+    /// the wallet seed, randomize it with the randomizer, and sign the sighash.
+    /// All of that happens in Rust — the seed goes in, only the detached
+    /// signature comes back out.
+    ///
+    /// This is the software counterpart of the Keystone flow: there, the device
+    /// produces the signature and the app extracts it from the signed PCZT; here
+    /// the wallet produces it itself. Both then call the same
+    /// ``getDelegationSubmission(roundId:bundleIndex:signature:sighash:)``,
+    /// which is the only remaining path into a submission payload.
+    ///
+    /// - Parameters:
+    ///   - keys: the same ``VotingDelegationKeyInputs`` used to build and prove
+    ///     this bundle. The crate loads the signing request through them, so a
+    ///     different account index, hotkey secret or seed fingerprint fails
+    ///     instead of silently signing for the wrong account.
+    ///   - seed: the wallet's root seed, at least 32 bytes. It is borrowed for
+    ///     the duration of this call, is never persisted or logged, and must be
+    ///     the seed whose fingerprint is in `keys` — a mismatch throws rather
+    ///     than producing a signature the chain would reject.
+    /// - Returns: the detached 64-byte SpendAuth signature and the 32-byte
+    ///   ZIP-244 sighash it covers. Pass both to `getDelegationSubmission`
+    ///   unchanged.
+    /// - Throws: ``VotingRustBackendError/databaseNotOpen`` if no database is
+    ///   open; ``VotingRustBackendError/invalidData`` if `seed` or the seed
+    ///   fingerprint is the wrong length; ``VotingRustBackendError/rustError``
+    ///   if the bundle has no stored signing request yet (its PCZT setup has not
+    ///   run), or the seed does not match the request.
+    public func signDelegationRequest(
+        roundId: String,
+        bundleIndex: UInt32,
+        keys: VotingDelegationKeyInputs,
+        seed: [UInt8]
+    ) throws -> VotingDelegationSignature {
+        guard keys.seedFingerprint.count == votingSeedFingerprintByteCount else {
+            throw VotingRustBackendError.invalidData(
+                "seedFingerprint must be exactly \(votingSeedFingerprintByteCount) bytes"
+            )
+        }
+        guard seed.count >= votingMinSeedByteCount else {
+            throw VotingRustBackendError.invalidData(
+                "seed must be at least \(votingMinSeedByteCount) bytes"
+            )
+        }
+
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let roundNameBytes = [UInt8](keys.roundName.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                keys.fvk.withUnsafeBufferPointer { fvkBuf in
+                    keys.hotkeyStoredSecret.withUnsafeBufferPointer { secretBuf in
+                        keys.seedFingerprint.withUnsafeBufferPointer { fpBuf in
+                            roundNameBytes.withUnsafeBufferPointer { nameBuf in
+                                seed.withUnsafeBufferPointer { seedBuf in
+                                    zcashlc_voting_sign_delegation_request(
+                                        dbh,
+                                        ridBuf.baseAddress,
+                                        UInt(ridBuf.count),
+                                        bundleIndex,
+                                        fvkBuf.baseAddress,
+                                        UInt(fvkBuf.count),
+                                        secretBuf.baseAddress,
+                                        UInt(secretBuf.count),
+                                        fpBuf.baseAddress,
+                                        UInt(fpBuf.count),
+                                        keys.accountIndex,
+                                        nameBuf.baseAddress,
+                                        UInt(nameBuf.count),
+                                        seedBuf.baseAddress,
+                                        UInt(seedBuf.count)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`sign_delegation_request` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
     /// Get the delegation submission payload for an externally produced
     /// signature.
     ///

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -558,6 +558,37 @@ extension VotingRustBackend {
         }
         return String(decoding: payload, as: UTF8.self)
     }
+
+    /// List the share indices recoverable from a persisted vote recovery bundle.
+    ///
+    /// The crate parses the bundle and applies its own single-share slicing
+    /// (one share when the vote was single-share, all of them otherwise);
+    /// this reads off each recovered payload's own share index. Crash
+    /// recovery calls this instead of guessing a share count from
+    /// `singleShare` alone (`singleShare ? 1 : numOptions`), so a caller-side
+    /// guess can never under- or over-deliver relative to what the crate
+    /// actually reconstructs.
+    ///
+    /// - Parameter commitmentBundleJson: ``VotingStoredCommitmentBundle/bundleJson``
+    ///   from `getCommitmentBundle(roundId:bundleIndex:proposalId:)`.
+    /// - Returns: the recoverable share indices, in the crate's own order.
+    /// - Throws: `VotingRustBackendError.rustError` if the bundle JSON is
+    ///   malformed or its vote fields are out of range.
+    public static func recoverableShareIndices(
+        commitmentBundleJson: String
+    ) throws -> [UInt32] {
+        let bundleBytes = [UInt8](commitmentBundleJson.utf8)
+        let ptr = bundleBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_recoverable_share_indices(buf.baseAddress, UInt(buf.count))
+        }
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`recoverable_share_indices` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try staticDecodeJSON(from: ptr)
+    }
 }
 
 // MARK: - Foundation helpers (static)

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -592,3 +592,27 @@ public struct VotingPirLayout: Equatable, Sendable {
         self.tier1Layers = tier1Layers
     }
 }
+
+// MARK: - Vote confirmation (JSON)
+
+/// The positions a mined cast-vote transaction confirmed.
+///
+/// Decoded from `zcash_voting::wire::VoteConfirmation`. Both positions are read
+/// out of the chain's confirmation events by the crate, which also writes them
+/// to the voting database in the same transaction that returns them — so this
+/// value and the persisted state can never disagree.
+public struct VotingVoteConfirmation: Codable, Sendable, Equatable {
+    /// The confirmed transaction hash, echoed back from the events.
+    public let txHash: String
+    /// Confirmed vote-authority-note leaf position.
+    public let vanLeafPosition: UInt32
+    /// Confirmed position of the vote commitment within the vote commitment
+    /// tree. This is the value to late-bind into helper-share payloads.
+    public let voteCommitmentTreePosition: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case txHash = "tx_hash"
+        case vanLeafPosition = "van_leaf_position"
+        case voteCommitmentTreePosition = "vc_tree_position"
+    }
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -267,26 +267,38 @@ public struct VotingDelegationPirPrecomputeResult: Codable, Sendable {
 
 // MARK: - Delegation Submission (JSON)
 
-/// Delegation submission payload.
+/// The chain-ready delegation submission body, in `zcash_voting`'s own wire
+/// encoding.
+///
+/// The FFI returns `zcash_voting::wire::DelegationSubmissionWire` serialized by
+/// the crate, so the field names and the base64 encoding are the crate's and the
+/// SDK reshapes nothing. Two consequences for callers: `tx1Effects` — the
+/// versioned Ironwood TX1 effecting data the vote chain requires, and whose
+/// absence is the `400: tx1 effects must be 821 bytes, got 0` rejection — is
+/// present without anyone assembling it, and the legacy `sighash` field is gone
+/// from the wire. The signer's sighash still exists; it simply never belonged in
+/// the submission body, because the server derives the signing digest itself.
 public struct VotingDelegationSubmission: Codable, Sendable {
-    /// Randomized verification key (`rk` on the wire).
-    public let randomizedKey: [UInt8]
-    public let spendAuthSig: [UInt8]
-    public let sighash: [UInt8]
-    public let nfSigned: [UInt8]
-    public let cmxNew: [UInt8]
-    public let govComm: [UInt8]
-    public let govNullifiers: [[UInt8]]
-    public let proof: [UInt8]
+    /// Randomized verification key (`rk` on the wire), base64.
+    public let randomizedKey: String
+    /// SpendAuth signature over the PCZT sighash, base64.
+    public let spendAuthSig: String
+    /// Versioned Ironwood TX1 effecting data, base64 (821 bytes decoded).
+    public let tx1Effects: String
+    public let nfSigned: String
+    public let cmxNew: String
+    public let govComm: String
+    public let govNullifiers: [String]
+    public let proof: String
     public let voteRoundId: String
 
     enum CodingKeys: String, CodingKey {
         case randomizedKey = "rk"
         case spendAuthSig = "spend_auth_sig"
-        case sighash
-        case nfSigned = "nf_signed"
+        case tx1Effects = "tx1_effects"
+        case nfSigned = "signed_note_nullifier"
         case cmxNew = "cmx_new"
-        case govComm = "gov_comm"
+        case govComm = "van_cmx"
         case govNullifiers = "gov_nullifiers"
         case proof
         case voteRoundId = "vote_round_id"
@@ -295,13 +307,19 @@ public struct VotingDelegationSubmission: Codable, Sendable {
 
 // MARK: - Vote Commit (JSON)
 
-/// Everything produced by committing one cast vote: the signed commitment
-/// fields destined for the vote chain, the encrypted shares the vote proof
-/// binds, and the helper-server payloads derived from them.
+/// The result of committing one cast vote: the signed commitment fields destined
+/// for the vote chain, and the encrypted shares the vote proof binds.
 ///
-/// Every field here is wire data — it is published on chain or sent to helper
-/// servers — so the commit result carries no secret the wallet must retain. The
-/// signing secrets used to produce it stay inside `zcash_voting`.
+/// Helper-server payloads are deliberately not here. A commit made before the
+/// vote's tree position is confirmed can only produce provisional payloads, and
+/// sending those is the bug the sequence in `CHP_DESIGN.md` §3/A2 exists to
+/// prevent. Build helper payloads with
+/// ``VotingRustBackend/recoverWireJson(commitmentBundleJson:proposalId:shareIndex:voteCommitmentTreePosition:submitAt:)``
+/// after ``VotingRustBackend/confirmVoteSubmission(roundId:bundleIndex:proposalId:txHash:eventsJson:)``.
+///
+/// Every field here is wire data — it is published on chain — so the commit
+/// result carries no secret the wallet must retain. The signing secrets used to
+/// produce it stay inside `zcash_voting`.
 public struct VotingVoteCommit: Codable, Sendable {
     public let proposalId: UInt32
     public let vanNullifier: [UInt8]
@@ -313,7 +331,6 @@ public struct VotingVoteCommit: Codable, Sendable {
     public let voteKeyRandomizer: [UInt8]
     public let voteAuthSig: [UInt8]
     public let encShares: [VotingWireEncryptedShare]
-    public let sharePayloads: [VotingSharePayload]
 
     enum CodingKeys: String, CodingKey {
         case proposalId = "proposal_id"
@@ -325,19 +342,22 @@ public struct VotingVoteCommit: Codable, Sendable {
         case voteKeyRandomizer = "r_vpk"
         case voteAuthSig = "vote_auth_sig"
         case encShares = "enc_shares"
-        case sharePayloads = "share_payloads"
     }
 }
 
 // MARK: - Wire Encrypted Share (JSON)
 
-/// Wire-safe encrypted share — contains only the public ciphertext components.
-/// Secrets (plaintextValue, randomness) stay inside Rust and never cross the FFI boundary.
+/// Wire-safe encrypted share — only the public ciphertext components.
+///
+/// Decoded straight from `zcash_voting::types::WireEncryptedShare`, which
+/// base64-encodes both ciphertext components, so `ciphertext1` and `ciphertext2`
+/// are base64 strings rather than byte arrays. Secrets (`plaintext_value`,
+/// `randomness`) stay inside Rust and never cross the FFI boundary.
 public struct VotingWireEncryptedShare: Codable, Sendable {
-    /// First ciphertext component (`c1` on the wire).
-    public let ciphertext1: [UInt8]
-    /// Second ciphertext component (`c2` on the wire).
-    public let ciphertext2: [UInt8]
+    /// First ciphertext component (`c1` on the wire), base64.
+    public let ciphertext1: String
+    /// Second ciphertext component (`c2` on the wire), base64.
+    public let ciphertext2: String
     public let shareIndex: UInt32
 
     enum CodingKeys: String, CodingKey {
@@ -346,35 +366,10 @@ public struct VotingWireEncryptedShare: Codable, Sendable {
         case shareIndex = "share_index"
     }
 
-    public init(ciphertext1: [UInt8], ciphertext2: [UInt8], shareIndex: UInt32) {
+    public init(ciphertext1: String, ciphertext2: String, shareIndex: UInt32) {
         self.ciphertext1 = ciphertext1
         self.ciphertext2 = ciphertext2
         self.shareIndex = shareIndex
-    }
-}
-
-// MARK: - Share Payload (JSON)
-
-/// Share payload for delegated share submission.
-public struct VotingSharePayload: Codable, Sendable {
-    public let sharesHash: [UInt8]
-    public let proposalId: UInt32
-    public let voteDecision: UInt32
-    public let encShare: VotingWireEncryptedShare
-    public let treePosition: UInt64
-    public let allEncShares: [VotingWireEncryptedShare]
-    public let shareComms: [[UInt8]]
-    public let primaryBlind: [UInt8]
-
-    enum CodingKeys: String, CodingKey {
-        case sharesHash = "shares_hash"
-        case proposalId = "proposal_id"
-        case voteDecision = "vote_decision"
-        case encShare = "enc_share"
-        case treePosition = "tree_position"
-        case allEncShares = "all_enc_shares"
-        case shareComms = "share_comms"
-        case primaryBlind = "primary_blind"
     }
 }
 

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -616,3 +616,26 @@ public struct VotingVoteConfirmation: Codable, Sendable, Equatable {
         case voteCommitmentTreePosition = "vc_tree_position"
     }
 }
+
+// MARK: - Delegation signature (JSON)
+
+/// A SpendAuth signature this wallet produced for one delegation bundle, with
+/// the sighash it covers.
+///
+/// Both values go straight into
+/// ``VotingRustBackend/getDelegationSubmission(roundId:bundleIndex:signature:sighash:)``.
+/// The sighash is not informational: `zcash_voting` checks it against the one it
+/// stored when the bundle's PCZT was set up and rejects the submission if they
+/// disagree, so pass back the value that came out with the signature rather than
+/// one recomputed elsewhere.
+public struct VotingDelegationSignature: Codable, Sendable, Equatable {
+    /// The 64-byte detached RedPallas SpendAuth signature.
+    public let signature: [UInt8]
+    /// The 32-byte ZIP-244 sighash the signature covers.
+    public let sighash: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case signature = "sig"
+        case sighash
+    }
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -566,3 +566,34 @@ public struct VotingStoredCommitmentBundle: Sendable, Equatable {
     /// Position of the vote commitment within the vote commitment tree.
     public let voteCommitmentTreePosition: UInt64
 }
+
+// MARK: - PIR layout
+
+/// PIR tree geometry advertised by the round's resolved dynamic voting config.
+///
+/// Mirrors `zcash_voting::config::PirLayout` field for field. `zcash_voting`
+/// runs the config/server layout handshake with these values and fails closed
+/// before issuing any private query when the server disagrees, so they must come
+/// from a resolved dynamic config rather than being assumed or compiled in.
+public struct VotingPirLayout: Equatable, Sendable {
+    public let pirDepth: UInt32
+    public let tier0Layers: UInt32
+    public let tier1Layers: UInt32
+
+    /// The crate's `PirLayout::UNKNOWN` sentinel, and its `Default`.
+    ///
+    /// `zcash_voting` rejects it — "pir_layout is unknown; resolve a current
+    /// dynamic voting config first" — so this is a fail-closed placeholder for
+    /// callers that have not resolved a config yet, never a usable layout.
+    public static let unknown = VotingPirLayout(
+        pirDepth: 0,
+        tier0Layers: 0,
+        tier1Layers: 0
+    )
+
+    public init(pirDepth: UInt32, tier0Layers: UInt32, tier1Layers: UInt32) {
+        self.pirDepth = pirDepth
+        self.tier0Layers = tier0Layers
+        self.tier1Layers = tier1Layers
+    }
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -278,6 +278,10 @@ public struct VotingDelegationPirPrecomputeResult: Codable, Sendable {
 /// present without anyone assembling it, and the legacy `sighash` field is gone
 /// from the wire. The signer's sighash still exists; it simply never belonged in
 /// the submission body, because the server derives the signing digest itself.
+///
+/// Mirrors `zcash_voting::wire::DelegationSubmissionWire` (crate `src/wire.rs`);
+/// the `CodingKeys` carry the crate's serde field names where the Swift names
+/// differ (`signed_note_nullifier`, `van_cmx`).
 public struct VotingDelegationSubmission: Codable, Sendable {
     /// Randomized verification key (`rk` on the wire), base64.
     public let randomizedKey: String
@@ -311,15 +315,20 @@ public struct VotingDelegationSubmission: Codable, Sendable {
 /// for the vote chain, and the encrypted shares the vote proof binds.
 ///
 /// Helper-server payloads are deliberately not here. A commit made before the
-/// vote's tree position is confirmed can only produce provisional payloads, and
-/// sending those is the bug the sequence in `CHP_DESIGN.md` §3/A2 exists to
-/// prevent. Build helper payloads with
+/// vote's tree position is confirmed can only produce provisional payloads,
+/// and provisional payloads must never be sent to a helper server. Build
+/// helper payloads with
 /// ``VotingRustBackend/recoverWireJson(commitmentBundleJson:proposalId:shareIndex:voteCommitmentTreePosition:submitAt:)``
 /// after ``VotingRustBackend/confirmVoteSubmission(roundId:bundleIndex:proposalId:txHash:eventsJson:)``.
 ///
 /// Every field here is wire data — it is published on chain — so the commit
 /// result carries no secret the wallet must retain. The signing secrets used to
 /// produce it stay inside `zcash_voting`.
+///
+/// Mirrors the FFI's `JsonVoteCommit` (`rust/src/voting/json.rs`), the JSON
+/// shape of `zcash_voting::vote::VoteCommit` (crate `src/vote.rs`) minus its
+/// provisional `share_payloads`; the `CodingKeys` carry that JSON's field
+/// names (`r_vpk`, `enc_shares`) where the Swift names differ.
 public struct VotingVoteCommit: Codable, Sendable {
     public let proposalId: UInt32
     public let vanNullifier: [UInt8]

--- a/Tests/OfflineTests/VotingConfirmVoteSubmissionTests.swift
+++ b/Tests/OfflineTests/VotingConfirmVoteSubmissionTests.swift
@@ -1,0 +1,100 @@
+//
+//  VotingConfirmVoteSubmissionTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+/// Builds a round identifier that satisfies the Rust round-parameter validation,
+/// which requires 64 lowercase hex characters encoding a canonical Pallas field
+/// element. `tag` occupies the low byte so each caller gets a distinct round.
+private func hexRoundId(_ tag: UInt8) -> String {
+    String(format: "%02x", tag) + String(repeating: "00", count: 31)
+}
+
+private let confirmWalletId = "test-wallet"
+private let confirmNetworkId: UInt32 = 1
+/// A well-formed round identifier that is never initialized, so the crate has no
+/// vote row to confirm against.
+private let confirmMissingRoundId = hexRoundId(0xfd)
+private let confirmTxHash = "vote-tx-hash"
+/// One well-formed `cast_vote` event, shaped exactly as
+/// `Vec<zcash_voting::confirmation::TxEvent>` deserializes it. The FFI must hand
+/// it to the crate unparsed — the SDK never splits `leaf_index` itself.
+private let confirmEventsJson = """
+[{"type":"cast_vote","attributes":[\
+{"key":"vote_round_id","value":"\(confirmMissingRoundId)"},\
+{"key":"leaf_index","value":"7,42"}]}]
+"""
+
+final class VotingConfirmVoteSubmissionTests: XCTestCase {
+    private var dbPath: String?
+
+    override func tearDown() {
+        if let dbPath {
+            try? FileManager.default.removeItem(atPath: dbPath)
+        }
+        dbPath = nil
+        super.tearDown()
+    }
+
+    func test_confirmVoteSubmission_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+
+        XCTAssertThrowsError(
+            try backend.confirmVoteSubmission(
+                roundId: confirmMissingRoundId,
+                bundleIndex: 0,
+                proposalId: 1,
+                txHash: confirmTxHash,
+                eventsJson: confirmEventsJson
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+
+    func test_confirmVoteSubmission_afterOpen_missingVote_throwsRustError() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.confirmVoteSubmission(
+                roundId: confirmMissingRoundId,
+                bundleIndex: 0,
+                proposalId: 1,
+                txHash: confirmTxHash,
+                eventsJson: confirmEventsJson
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("confirm_vote_submission failed"),
+                "unexpected message: \(message)"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDbPath() -> String {
+        let unique = ProcessInfo.processInfo.globallyUniqueString
+        let path = "\(NSTemporaryDirectory())VotingConfirmVoteSubmissionTests-\(unique).sqlite"
+        dbPath = path
+        return path
+    }
+
+    private func makeOpenBackend() throws -> VotingRustBackend {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath(), networkId: confirmNetworkId)
+        try backend.setWalletId(confirmWalletId)
+        return backend
+    }
+}

--- a/Tests/OfflineTests/VotingRecoverWireJsonTests.swift
+++ b/Tests/OfflineTests/VotingRecoverWireJsonTests.swift
@@ -1,0 +1,56 @@
+//
+//  VotingRecoverWireJsonTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+private let recoverProposalId: UInt32 = 1
+private let recoverShareIndex: UInt32 = 0
+private let recoverConfirmedPosition: UInt64 = 999
+private let recoverSubmitAt: UInt64 = 123
+
+final class VotingRecoverWireJsonTests: XCTestCase {
+    func test_recoverWireJson_malformedBundleJson_throwsRustError() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.recoverWireJson(
+                commitmentBundleJson: "not json",
+                proposalId: recoverProposalId,
+                shareIndex: recoverShareIndex,
+                voteCommitmentTreePosition: recoverConfirmedPosition,
+                submitAt: recoverSubmitAt
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("recover_wire_json failed"),
+                "unexpected message: \(message)"
+            )
+        }
+    }
+
+    func test_recoverWireJson_emptyBundleJson_throwsRustError() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.recoverWireJson(
+                commitmentBundleJson: "",
+                proposalId: recoverProposalId,
+                shareIndex: recoverShareIndex,
+                voteCommitmentTreePosition: recoverConfirmedPosition,
+                submitAt: recoverSubmitAt
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("recover_wire_json failed"),
+                "unexpected message: \(message)"
+            )
+        }
+    }
+}

--- a/Tests/OfflineTests/VotingSignDelegationRequestTests.swift
+++ b/Tests/OfflineTests/VotingSignDelegationRequestTests.swift
@@ -1,0 +1,132 @@
+//
+//  VotingSignDelegationRequestTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+/// Builds a round identifier that satisfies the Rust round-parameter validation,
+/// which requires 64 lowercase hex characters encoding a canonical Pallas field
+/// element. `tag` occupies the low byte so each caller gets a distinct round.
+private func signHexRoundId(_ tag: UInt8) -> String {
+    String(format: "%02x", tag) + String(repeating: "00", count: 31)
+}
+
+private let signWalletId = "test-wallet"
+private let signNetworkId: UInt32 = 1
+/// A well-formed round identifier that is never initialized, so the crate has no
+/// stored signing request to answer with.
+private let signMissingRoundId = signHexRoundId(0xfc)
+/// Orchard FVK length. The value is never used as a key here: the crate reads
+/// only the account index, seed fingerprint and network out of the delegation
+/// keys when loading a signing request.
+private let signFvk = [UInt8](repeating: 0, count: 96)
+private let signSeedFingerprint = [UInt8](repeating: 7, count: 32)
+private let signSeed = [UInt8](repeating: 9, count: 32)
+private let signRoundName = "chp-offline"
+
+final class VotingSignDelegationRequestTests: XCTestCase {
+    private var dbPath: String?
+
+    override func tearDown() {
+        if let dbPath {
+            try? FileManager.default.removeItem(atPath: dbPath)
+        }
+        dbPath = nil
+        super.tearDown()
+    }
+
+    func test_signDelegationRequest_shortSeed_throwsInvalidData() throws {
+        let backend = VotingRustBackend()
+
+        XCTAssertThrowsError(
+            try backend.signDelegationRequest(
+                roundId: signMissingRoundId,
+                bundleIndex: 0,
+                keys: try makeKeys(),
+                seed: [UInt8](repeating: 9, count: 31)
+            )
+        ) { error in
+            guard case VotingRustBackendError.invalidData(let message) = error else {
+                XCTFail("expected .invalidData, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("seed must be at least"),
+                "unexpected message: \(message)"
+            )
+        }
+    }
+
+    func test_signDelegationRequest_beforeOpen_throwsDatabaseNotOpen() throws {
+        let backend = VotingRustBackend()
+
+        XCTAssertThrowsError(
+            try backend.signDelegationRequest(
+                roundId: signMissingRoundId,
+                bundleIndex: 0,
+                keys: try makeKeys(),
+                seed: signSeed
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+
+    func test_signDelegationRequest_afterOpen_missingRound_throwsRustError() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.signDelegationRequest(
+                roundId: signMissingRoundId,
+                bundleIndex: 0,
+                keys: try makeKeys(),
+                seed: signSeed
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("signing_request failed"),
+                "unexpected message: \(message)"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// A hotkey secret has to be real: the FFI reconstructs a `VotingHotkey`
+    /// from it before it can build the delegation keys the signing request is
+    /// loaded through. `generateHotkey` is static and needs no database.
+    private func makeKeys() throws -> VotingDelegationKeyInputs {
+        let hotkey = try VotingRustBackend.generateHotkey(networkId: signNetworkId)
+        return VotingDelegationKeyInputs(
+            fvk: signFvk,
+            hotkeyStoredSecret: hotkey.storedSecret,
+            seedFingerprint: signSeedFingerprint,
+            accountIndex: 0,
+            roundName: signRoundName
+        )
+    }
+
+    private func makeTempDbPath() -> String {
+        let unique = ProcessInfo.processInfo.globallyUniqueString
+        let path = "\(NSTemporaryDirectory())VotingSignDelegationRequestTests-\(unique).sqlite"
+        dbPath = path
+        return path
+    }
+
+    private func makeOpenBackend() throws -> VotingRustBackend {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath(), networkId: signNetworkId)
+        try backend.setWalletId(signWalletId)
+        return backend
+    }
+}

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -18,6 +18,7 @@ pub mod progress;
 pub mod recovery;
 pub mod rounds;
 pub mod share_tracking;
+pub mod signing;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod tree;

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -6,6 +6,7 @@
 //! `store_commitment_bundle`, `decompose_weight`, `generate_delegation_inputs`)
 //! keep their symbols as honest "superseded" error stubs.
 
+pub mod confirmation;
 mod constants;
 pub mod db;
 pub mod delegation;

--- a/rust/src/voting/confirmation.rs
+++ b/rust/src/voting/confirmation.rs
@@ -1,0 +1,70 @@
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_voting as voting;
+
+use crate::unwrap_exc_or_null;
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
+
+/// Record a confirmed cast-vote transaction in one durable step.
+///
+/// Thin passthrough to `zcash_voting::confirmation::confirm_vote_submission`:
+/// the crate parses the confirmation events, records the transaction hash,
+/// advances the vote-authority-note position and records the vote-commitment
+/// tree position inside a single database transaction, then returns both
+/// positions. The FFI adds no parsing, no phase tracking and no state of its
+/// own — in particular it does not split the `leaf_index` attribute, which is
+/// the crate's job.
+///
+/// `events_json` is the confirmation-events array the wallet's chain client
+/// returned, serialized as JSON: a list of
+/// `{"type": "...", "attributes": [{"key": "...", "value": "..."}]}` objects,
+/// which is exactly `Vec<zcash_voting::confirmation::TxEvent>`.
+///
+/// Returns JSON-encoded `zcash_voting::wire::VoteConfirmation` as
+/// `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - For every `(ptr, len)` byte argument (`round_id`, `tx_hash`,
+///   `events_json`): if `len > 0` then `ptr` must be non-null and valid for
+///   reads for `len` bytes; if `len == 0`, `ptr` is ignored.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_confirm_vote_submission(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    tx_hash: *const u8,
+    tx_hash_len: usize,
+    events_json: *const u8,
+    events_json_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        let events_bytes = unsafe { bytes_from_ptr(events_json, events_json_len) }?;
+        let events: Vec<voting::confirmation::TxEvent> = serde_json::from_slice(events_bytes)?;
+
+        let confirmation = voting::confirmation::confirm_vote_submission(
+            &handle.db,
+            &round_id_str,
+            bundle_index,
+            proposal_id,
+            &tx_hash_str,
+            &events,
+        )
+        .map_err(|e| anyhow!("confirm_vote_submission failed: {}", e))?;
+
+        json_to_boxed_slice(&confirmation)
+    });
+    unwrap_exc_or_null(res)
+}

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -23,8 +23,8 @@ use super::helpers::{
     voting_network,
 };
 use super::json::{
-    JsonDelegationPirPrecomputeResult, JsonDelegationProofResult, JsonDelegationSubmission,
-    JsonNoteInfo, JsonVotingPczt, JsonWitnessData,
+    JsonDelegationPirPrecomputeResult, JsonDelegationProofResult, JsonNoteInfo, JsonVotingPczt,
+    JsonWitnessData,
 };
 use super::progress::ProgressBridge;
 
@@ -616,7 +616,10 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
 /// wallet itself. The dropped seed-derived entry point therefore has no
 /// replacement, and `sender_seed`, `network_id` and `account_index` are gone.
 ///
-/// Returns JSON-encoded `DelegationSubmission` as `*mut FfiBoxedSlice`, or null on error.
+/// Returns `zcash_voting`'s own `wire::DelegationSubmissionWire` JSON as
+/// `*mut FfiBoxedSlice`, or null on error. The crate serializes it, so the
+/// field names, the base64 encoding and the Ironwood `tx1_effects` blob are
+/// the crate's and are never reshaped here.
 ///
 /// # Safety
 ///
@@ -640,18 +643,17 @@ pub unsafe extern "C" fn zcashlc_voting_get_delegation_submission_with_signature
         let sig_bytes = unsafe { bytes_from_ptr(sig, sig_len) }?;
         let sighash_bytes = unsafe { bytes_from_ptr(sighash, sighash_len) }?;
 
-        let submission = handle
-            .db
-            .get_delegation_submission_with_signature(
-                &round_id_str,
-                bundle_index,
-                sig_bytes,
-                sighash_bytes,
-            )
-            .map_err(|e| anyhow!("get_delegation_submission_with_signature failed: {}", e))?;
+        let signer =
+            voting::delegate::DelegationSigner::signature_from_bytes(sig_bytes, sighash_bytes)
+                .map_err(|e| anyhow!("invalid delegation signature material: {}", e))?;
+        let submission =
+            voting::delegate::submission(&handle.db, &round_id_str, bundle_index, signer)
+                .map_err(|e| anyhow!("delegate::submission failed: {}", e))?;
 
-        let json_sub: JsonDelegationSubmission = submission.into();
-        json_to_boxed_slice(&json_sub)
+        let wire_json = submission
+            .to_wire_json()
+            .map_err(|e| anyhow!("serialize delegation submission wire JSON failed: {}", e))?;
+        Ok(crate::ffi::BoxedSlice::some(wire_json.into_bytes()))
     });
     unwrap_exc_or_null(res)
 }

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -4,10 +4,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use ff::PrimeField;
 use ffi_helpers::panic::catch_panic;
-use incrementalmerkletree::Position;
 use pasta_curves::pallas;
-use prost::Message;
-use zcash_client_backend::proto::service::TreeState;
 use zcash_voting::{self as voting, zkp1};
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
@@ -27,35 +24,6 @@ use super::json::{
     JsonWitnessData,
 };
 use super::progress::ProgressBridge;
-
-/// Validate that a cached lightwalletd `TreeState` is anchored to the voting
-/// round it will be used for.
-///
-/// Witness generation trusts the cached Orchard frontier as the historical
-/// checkpoint input. The generated Merkle path can verify against that
-/// frontier's own root, so we must also enforce that the frontier is exactly
-/// the round snapshot: same block height and same note commitment tree root.
-fn validate_cached_tree_state_for_round(
-    tree_state: &TreeState,
-    orchard_root: &[u8],
-    params: &voting::VotingRoundParams,
-) -> anyhow::Result<()> {
-    if tree_state.height != params.snapshot_height {
-        return Err(anyhow!(
-            "cached TreeState height {} does not match round snapshot_height {}",
-            tree_state.height,
-            params.snapshot_height
-        ));
-    }
-
-    if orchard_root != params.nc_root.as_slice() {
-        return Err(anyhow!(
-            "cached TreeState orchard root does not match round nc_root"
-        ));
-    }
-
-    Ok(())
-}
 
 // =============================================================================
 // VotingDatabase methods — Delegation proof
@@ -274,6 +242,12 @@ pub unsafe extern "C" fn zcashlc_voting_store_tree_state(
 /// Generate Merkle inclusion witnesses for the notes in a bundle and cache
 /// them in the voting DB.
 ///
+/// The witnesses come from the **Ironwood** note-commitment tree. Voting notes
+/// live in the Ironwood pool and a round's `nc_root` is that tree's root at the
+/// snapshot height; `zcash_voting` picks the pool, validates the cached
+/// `TreeState` against the round, and generates the paths. This function only
+/// marshals.
+///
 /// `notes_json` is a JSON-encoded `Vec<NoteInfo>`.
 ///
 /// Returns JSON-encoded `Vec<WitnessData>` as `*mut FfiBoxedSlice`, or null on
@@ -316,90 +290,29 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
         };
         let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
 
-        let (tree_state_bytes, params) = {
-            let wallet_id = handle.db.wallet_id();
-            let conn = handle.db.conn();
-            let tree_state_bytes =
-                voting::storage::queries::load_tree_state(&conn, &round_id_str, &wallet_id)
-                    .map_err(|e| anyhow!("load_tree_state failed: {}", e))?;
-            let params =
-                voting::storage::queries::load_round_params(&conn, &round_id_str, &wallet_id)
-                    .map_err(|e| anyhow!("load_round_params failed: {}", e))?;
-            (tree_state_bytes, params)
-        };
-
-        // Decode the tree state
-        let tree_state = TreeState::decode(tree_state_bytes.as_slice())
-            .map_err(|e| anyhow!("failed to decode TreeState protobuf: {}", e))?;
-        let orchard_ct = tree_state
-            .orchard_tree()
-            .map_err(|e| anyhow!("failed to parse orchard tree from TreeState: {}", e))?;
-        let frontier_root = orchard_ct.root();
-        let frontier_root_bytes = frontier_root.to_bytes();
-        validate_cached_tree_state_for_round(&tree_state, &frontier_root_bytes[..], &params)?;
-        let frontier = orchard_ct.to_frontier();
-        let nonempty_frontier = frontier.take().ok_or_else(|| {
-            anyhow!("empty orchard frontier — no orchard activity at snapshot height")
-        })?;
-
-        // Convert note positions to Merkle positions
-        let positions: Vec<Position> = core_notes
-            .iter()
-            .map(|n| Position::from(n.position))
-            .collect();
-
-        // `BlockHeight` is u32-backed; `snapshot_height` is u64. A wallet that
-        // somehow synced past u32::MAX blocks is impossible in protocol terms,
-        // but reject it explicitly rather than silently truncating.
-        let snapshot_height = u32::try_from(params.snapshot_height).map_err(|_| {
-            anyhow!(
-                "snapshot_height {} does not fit in u32",
-                params.snapshot_height
-            )
-        })?;
-        let checkpoint_height = zcash_protocol::consensus::BlockHeight::from_u32(snapshot_height);
-
-        // Generate witnesses from wallet DB shard data + frontier
-        let merkle_paths = wallet_db
-            .generate_orchard_witnesses_at_historical_height(
-                &positions,
-                nonempty_frontier,
-                checkpoint_height,
-            )
-            .map_err(|e| {
-                anyhow!(
-                    "generate_orchard_witnesses_at_historical_height failed: {}",
-                    e
-                )
-            })?;
-
-        if merkle_paths.len() != core_notes.len() {
-            return Err(anyhow!(
-                "generated {} Merkle paths for {} notes",
-                merkle_paths.len(),
-                core_notes.len()
-            ));
-        }
-
-        // Convert MerklePaths to WitnessData
-        let root_bytes = frontier_root_bytes.to_vec();
-        let witnesses: Vec<voting::WitnessData> = merkle_paths
-            .into_iter()
-            .zip(core_notes.iter())
-            .map(|(path, note)| {
-                let auth_path: Vec<Vec<u8>> = path
-                    .path_elems()
-                    .iter()
-                    .map(|h| h.to_bytes().to_vec())
-                    .collect();
-                voting::WitnessData {
-                    note_commitment: note.commitment.clone(),
-                    position: note.position,
-                    root: root_bytes.clone(),
-                    auth_path,
-                }
-            })
-            .collect();
+        // `zcash_voting` owns shielded-protocol-aware witness generation and has
+        // since 2.0. It loads this round's cached `TreeState` and stored params,
+        // checks the wallet DB's network against the round's, resolves the
+        // shielded protocol for the snapshot height (Ironwood — the crate
+        // supports no other, and rejects a pre-NU6.3 snapshot outright), reads
+        // the **Ironwood** note-commitment tree out of the cached `TreeState`,
+        // binds that frontier to the round (same height, same `nc_root` — the
+        // check this SDK used to hand-roll), and generates the historical
+        // Ironwood Merkle paths from the wallet's own shard data.
+        //
+        // Do not re-hand-roll this against the Orchard tree. Voting notes live
+        // in the Ironwood pool — `notes.rs` already selects them with
+        // `get_unspent_ironwood_notes_at_historical_height` — so an Orchard root
+        // can never equal a round's `nc_root`, on any chain, against any server.
+        // That hand-rolled version is what `8a40d1f9` deleted and what the
+        // `eea6cde8` merge silently brought back.
+        let witnesses = voting::witness::generate_note_witnesses(
+            &handle.db,
+            &round_id_str,
+            &core_notes,
+            &wallet_db,
+        )
+        .map_err(|e| anyhow!("failed to generate voting note witnesses: {}", e))?;
 
         // Verify and cache in voting DB
         handle
@@ -796,7 +709,9 @@ mod tests {
     use incrementalmerkletree::frontier::{CommitmentTree, Frontier};
     use incrementalmerkletree::{Position, Retention};
     use orchard::tree::MerkleHashOrchard;
+    use prost::Message;
     use zcash_client_backend::data_api::WalletCommitmentTrees;
+    use zcash_client_backend::proto::service::TreeState;
     use zcash_client_sqlite::wallet::init::WalletMigrator;
     use zcash_client_sqlite::{WalletDb, util::SystemClock};
     use zcash_primitives::merkle_tree::write_commitment_tree;
@@ -825,6 +740,22 @@ mod tests {
     const TEST_ROUND_ID: &str = "round1";
     const TEST_WALLET_ID: &str = "wallet-id";
 
+    /// Testnet NU6.3 activation (`zcash_protocol` TEST_NETWORK: `Nu6_3 =>
+    /// 4_134_000`). `zcash_voting` resolves the shielded protocol from the
+    /// round's snapshot height and rejects anything that is not NU6.3, so these
+    /// fixtures cannot use the pre-Ironwood height-100 rounds they used to.
+    const SNAPSHOT_HEIGHT: u64 = 4_134_000;
+    /// A later wallet checkpoint, so witness generation has to use the cached
+    /// historical frontier rather than the wallet's current tree.
+    const LATER_HEIGHT: u32 = 4_134_100;
+
+    /// The Orchard-shaped commitment-tree frontier both pools use. Ironwood is
+    /// Orchard-*shaped* — same hash, same depth — while being a separate pool
+    /// with a separate tree, which is exactly why reading the wrong one compiles
+    /// cleanly and fails only against a live round.
+    type VotingFrontier =
+        Frontier<MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
+
     fn decode_hex<const N: usize>(s: &str) -> [u8; N] {
         assert_eq!(s.len(), N * 2);
         let mut out = [0u8; N];
@@ -851,18 +782,6 @@ mod tests {
                 nullifier.as_ptr(),
                 expected_root.as_ptr(),
             )
-        }
-    }
-
-    fn tree_state_at_height(height: u64) -> TreeState {
-        TreeState {
-            network: "test".to_string(),
-            height,
-            hash: String::new(),
-            time: 0,
-            sapling_tree: String::new(),
-            orchard_tree: String::new(),
-            ironwood_tree: String::new(),
         }
     }
 
@@ -938,23 +857,39 @@ mod tests {
         MerkleHashOrchard::from_bytes(&repr).expect("small field element is canonical")
     }
 
-    fn tree_state_from_frontier(
-        height: u64,
-        frontier: &Frontier<MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>,
-    ) -> TreeState {
+    fn commitment_tree_hex(frontier: &VotingFrontier) -> String {
         let commitment_tree = CommitmentTree::from_frontier(frontier);
-        let mut orchard_tree_bytes = Vec::new();
-        write_commitment_tree(&commitment_tree, &mut orchard_tree_bytes)
-            .expect("serialize Orchard tree state");
+        let mut tree_bytes = Vec::new();
+        write_commitment_tree(&commitment_tree, &mut tree_bytes)
+            .expect("serialize note commitment tree state");
+        bytes_to_hex(&tree_bytes)
+    }
 
+    /// A frontier deliberately unlike any Ironwood frontier these tests seed.
+    fn orchard_decoy_frontier() -> VotingFrontier {
+        let mut frontier = VotingFrontier::empty();
+        assert!(frontier.append(merkle_hash(77)));
+        assert!(frontier.append(merkle_hash(78)));
+        frontier
+    }
+
+    /// Build the cached round `TreeState` the FFI will read.
+    ///
+    /// The Ironwood slot carries the voting frontier; the Orchard slot carries a
+    /// **different** decoy tree, on purpose. Voting rounds anchor `nc_root` to
+    /// the Ironwood pool, so any code path that reads the Orchard tree instead
+    /// computes a root that cannot match the round, and every witness test in
+    /// this module fails closed. That is precisely the regression `8a40d1f9`
+    /// fixed and the `eea6cde8` merge lost — keep the decoy.
+    fn tree_state_from_frontier(height: u64, ironwood_frontier: &VotingFrontier) -> TreeState {
         TreeState {
             network: "test".to_string(),
             height,
             hash: String::new(),
             time: 0,
             sapling_tree: String::new(),
-            orchard_tree: bytes_to_hex(&orchard_tree_bytes),
-            ironwood_tree: String::new(),
+            orchard_tree: commitment_tree_hex(&orchard_decoy_frontier()),
+            ironwood_tree: commitment_tree_hex(ironwood_frontier),
         }
     }
 
@@ -962,15 +897,14 @@ mod tests {
         unsafe { zcashlc_free_boxed_slice(ptr) };
     }
 
-    fn seed_wallet_orchard_tree(
+    /// Seed the wallet's **Ironwood** commitment tree — the pool voting notes
+    /// live in, and the pool `zcash_voting` generates historical witnesses from.
+    fn seed_wallet_ironwood_tree(
         wallet_path: &std::path::Path,
         snapshot_height: u64,
         later_height: u32,
         marked_positions: &[Position],
-    ) -> (
-        Frontier<MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>,
-        Vec<MerkleHashOrchard>,
-    ) {
+    ) -> (VotingFrontier, Vec<MerkleHashOrchard>) {
         let max_position = marked_positions
             .iter()
             .map(|position| u64::from(*position))
@@ -978,10 +912,7 @@ mod tests {
             .unwrap_or(2);
         let leaf_count = max_position + 3;
         let leaves = (1u64..=leaf_count).map(merkle_hash).collect::<Vec<_>>();
-        let mut frontier_tree: Frontier<
-            MerkleHashOrchard,
-            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-        > = Frontier::empty();
+        let mut frontier_tree: VotingFrontier = Frontier::empty();
 
         let mut wallet_db = WalletDb::for_path(
             wallet_path,
@@ -995,7 +926,7 @@ mod tests {
             .expect("initialize wallet db");
 
         wallet_db
-            .with_orchard_tree_mut(|tree| {
+            .with_ironwood_tree_mut(|tree| {
                 for (i, leaf) in leaves.iter().enumerate() {
                     let retention = if marked_positions
                         .iter()
@@ -1020,7 +951,7 @@ mod tests {
 
                 Ok::<(), zcash_client_sqlite::error::SqliteClientError>(())
             })
-            .expect("seed wallet Orchard tree");
+            .expect("seed wallet Ironwood tree");
 
         (frontier_tree, leaves)
     }
@@ -1042,10 +973,14 @@ mod tests {
             .map(|position| u64::from(*position))
             .collect::<Vec<_>>();
 
+        // Testnet, to match the wallet DB these tests open and the
+        // `NETWORK_ID_TESTNET` the FFI is called with: `zcash_voting` rejects a
+        // wallet whose network differs from the round's, and resolves the
+        // Ironwood protocol from the stored network's NU6.3 activation height.
         queries::insert_round(
             &conn,
             TEST_WALLET_ID,
-            voting::Network::Mainnet,
+            voting::Network::Testnet,
             &params,
             None,
         )
@@ -1416,40 +1351,6 @@ mod tests {
     }
 
     #[test]
-    fn cached_tree_state_validation_accepts_matching_round() {
-        let root = [7; 32];
-        let tree_state = tree_state_at_height(100);
-        let params = round_params(100, root.to_vec());
-
-        assert!(validate_cached_tree_state_for_round(&tree_state, &root, &params).is_ok());
-    }
-
-    #[test]
-    fn cached_tree_state_validation_rejects_height_mismatch() {
-        let root = [7; 32];
-        let tree_state = tree_state_at_height(99);
-        let params = round_params(100, root.to_vec());
-
-        let error = validate_cached_tree_state_for_round(&tree_state, &root, &params)
-            .expect_err("height mismatch must be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("does not match round snapshot_height")
-        );
-    }
-
-    #[test]
-    fn cached_tree_state_validation_rejects_root_mismatch() {
-        let tree_state = tree_state_at_height(100);
-        let params = round_params(100, vec![7; 32]);
-
-        let error = validate_cached_tree_state_for_round(&tree_state, &[8; 32], &params)
-            .expect_err("root mismatch must be rejected");
-        assert!(error.to_string().contains("does not match round nc_root"));
-    }
-
-    #[test]
     fn validate_pir_proof_accepts_valid() {
         let root = decode_hex::<32>(ROOT);
         let nf_bounds = decode_hex::<96>(NF_BOUNDS);
@@ -1600,8 +1501,6 @@ mod tests {
 
     #[test]
     fn generate_note_witnesses_returns_and_caches_valid_witnesses() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
-        const LATER_HEIGHT: u32 = 200;
         const BUNDLE_INDEX: u32 = 7;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_success_wallet");
@@ -1609,7 +1508,7 @@ mod tests {
         let note_positions = vec![Position::from(2)];
 
         let (frontier_tree, leaves) =
-            seed_wallet_orchard_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
         let expected_root = frontier_tree.root().to_bytes().to_vec();
         let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &frontier_tree);
 
@@ -1643,8 +1542,6 @@ mod tests {
 
     #[test]
     fn generate_note_witnesses_returns_and_caches_multiple_valid_witnesses() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
-        const LATER_HEIGHT: u32 = 200;
         const BUNDLE_INDEX: u32 = 8;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_multi_wallet");
@@ -1652,7 +1549,7 @@ mod tests {
         let note_positions = vec![Position::from(1), Position::from(2), Position::from(4)];
 
         let (frontier_tree, leaves) =
-            seed_wallet_orchard_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
         let expected_root = frontier_tree.root().to_bytes().to_vec();
         let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &frontier_tree);
 
@@ -1686,8 +1583,6 @@ mod tests {
 
     #[test]
     fn generate_note_witnesses_rejects_stale_tree_state_height_through_ffi() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
-        const LATER_HEIGHT: u32 = 200;
         const BUNDLE_INDEX: u32 = 9;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_stale_height_wallet");
@@ -1695,7 +1590,7 @@ mod tests {
         let note_positions = vec![Position::from(2)];
 
         let (frontier_tree, leaves) =
-            seed_wallet_orchard_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
         let expected_root = frontier_tree.root().to_bytes().to_vec();
         let stale_tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT - 1, &frontier_tree);
 
@@ -1727,8 +1622,6 @@ mod tests {
 
     #[test]
     fn generate_note_witnesses_rejects_stale_tree_state_root_through_ffi() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
-        const LATER_HEIGHT: u32 = 200;
         const BUNDLE_INDEX: u32 = 10;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_stale_root_wallet");
@@ -1736,7 +1629,7 @@ mod tests {
         let note_positions = vec![Position::from(2)];
 
         let (frontier_tree, leaves) =
-            seed_wallet_orchard_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
         let mut mismatched_root = frontier_tree.root().to_bytes().to_vec();
         mismatched_root[0] ^= 1;
         let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &frontier_tree);
@@ -1768,8 +1661,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_note_witnesses_rejects_empty_orchard_frontier() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
+    fn generate_note_witnesses_rejects_empty_ironwood_frontier() {
         const BUNDLE_INDEX: u32 = 11;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_empty_frontier_wallet");
@@ -1787,10 +1679,7 @@ mod tests {
                 .expect("initialize wallet db");
         }
 
-        let empty_frontier: Frontier<
-            MerkleHashOrchard,
-            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-        > = Frontier::empty();
+        let empty_frontier: VotingFrontier = Frontier::empty();
         let expected_root = empty_frontier.root().to_bytes().to_vec();
         let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &empty_frontier);
         let note_positions = vec![Position::from(0)];
@@ -1824,8 +1713,6 @@ mod tests {
 
     #[test]
     fn generate_note_witnesses_accepts_zero_len_notes_json() {
-        const SNAPSHOT_HEIGHT: u64 = 100;
-        const LATER_HEIGHT: u32 = 200;
         const BUNDLE_INDEX: u32 = 12;
 
         let wallet_path = temp_sqlite_path("generate_witnesses_empty_notes_wallet");
@@ -1833,7 +1720,7 @@ mod tests {
         let note_positions = Vec::new();
 
         let (frontier_tree, _leaves) =
-            seed_wallet_orchard_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
         let expected_root = frontier_tree.root().to_bytes().to_vec();
         let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &frontier_tree);
 
@@ -1853,6 +1740,81 @@ mod tests {
 
         let returned = decode_witnesses(result);
         assert!(returned.is_empty());
+        assert_cached_witnesses_match(db, BUNDLE_INDEX, &returned);
+
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&wallet_path);
+    }
+
+    /// The load-bearing Ironwood-era behaviour, and the regression `8a40d1f9`
+    /// fixed before the `eea6cde8` merge silently reverted it: voting notes live
+    /// in the Ironwood pool, so witnesses must come from the Ironwood commitment
+    /// tree and verify against the round's Ironwood `nc_root` — even though the
+    /// cached `TreeState` also carries a different Orchard tree. Reading the
+    /// Orchard tree yields a root that can never equal a round's `nc_root`,
+    /// which is what shipped against live testnet round `0199de7a…9723` at
+    /// snapshot 4179680 and failed every delegation attempt.
+    ///
+    /// If this test is ever deleted or weakened by a merge, the wrong-pool bug
+    /// comes back silently. It is the guard, not decoration.
+    #[test]
+    fn generate_note_witnesses_uses_ironwood_tree() {
+        const BUNDLE_INDEX: u32 = 13;
+
+        let wallet_path = temp_sqlite_path("generate_witnesses_uses_ironwood_wallet");
+        let wallet_path_bytes = wallet_path.to_string_lossy().as_bytes().to_vec();
+        let note_positions = vec![Position::from(1), Position::from(2)];
+
+        let (frontier_tree, leaves) =
+            seed_wallet_ironwood_tree(&wallet_path, SNAPSHOT_HEIGHT, LATER_HEIGHT, &note_positions);
+        let ironwood_root = frontier_tree.root().to_bytes().to_vec();
+        let orchard_root = orchard_decoy_frontier().root().to_bytes().to_vec();
+        assert_ne!(
+            ironwood_root, orchard_root,
+            "the fixture needs distinguishable pools"
+        );
+
+        let tree_state = tree_state_from_frontier(SNAPSHOT_HEIGHT, &frontier_tree);
+        assert!(
+            !tree_state.orchard_tree.is_empty(),
+            "the cached TreeState must carry the decoy Orchard tree"
+        );
+
+        let db = open_memory_voting_db();
+        store_round_bundle_and_tree_state(
+            db,
+            SNAPSHOT_HEIGHT,
+            BUNDLE_INDEX,
+            &note_positions,
+            ironwood_root.clone(),
+            &tree_state,
+        );
+
+        let notes_json = notes_json_for_positions(&leaves, &note_positions);
+        let result = call_generate_note_witnesses(
+            db,
+            BUNDLE_INDEX,
+            &wallet_path_bytes,
+            notes_json.as_ptr(),
+            notes_json.len(),
+        );
+        assert!(
+            !result.is_null(),
+            "witness generation must succeed against the Ironwood tree"
+        );
+
+        let returned = decode_witnesses(result);
+        assert_witnesses_match_positions(&returned, &leaves, &note_positions, &ironwood_root);
+        for witness in &returned {
+            assert_eq!(
+                witness.root, ironwood_root,
+                "witness root must be the round's Ironwood nc_root"
+            );
+            assert_ne!(
+                witness.root, orchard_root,
+                "witness root must not come from the Orchard tree"
+            );
+        }
         assert_cached_witnesses_match(db, BUNDLE_INDEX, &returned);
 
         unsafe { zcashlc_voting_db_free(db) };

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -416,8 +416,15 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
 // Keep PIR client construction at the SDK boundary so zcash_voting can accept
 // an injected transport. Today we use direct Hyper/Rustls. In the future this will be the
 // single place to add a Tor-backed transport based on SDK configuration.
-fn connect_pir_client(pir_url: &str) -> anyhow::Result<voting::PirClientBlocking> {
-    voting::PirClientBlocking::with_transport(pir_url, Arc::new(voting::HyperTransport::new()))
+//
+// The layout comes from the round's resolved dynamic config and is passed through
+// unchanged: `connect_pir_blocking` performs the config/server layout handshake and
+// fails closed before any private query when the server disagrees.
+fn connect_pir_client(
+    pir_url: &str,
+    pir_layout: voting::config::PirLayout,
+) -> anyhow::Result<voting::PirClientBlocking> {
+    voting::connect_pir_blocking(pir_layout, pir_url, Arc::new(voting::HyperTransport::new()))
         .map_err(|e| anyhow!("connect to PIR server failed: {}", e))
 }
 
@@ -443,6 +450,9 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
     notes_json_len: usize,
     pir_server_url: *const u8,
     pir_server_url_len: usize,
+    pir_depth: u32,
+    tier0_layers: u32,
+    tier1_layers: u32,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
@@ -458,7 +468,12 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
         };
         let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
         let pir_url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
-        let pir_client = connect_pir_client(&pir_url)?;
+        let pir_layout = voting::config::PirLayout {
+            pir_depth,
+            tier0_layers,
+            tier1_layers,
+        };
+        let pir_client = connect_pir_client(&pir_url, pir_layout)?;
 
         let result = handle
             .db
@@ -513,6 +528,9 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
     round_name_len: usize,
     pir_server_url: *const u8,
     pir_server_url_len: usize,
+    pir_depth: u32,
+    tier0_layers: u32,
+    tier1_layers: u32,
     progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
     progress_context: *mut std::ffi::c_void,
 ) -> *mut crate::ffi::BoxedSlice {
@@ -539,7 +557,12 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
         })?;
         let round_name_str = unsafe { str_from_ptr(round_name, round_name_len) }?;
         let pir_url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
-        let pir_client = connect_pir_client(&pir_url)?;
+        let pir_layout = voting::config::PirLayout {
+            pir_depth,
+            tier0_layers,
+            tier1_layers,
+        };
+        let pir_client = connect_pir_client(&pir_url, pir_layout)?;
 
         let hotkey = voting::VotingHotkey::from_stored_secret(hotkey_secret, handle.network)
             .map_err(|e| anyhow!("failed to reconstruct voting hotkey: {}", e))?;
@@ -757,6 +780,14 @@ fn parse_path(bytes: &[u8]) -> anyhow::Result<[pallas::Base; PIR_PATH_ELEMENT_CO
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The PIR geometry the live dynamic voting config serves today. These
+    /// tests never reach the PIR handshake — they assert null-handle and
+    /// input-validation rejections — so the values only need to be a
+    /// well-formed layout rather than the sentinel `PirLayout::UNKNOWN`.
+    const PIR_DEPTH: u32 = 19;
+    const TIER0_LAYERS: u32 = 12;
+    const TIER1_LAYERS: u32 = 7;
 
     use super::super::constants::HOTKEY_RAW_ADDRESS_LEN;
 
@@ -1218,6 +1249,9 @@ mod tests {
                     round.len(),
                     round.as_ptr(),
                     round.len(),
+                    PIR_DEPTH,
+                    TIER0_LAYERS,
+                    TIER1_LAYERS,
                     None,
                     std::ptr::null_mut(),
                 )
@@ -1511,6 +1545,9 @@ mod tests {
                 0,
                 std::ptr::null(),
                 0,
+                PIR_DEPTH,
+                TIER0_LAYERS,
+                TIER1_LAYERS,
             )
         };
 

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -177,117 +177,12 @@ impl From<voting::DelegationPirPrecomputeResult> for JsonDelegationPirPrecompute
     }
 }
 
-/// JSON-serializable DelegationSubmission.
-///
-/// Omits the spend-auth randomizer `alpha`; the submission already carries
-/// `spend_auth_sig`, so callers do not need the signing secret after signing.
-#[allow(dead_code)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonDelegationSubmission {
-    pub rk: Vec<u8>,
-    pub spend_auth_sig: Vec<u8>,
-    pub sighash: Vec<u8>,
-    pub nf_signed: Vec<u8>,
-    pub cmx_new: Vec<u8>,
-    pub gov_comm: Vec<u8>,
-    pub gov_nullifiers: Vec<Vec<u8>>,
-    pub proof: Vec<u8>,
-    pub vote_round_id: String,
-}
-
-impl From<voting::DelegationSubmissionData> for JsonDelegationSubmission {
-    fn from(d: voting::DelegationSubmissionData) -> Self {
-        Self {
-            rk: d.rk,
-            spend_auth_sig: d.spend_auth_sig,
-            sighash: d.sighash,
-            nf_signed: d.nf_signed,
-            cmx_new: d.cmx_new,
-            gov_comm: d.gov_comm,
-            gov_nullifiers: d.gov_nullifiers,
-            proof: d.proof,
-            vote_round_id: d.vote_round_id,
-        }
-    }
-}
-
-/// Wire-safe encrypted share that omits secret fields (plaintext_value, randomness).
-/// Used in SharePayload which is sent to the helper server.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonWireEncryptedShare {
-    pub c1: Vec<u8>,
-    pub c2: Vec<u8>,
-    pub share_index: u32,
-}
-
-impl From<voting::EncryptedShare> for JsonWireEncryptedShare {
-    fn from(s: voting::EncryptedShare) -> Self {
-        Self {
-            c1: s.c1,
-            c2: s.c2,
-            share_index: s.share_index,
-        }
-    }
-}
-
-impl From<JsonWireEncryptedShare> for voting::WireEncryptedShare {
-    fn from(s: JsonWireEncryptedShare) -> Self {
-        Self {
-            c1: s.c1,
-            c2: s.c2,
-            share_index: s.share_index,
-        }
-    }
-}
-
-/// JSON-serializable SharePayload.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonSharePayload {
-    pub shares_hash: Vec<u8>,
-    pub proposal_id: u32,
-    pub vote_decision: u32,
-    pub enc_share: JsonWireEncryptedShare,
-    pub tree_position: u64,
-    pub all_enc_shares: Vec<JsonWireEncryptedShare>,
-    pub share_comms: Vec<Vec<u8>>,
-    pub primary_blind: Vec<u8>,
-}
-
-impl From<voting::SharePayload> for JsonSharePayload {
-    fn from(p: voting::SharePayload) -> Self {
-        Self {
-            shares_hash: p.shares_hash,
-            proposal_id: p.proposal_id,
-            vote_decision: p.vote_decision,
-            enc_share: JsonWireEncryptedShare {
-                c1: p.enc_share.c1,
-                c2: p.enc_share.c2,
-                share_index: p.enc_share.share_index,
-            },
-            tree_position: p.tree_position,
-            all_enc_shares: p
-                .all_enc_shares
-                .into_iter()
-                .map(|s| JsonWireEncryptedShare {
-                    c1: s.c1,
-                    c2: s.c2,
-                    share_index: s.share_index,
-                })
-                .collect(),
-            share_comms: p.share_comms,
-            primary_blind: p.primary_blind,
-        }
-    }
-}
-
 /// JSON-serializable `voting::vote::VoteCommit`.
 ///
-/// This is the whole result of committing one cast-vote: the signed commitment
-/// fields destined for the vote chain, the encrypted shares that the vote proof
-/// binds, and the helper-server payloads derived from them. Previously the
-/// Swift layer assembled the equivalent by calling three separate FFI entry
-/// points and re-serializing intermediate state between them; `zcash_voting`
-/// now owns that orchestration, so a single response carries everything.
+/// The helper-share payloads are deliberately absent: they are wire data owned
+/// by `zcash_voting`, produced by `zcashlc_voting_recover_wire_json` once the
+/// confirmed vote-commitment-tree position is known. Commit-time payloads are
+/// provisional and must never be sent to helper servers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonVoteCommit {
     pub proposal_id: u32,
@@ -298,8 +193,7 @@ pub struct JsonVoteCommit {
     pub anchor_height: u32,
     pub r_vpk: Vec<u8>,
     pub vote_auth_sig: Vec<u8>,
-    pub enc_shares: Vec<JsonWireEncryptedShare>,
-    pub share_payloads: Vec<JsonSharePayload>,
+    pub enc_shares: Vec<voting::WireEncryptedShare>,
 }
 
 impl From<voting::vote::VoteCommit> for JsonVoteCommit {
@@ -313,16 +207,7 @@ impl From<voting::vote::VoteCommit> for JsonVoteCommit {
             anchor_height: c.anchor_height,
             r_vpk: c.r_vpk.to_vec(),
             vote_auth_sig: c.vote_auth_sig.to_vec(),
-            enc_shares: c
-                .encrypted_shares
-                .into_iter()
-                .map(|s| JsonWireEncryptedShare {
-                    c1: s.c1,
-                    c2: s.c2,
-                    share_index: s.share_index,
-                })
-                .collect(),
-            share_payloads: c.share_payloads.into_iter().map(Into::into).collect(),
+            enc_shares: c.encrypted_shares,
         }
     }
 }
@@ -335,25 +220,4 @@ pub struct JsonDelegationInputs {
     pub pk_d_new_x: Vec<u8>,
     pub hotkey_raw_address: Vec<u8>,
     pub seed_fingerprint: Vec<u8>,
-}
-
-/// JSON-serializable VanWitness.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonVanWitness {
-    /// The authentication path for the witness.
-    pub auth_path: Vec<Vec<u8>>,
-    /// The position of the witness.
-    pub position: u32,
-    /// The anchor height of the witness.
-    pub anchor_height: u32,
-}
-
-impl From<voting::vote::VanWitness> for JsonVanWitness {
-    fn from(w: voting::vote::VanWitness) -> Self {
-        Self {
-            auth_path: w.auth_path.iter().map(|h| h.to_vec()).collect(),
-            position: w.position,
-            anchor_height: w.anchor_height,
-        }
-    }
 }

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -275,6 +275,52 @@ pub unsafe extern "C" fn zcashlc_voting_add_sent_servers(
     unwrap_exc_or(res, -1)
 }
 
+/// Rebuild one helper-server share payload as the crate's own wire JSON.
+///
+/// Thin passthrough to `zcash_voting::share::recover_wire_json`: the crate
+/// parses the persisted recovery bundle, selects the requested share, binds the
+/// confirmed vote-commitment-tree position and the scheduled submission time
+/// into it, and serializes the result with its own `VoteShareWire` codec. No
+/// second commit happens, and the FFI shapes nothing: the returned bytes are
+/// the helper payload verbatim.
+///
+/// `commitment_bundle_json` is the recovery JSON previously read with
+/// `zcashlc_voting_get_commitment_bundle`.
+///
+/// Returns the UTF-8 wire JSON as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - If `commitment_bundle_json_len > 0` then `commitment_bundle_json` must be
+///   non-null and valid for reads for that many bytes; if it is `0`, the pointer
+///   is ignored.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_recover_wire_json(
+    commitment_bundle_json: *const u8,
+    commitment_bundle_json_len: usize,
+    proposal_id: u32,
+    share_index: u32,
+    vc_tree_position: u64,
+    submit_at: u64,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let bundle_json =
+            unsafe { str_from_ptr(commitment_bundle_json, commitment_bundle_json_len) }?;
+
+        let wire_json = voting::share::recover_wire_json(
+            &bundle_json,
+            proposal_id,
+            share_index,
+            vc_tree_position,
+            submit_at,
+        )
+        .map_err(|e| anyhow!("recover_wire_json failed: {}", e))?;
+
+        Ok(crate::ffi::BoxedSlice::some(wire_json.into_bytes()))
+    });
+    unwrap_exc_or_null(res)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -321,6 +321,52 @@ pub unsafe extern "C" fn zcashlc_voting_recover_wire_json(
     unwrap_exc_or_null(res)
 }
 
+/// List the share indices recoverable from a persisted vote recovery bundle.
+///
+/// Thin passthrough to `zcash_voting::vote::parse_recovery` +
+/// `zcash_voting::share::recover_payloads`: the crate parses the bundle and
+/// applies its own single-share slicing (one share when `single_share`, all
+/// of them otherwise), and this wrapper reads off each recovered payload's
+/// `enc_share.share_index`. Crash recovery uses this list instead of guessing
+/// a share count from `single_share` alone (`singleShare ? 1 : numOptions`),
+/// so a caller-side guess can never under- or over-deliver relative to what
+/// the crate actually reconstructs.
+///
+/// `commitment_bundle_json` is the recovery JSON previously read with
+/// `zcashlc_voting_get_commitment_bundle`.
+///
+/// Returns a JSON array of `u32` share indices as `*mut FfiBoxedSlice`, or
+/// null on error.
+///
+/// # Safety
+///
+/// - If `commitment_bundle_json_len > 0` then `commitment_bundle_json` must be
+///   non-null and valid for reads for that many bytes; if it is `0`, the pointer
+///   is ignored.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_recoverable_share_indices(
+    commitment_bundle_json: *const u8,
+    commitment_bundle_json_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let bundle_json =
+            unsafe { str_from_ptr(commitment_bundle_json, commitment_bundle_json_len) }?;
+
+        let bundle = voting::vote::parse_recovery(&bundle_json)
+            .map_err(|e| anyhow!("parse_recovery failed: {}", e))?;
+        let payloads = voting::share::recover_payloads(&bundle)
+            .map_err(|e| anyhow!("recover_payloads failed: {}", e))?;
+
+        let indices: Vec<u32> = payloads
+            .into_iter()
+            .map(|payload| payload.enc_share.share_index)
+            .collect();
+
+        json_to_boxed_slice(&indices)
+    });
+    unwrap_exc_or_null(res)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,5 +424,114 @@ mod tests {
 
         unsafe { zcashlc_free_boxed_slice(result) };
         unsafe { zcashlc_voting_db_free(db) };
+    }
+
+    fn field_bytes(value: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = value;
+        bytes
+    }
+
+    /// Build a `VoteRecoveryBundle` whose encrypted shares carry exactly
+    /// `share_indices`, in that order — mirroring `zcash_voting`'s own
+    /// `share.rs` fixture, generalized so both the single-share and
+    /// multi-share cases below can reuse it.
+    fn recovery_bundle_with_share_indices(
+        single_share: bool,
+        share_indices: &[u32],
+    ) -> voting::vote::VoteRecoveryBundle {
+        let encrypted_shares: Vec<voting::types::EncryptedShare> = share_indices
+            .iter()
+            .enumerate()
+            .map(|(i, &share_index)| voting::types::EncryptedShare {
+                c1: vec![0x21 + i as u8; 32],
+                c2: vec![0x22 + i as u8; 32],
+                share_index,
+                plaintext_value: 5,
+                randomness: vec![0x23 + i as u8; 32],
+            })
+            .collect();
+        let share_blinds: Vec<[u8; 32]> = (0..encrypted_shares.len())
+            .map(|i| field_bytes(1 + i as u8))
+            .collect();
+        let share_comms: Vec<[u8; 32]> = (0..encrypted_shares.len())
+            .map(|i| [0x51 + i as u8; 32])
+            .collect();
+
+        voting::vote::VoteRecoveryBundle {
+            vote_round_id: "round1".to_string(),
+            bundle_index: 0,
+            proposal_id: 1,
+            vote_decision: 2,
+            anchor_height: 123,
+            vc_tree_position: 456,
+            single_share,
+            num_options: 4,
+            van_nullifier: [0x10; 32],
+            vote_authority_note_new: [0x11; 32],
+            vote_commitment: [0x12; 32],
+            proof: vec![0x13; 96],
+            shares_hash: [0x14; 32],
+            r_vpk: [0x15; 32],
+            alpha_v: [0x16; 32],
+            vote_auth_sig: [0x17; 64],
+            encrypted_shares,
+            share_blinds,
+            share_comms,
+        }
+    }
+
+    /// Call the FFI under test and decode its `Vec<u32>` JSON response,
+    /// failing the test outright if the pointer comes back null.
+    fn recoverable_share_indices(bundle: &voting::vote::VoteRecoveryBundle) -> Vec<u32> {
+        let json = voting::vote::serialize_recovery(bundle).expect("serialize recovery bundle");
+        let json_bytes = json.as_bytes();
+        let ptr = unsafe {
+            zcashlc_voting_recoverable_share_indices(json_bytes.as_ptr(), json_bytes.len())
+        };
+        assert!(!ptr.is_null(), "expected recoverable share indices, got null");
+        let result_bytes = unsafe { (*ptr).as_slice() }.to_vec();
+        unsafe { zcashlc_free_boxed_slice(ptr) };
+        serde_json::from_slice(&result_bytes).expect("share indices json")
+    }
+
+    #[test]
+    fn recoverable_share_indices_single_share_mode_returns_only_the_first_share() {
+        // Four built shares whose indices are deliberately not 0..3 in order,
+        // so a passing assertion proves the FFI reports the crate's actual
+        // sliced share index rather than a hardcoded 0.
+        let bundle = recovery_bundle_with_share_indices(true, &[9, 2, 4, 11]);
+
+        let indices = recoverable_share_indices(&bundle);
+
+        assert_eq!(
+            indices,
+            vec![9],
+            "single-share mode must recover exactly the first built share's own index"
+        );
+    }
+
+    #[test]
+    fn recoverable_share_indices_multi_share_mode_returns_every_built_share() {
+        // Six built shares against a four-option proposal: the recovered
+        // count must track the shares actually built, not `num_options` —
+        // the caller-side guess this FFI replaces.
+        let share_indices: Vec<u32> = (0..6).collect();
+        let bundle = recovery_bundle_with_share_indices(false, &share_indices);
+
+        let indices = recoverable_share_indices(&bundle);
+
+        assert_eq!(indices, share_indices);
+    }
+
+    #[test]
+    fn recoverable_share_indices_rejects_malformed_json() {
+        let malformed = b"{ this is not valid json";
+
+        let ptr = unsafe {
+            zcashlc_voting_recoverable_share_indices(malformed.as_ptr(), malformed.len())
+        };
+
+        assert!(ptr.is_null(), "malformed recovery JSON must return null");
     }
 }

--- a/rust/src/voting/signing.rs
+++ b/rust/src/voting/signing.rs
@@ -1,0 +1,177 @@
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ff::PrimeField;
+use ffi_helpers::panic::catch_panic;
+use pasta_curves::pallas;
+use serde::Serialize;
+use zcash_voting as voting;
+use zip32::AccountId;
+
+use crate::unwrap_exc_or_null;
+
+use super::constants::SEED_FINGERPRINT_LEN;
+use super::db::VotingDatabaseHandle;
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr, usk_from_seed};
+
+/// The detached SpendAuth signature this wallet produced for one delegation
+/// bundle, with the sighash it covers.
+///
+/// Not a mirror of any `zcash_voting` wire type: the crate has no type for a
+/// bare `(signature, sighash)` pair, because it never sees the signing step.
+/// This is the FFI's own two-field return envelope, so it lives here rather
+/// than in `json.rs`.
+#[derive(Serialize)]
+struct JsonDelegationSignature {
+    sig: Vec<u8>,
+    sighash: Vec<u8>,
+}
+
+/// Sign one delegation bundle's PCZT sighash with the account's own Orchard
+/// SpendAuth key.
+///
+/// This implements `zcash_voting`'s own prescribed software-wallet recipe; it
+/// is not an SDK invention. The crate stopped deriving account keys and signing
+/// on the caller's behalf in 2.0 and documents the replacement on
+/// `delegate::DelegationSigningRequest` (rc.5 `src/delegate.rs:405-410`): a
+/// software wallet uses `account_index`, `network`, `sighash` and `alpha` to
+/// derive its account SpendAuth key locally, randomizes it, signs `sighash`,
+/// and passes the resulting signature back. The crate README states the same
+/// under "Secret boundaries" (`README.md:235-241`). The derive → randomize →
+/// sign body below is transcribed from the crate authors' own reference wallet,
+/// Vizor (`chainapsis/vizor-wallet`, `rust/src/wallet/voting/delegation.rs:318-349`),
+/// which ships it with a signature-verifying round-trip test.
+///
+/// Two calls make one delegation submission: this one produces the signature,
+/// then `zcashlc_voting_get_delegation_submission_with_signature` consumes it.
+/// The sighash returned here is not decorative — the crate checks it against
+/// the sighash it stored at setup and refuses the submission if they disagree.
+/// The Keystone flow differs only in where the signature comes from.
+///
+/// `fvk_bytes`, `hotkey_stored_secret`, `seed_fingerprint`, `account_index` and
+/// `round_name` are the same delegation-key inputs
+/// `zcashlc_voting_build_and_prove_delegation` takes, because the crate loads
+/// the signing request through the same `DelegationKeys` value that built the
+/// PCZT.
+///
+/// # Key material
+///
+/// `seed` is wallet root seed material — the only voting FFI entry point that
+/// takes it. It is borrowed for the duration of the call through
+/// `bytes_from_ptr` and never copied into an owned buffer, so there is nothing
+/// here to zeroize; the caller owns the allocation and its lifetime, exactly as
+/// for every other voting FFI byte input. It is never logged, never persisted
+/// and never handed to `zcash_voting`: only the locally derived randomized key
+/// touches it, and only the 64-byte detached signature leaves this function.
+///
+/// Returns JSON-encoded `{"sig": [..64], "sighash": [..32]}` as
+/// `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - For every `(ptr, len)` byte argument (`round_id`, `fvk_bytes`,
+///   `hotkey_stored_secret`, `seed_fingerprint`, `round_name`, `seed`): if
+///   `len > 0` then `ptr` must be non-null and valid for reads for `len` bytes;
+///   if `len == 0`, `ptr` is ignored.
+/// - `seed` must remain valid and unmutated for the duration of the call. The
+///   callee neither retains nor frees it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_sign_delegation_request(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    fvk_bytes: *const u8,
+    fvk_bytes_len: usize,
+    hotkey_stored_secret: *const u8,
+    hotkey_stored_secret_len: usize,
+    seed_fingerprint: *const u8,
+    seed_fingerprint_len: usize,
+    account_index: u32,
+    round_name: *const u8,
+    round_name_len: usize,
+    seed: *const u8,
+    seed_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let fvk = unsafe { bytes_from_ptr(fvk_bytes, fvk_bytes_len) }?;
+        let hotkey_secret =
+            unsafe { bytes_from_ptr(hotkey_stored_secret, hotkey_stored_secret_len) }?;
+        let seed_fp_bytes = unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }?;
+        let seed_fp_32: [u8; SEED_FINGERPRINT_LEN] = seed_fp_bytes.try_into().map_err(|_| {
+            anyhow!(
+                "seed_fingerprint must be {} bytes, got {}",
+                SEED_FINGERPRINT_LEN,
+                seed_fp_bytes.len()
+            )
+        })?;
+        let round_name_str = unsafe { str_from_ptr(round_name, round_name_len) }?;
+        let seed_bytes = unsafe { bytes_from_ptr(seed, seed_len) }?;
+
+        let hotkey = voting::VotingHotkey::from_stored_secret(hotkey_secret, handle.network)
+            .map_err(|e| anyhow!("failed to reconstruct voting hotkey: {}", e))?;
+        let keys = voting::delegate::DelegationKeys::with_voting_hotkey(
+            fvk.to_vec(),
+            &hotkey,
+            seed_fp_32,
+            account_index,
+            round_name_str,
+        )
+        .map_err(|e| anyhow!("failed to build delegation keys: {}", e))?;
+
+        let request =
+            voting::delegate::signing_request(&handle.db, &round_id_str, bundle_index, &keys)
+                .map_err(|e| anyhow!("signing_request failed: {}", e))?;
+
+        // Bind the request to this exact wallet seed before deriving any keys.
+        let seed_fp = zip32::fingerprint::SeedFingerprint::from_seed(seed_bytes)
+            .ok_or_else(|| anyhow!("seed length is not valid for ZIP-32"))?;
+        if seed_fp.to_bytes() != request.seed_fingerprint {
+            return Err(anyhow!(
+                "wallet seed fingerprint does not match the delegation signing request"
+            ));
+        }
+
+        // The request's network is the round's stored network: the crate
+        // validated `keys.network` (which came from `handle.network` through
+        // the hotkey) against it before answering. Asserting it here is what
+        // makes deriving through the SDK's own `usk_from_seed(handle.network_id,
+        // ..)` provably equivalent to deriving from `request.network` directly,
+        // and it fails closed if a later release sources that field elsewhere.
+        if request.network != handle.network {
+            return Err(anyhow!(
+                "delegation signing request network does not match the open voting database"
+            ));
+        }
+
+        let account = AccountId::try_from(request.account_index).map_err(|_| {
+            anyhow!(
+                "account_index must be < 2^31, got {}",
+                request.account_index
+            )
+        })?;
+        let usk = usk_from_seed(handle.network_id, seed_bytes, account)
+            .map_err(|e| anyhow!("failed to derive sender UnifiedSpendingKey: {}", e))?;
+        let ask = orchard::keys::SpendAuthorizingKey::from(usk.orchard());
+
+        // The alpha randomizer must decode as a canonical Pallas scalar.
+        let alpha = Option::<pallas::Scalar>::from(pallas::Scalar::from_repr(request.alpha))
+            .ok_or_else(|| anyhow!("delegation alpha is not a canonical Pallas scalar"))?;
+
+        // Sign the request's own sighash with the randomized spend auth key.
+        let rsk = ask.randomize(&alpha);
+        let sig = rsk.sign(rand::rngs::OsRng, &request.sighash);
+        let sig_bytes: [u8; 64] = (&sig).into();
+
+        json_to_boxed_slice(&JsonDelegationSignature {
+            sig: sig_bytes.to_vec(),
+            sighash: request.sighash.to_vec(),
+        })
+    });
+    unwrap_exc_or_null(res)
+}

--- a/rust/src/voting/signing.rs
+++ b/rust/src/voting/signing.rs
@@ -175,3 +175,313 @@ pub unsafe extern "C" fn zcashlc_voting_sign_delegation_request(
     });
     unwrap_exc_or_null(res)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use zcash_voting::storage::queries;
+
+    use crate::voting::constants::ORCHARD_FVK_LEN;
+    use crate::voting::db::zcashlc_voting_db_free;
+    use crate::voting::test_helpers::{insert_round_and_bundle, open_memory_db};
+
+    /// Must match the wallet id `test_helpers::open_memory_db` registers, or the
+    /// planted rows are invisible to the handle under test.
+    const TEST_WALLET_ID: &str = "wallet";
+    const TEST_ROUND_ID: &str = "round";
+    const TEST_SEED: [u8; 32] = [1u8; 32];
+    const PLANTED_SIGHASH: [u8; 32] = [9u8; 32];
+
+    fn test_seed_fingerprint() -> [u8; SEED_FINGERPRINT_LEN] {
+        zip32::fingerprint::SeedFingerprint::from_seed(&TEST_SEED)
+            .expect("32-byte seed is valid for ZIP-32")
+            .to_bytes()
+    }
+
+    /// A stored hotkey secret that `zcash_voting` accepts, produced the same way
+    /// a wallet would produce it rather than by guessing at the encoding.
+    fn valid_stored_secret() -> Vec<u8> {
+        voting::hotkey::generate_random_voting_hotkey(voting::Network::Mainnet)
+            .expect("generate hotkey")
+            .stored_secret()
+            .to_vec()
+    }
+
+    /// Plant the round, bundle, and stored PCZT signing fields (`pczt_sighash`,
+    /// `alpha`) that `delegate::signing_request` loads, without running the
+    /// proving pipeline that stores them in production. Only the two loaded
+    /// fields and the crate-validated `tx1_effects` need real shapes; the other
+    /// delegation blobs are inert 32-byte placeholders.
+    fn plant_signing_request(db: *mut VotingDatabaseHandle, alpha: &[u8; 32]) {
+        insert_round_and_bundle(db, TEST_ROUND_ID);
+        let handle = unsafe { db.as_ref() }.expect("db handle");
+        let conn = handle.db.conn();
+        let mut tx1_effects = vec![0u8; voting::tx1::TX1_EFFECTS_LEN];
+        tx1_effects[0] = voting::tx1::TX1_EFFECTS_VERSION;
+        queries::store_delegation_data(
+            &conn,
+            TEST_ROUND_ID,
+            TEST_WALLET_ID,
+            0,
+            &[0u8; 32], // van_comm_rand
+            &[],        // dummy_nullifiers
+            &[0u8; 32], // rho_signed
+            &[],        // padded_cmx
+            &[0u8; 32], // nf_signed
+            &[0u8; 32], // cmx_new
+            alpha,
+            &[0u8; 32], // rseed_signed
+            &[0u8; 32], // rseed_output
+            &[0u8; 32], // gov_comm
+            65_000_000, // total_note_value
+            0,          // address_index
+            &[],        // padded_note_secrets
+            &PLANTED_SIGHASH,
+            &tx1_effects,
+        )
+        .expect("plant delegation signing data");
+    }
+
+    fn call_sign(
+        db: *mut VotingDatabaseHandle,
+        round_id: &[u8],
+        hotkey_secret: &[u8],
+        seed_fingerprint: &[u8],
+        seed: &[u8],
+    ) -> *mut crate::ffi::BoxedSlice {
+        // The FVK rides through `DelegationKeys` unvalidated and unread on the
+        // signing path — `get_delegation_signing_request` consumes only the
+        // network, the account index and the claimed fingerprint — so a fixed
+        // placeholder keeps these tests on the inputs the FFI actually checks.
+        let fvk = [0u8; ORCHARD_FVK_LEN];
+        let round_name = b"NU6.3 voting round";
+        unsafe {
+            zcashlc_voting_sign_delegation_request(
+                db,
+                round_id.as_ptr(),
+                round_id.len(),
+                0,
+                fvk.as_ptr(),
+                fvk.len(),
+                hotkey_secret.as_ptr(),
+                hotkey_secret.len(),
+                seed_fingerprint.as_ptr(),
+                seed_fingerprint.len(),
+                0,
+                round_name.as_ptr(),
+                round_name.len(),
+                seed.as_ptr(),
+                seed.len(),
+            )
+        }
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_null_db() {
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            std::ptr::null_mut(),
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_invalid_utf8_round_id() {
+        let db = open_memory_db();
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            db,
+            &[0xFF, 0xFE],
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_wrong_length_seed_fingerprint() {
+        let db = open_memory_db();
+        let secret = valid_stored_secret();
+        let short_fingerprint = [0xABu8; SEED_FINGERPRINT_LEN - 1];
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &short_fingerprint,
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_wrong_sized_hotkey_secret() {
+        let db = open_memory_db();
+        let short_secret = [0x42u8; 8];
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &short_secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_unknown_round() {
+        let db = open_memory_db();
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            db,
+            b"no-such-round",
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_bundle_without_stored_signing_data() {
+        let db = open_memory_db();
+        // Round and bundle exist, but no PCZT build ever stored a sighash or
+        // alpha for the bundle, so the signing request cannot be assembled.
+        insert_round_and_bundle(db, TEST_ROUND_ID);
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_mismatched_wallet_seed_fingerprint() {
+        let db = open_memory_db();
+        plant_signing_request(db, &[0u8; 32]);
+        let secret = valid_stored_secret();
+        let claimed_fingerprint = [0xABu8; SEED_FINGERPRINT_LEN];
+        assert_ne!(
+            claimed_fingerprint,
+            test_seed_fingerprint(),
+            "fixture must not collide with the real fingerprint"
+        );
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &claimed_fingerprint,
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(
+            result.is_null(),
+            "a claimed fingerprint that is not the wallet seed's must be rejected"
+        );
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_non_zip32_seed() {
+        let db = open_memory_db();
+        plant_signing_request(db, &[0u8; 32]);
+        let secret = valid_stored_secret();
+        // Below the 32-byte ZIP-32 minimum, so no fingerprint can be derived.
+        let short_seed = [1u8; 16];
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &test_seed_fingerprint(),
+            &short_seed,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn sign_delegation_request_rejects_non_canonical_alpha() {
+        let db = open_memory_db();
+        // 2^256 - 1 is far above the Pallas scalar modulus, so this stored
+        // alpha has no canonical decoding.
+        plant_signing_request(db, &[0xFFu8; 32]);
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(result.is_null());
+    }
+
+    /// Positive control for the planted-request fixtures: the same plant with
+    /// the matching wallet seed signs, which is what proves the negative tests
+    /// above fail on the checks they claim rather than on a broken plant.
+    #[test]
+    fn sign_delegation_request_signs_planted_request_with_matching_seed() {
+        let db = open_memory_db();
+        plant_signing_request(db, &[0u8; 32]);
+        let secret = valid_stored_secret();
+
+        let result = call_sign(
+            db,
+            TEST_ROUND_ID.as_bytes(),
+            &secret,
+            &test_seed_fingerprint(),
+            &TEST_SEED,
+        );
+
+        unsafe { zcashlc_voting_db_free(db) };
+        assert!(!result.is_null(), "matching seed and planted request must sign");
+        let bytes = unsafe { (*result).as_slice() }.to_vec();
+        unsafe { crate::ffi::zcashlc_free_boxed_slice(result) };
+
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("signature json");
+        assert_eq!(json["sig"].as_array().expect("sig array").len(), 64);
+        let sighash: Vec<u8> = json["sighash"]
+            .as_array()
+            .expect("sighash array")
+            .iter()
+            .map(|v| u8::try_from(v.as_u64().expect("byte")).expect("byte range"))
+            .collect();
+        assert_eq!(
+            sighash,
+            PLANTED_SIGHASH.to_vec(),
+            "returned sighash must echo the stored one"
+        );
+    }
+}

--- a/rust/src/voting/tree.rs
+++ b/rust/src/voting/tree.rs
@@ -7,7 +7,6 @@ use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
 use super::db::VotingDatabaseHandle;
 use super::helpers::{json_to_boxed_slice, str_from_ptr};
-use super::json::JsonVanWitness;
 
 // =============================================================================
 // VotingDatabase methods — Tree sync
@@ -70,8 +69,7 @@ pub unsafe extern "C" fn zcashlc_voting_generate_van_witness(
             .generate_van_witness(&handle.db, &round_id_str, bundle_index, anchor_height)
             .map_err(|e| anyhow!("generate_van_witness failed: {}", e))?;
 
-        let json_witness: JsonVanWitness = witness.into();
-        json_to_boxed_slice(&json_witness)
+        json_to_boxed_slice(&witness)
     });
     unwrap_exc_or_null(res)
 }

--- a/rust/src/voting/util.rs
+++ b/rust/src/voting/util.rs
@@ -270,10 +270,14 @@ pub unsafe extern "C" fn zcashlc_voting_verify_witness(
 
 #[cfg(test)]
 mod tests {
-    use orchard::tree::Anchor;
+    use ff::PrimeField;
+    use incrementalmerkletree::frontier::{CommitmentTree, Frontier};
+    use orchard::tree::{Anchor, MerkleHashOrchard};
+    use pasta_curves::pallas;
     use prost::Message;
     use zcash_client_backend::proto::service::TreeState;
     use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_primitives::merkle_tree::write_commitment_tree;
     use zcash_protocol::consensus::Network;
 
     use super::*;
@@ -588,6 +592,32 @@ mod tests {
         assert_eq!(root, Anchor::empty_tree().to_bytes().to_vec());
     }
 
+    const TREE_DEPTH: u8 = orchard::NOTE_COMMITMENT_TREE_DEPTH as u8;
+
+    /// A distinguishable Orchard-tree leaf built from a small field element.
+    fn merkle_hash(tag: u64) -> MerkleHashOrchard {
+        let repr = pallas::Base::from(tag).to_repr();
+        MerkleHashOrchard::from_bytes(&repr).expect("small field element is canonical")
+    }
+
+    /// A commitment-tree frontier holding one leaf per tag.
+    fn frontier_with(tags: &[u64]) -> Frontier<MerkleHashOrchard, TREE_DEPTH> {
+        let mut frontier = Frontier::empty();
+        for tag in tags {
+            assert!(frontier.append(merkle_hash(*tag)));
+        }
+        frontier
+    }
+
+    /// The hex tree-state encoding `TreeState` carries for a frontier.
+    fn tree_hex(frontier: &Frontier<MerkleHashOrchard, TREE_DEPTH>) -> String {
+        let commitment_tree = CommitmentTree::from_frontier(frontier);
+        let mut tree_bytes = Vec::new();
+        write_commitment_tree(&commitment_tree, &mut tree_bytes)
+            .expect("serialize note commitment tree state");
+        hex::encode(tree_bytes)
+    }
+
     /// Voting rounds are anchored to the **Ironwood** note commitment tree, so
     /// when the cached `TreeState` carries both pools the extracted `nc_root`
     /// must be the Ironwood root, not the Orchard one. This is the second half
@@ -595,35 +625,6 @@ mod tests {
     /// in the suite notices which field this FFI reads.
     #[test]
     fn extract_nc_root_returns_ironwood_root_when_both_trees_present() {
-        use ff::PrimeField;
-        use incrementalmerkletree::frontier::{CommitmentTree, Frontier};
-        use orchard::tree::MerkleHashOrchard;
-        use pasta_curves::pallas;
-        use zcash_primitives::merkle_tree::write_commitment_tree;
-
-        const TREE_DEPTH: u8 = orchard::NOTE_COMMITMENT_TREE_DEPTH as u8;
-
-        fn merkle_hash(tag: u64) -> MerkleHashOrchard {
-            let repr = pallas::Base::from(tag).to_repr();
-            MerkleHashOrchard::from_bytes(&repr).expect("small field element is canonical")
-        }
-
-        fn frontier_with(tags: &[u64]) -> Frontier<MerkleHashOrchard, TREE_DEPTH> {
-            let mut frontier = Frontier::empty();
-            for tag in tags {
-                assert!(frontier.append(merkle_hash(*tag)));
-            }
-            frontier
-        }
-
-        fn tree_hex(frontier: &Frontier<MerkleHashOrchard, TREE_DEPTH>) -> String {
-            let commitment_tree = CommitmentTree::from_frontier(frontier);
-            let mut tree_bytes = Vec::new();
-            write_commitment_tree(&commitment_tree, &mut tree_bytes)
-                .expect("serialize note commitment tree state");
-            hex::encode(tree_bytes)
-        }
-
         let orchard_frontier = frontier_with(&[1, 2, 3]);
         let ironwood_frontier = frontier_with(&[7, 8]);
         assert_ne!(

--- a/rust/src/voting/util.rs
+++ b/rust/src/voting/util.rs
@@ -211,7 +211,13 @@ pub unsafe extern "C" fn zcashlc_voting_extract_orchard_fvk_from_ufvk(
     unwrap_exc_or_null(res)
 }
 
-/// Extract the Orchard note commitment tree root from a protobuf-encoded TreeState.
+/// Extract the Ironwood note commitment tree root from a protobuf-encoded TreeState.
+///
+/// Voting rounds anchor to the Ironwood pool — `zcash_voting 2.0` supports no
+/// other shielded protocol — so a round's `nc_root` is the root of the Ironwood
+/// tree, not the Orchard one. They are distinct pools with distinct trees whose
+/// roots never coincide on a live chain, so reading the wrong field does not
+/// degrade gracefully: it fails every round, always.
 ///
 /// Returns the 32-byte nc_root as `*mut FfiBoxedSlice`, or null on error.
 ///
@@ -227,10 +233,10 @@ pub unsafe extern "C" fn zcashlc_voting_extract_nc_root(
         let bytes = unsafe { bytes_from_ptr(tree_state_bytes, tree_state_bytes_len) }?;
         let tree_state = TreeState::decode(bytes)
             .map_err(|e| anyhow!("failed to decode TreeState protobuf: {}", e))?;
-        let orchard_ct = tree_state
-            .orchard_tree()
-            .map_err(|e| anyhow!("failed to parse orchard tree from TreeState: {}", e))?;
-        let nc_root = orchard_ct.root().to_bytes().to_vec();
+        let ironwood_ct = tree_state
+            .ironwood_tree()
+            .map_err(|e| anyhow!("failed to parse ironwood tree from TreeState: {}", e))?;
+        let nc_root = ironwood_ct.root().to_bytes().to_vec();
         Ok(crate::ffi::BoxedSlice::some(nc_root))
     });
     unwrap_exc_or_null(res)
@@ -561,7 +567,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_nc_root_returns_empty_orchard_root_for_empty_tree_state() {
+    fn extract_nc_root_returns_empty_ironwood_root_for_empty_tree_state() {
         let tree_state = TreeState {
             network: "main".to_string(),
             height: 1,
@@ -580,6 +586,72 @@ mod tests {
         let root = boxed_slice_to_vec(result);
         assert_eq!(root.len(), 32);
         assert_eq!(root, Anchor::empty_tree().to_bytes().to_vec());
+    }
+
+    /// Voting rounds are anchored to the **Ironwood** note commitment tree, so
+    /// when the cached `TreeState` carries both pools the extracted `nc_root`
+    /// must be the Ironwood root, not the Orchard one. This is the second half
+    /// of the `8a40d1f9` fix that the `eea6cde8` merge lost; without it, nothing
+    /// in the suite notices which field this FFI reads.
+    #[test]
+    fn extract_nc_root_returns_ironwood_root_when_both_trees_present() {
+        use ff::PrimeField;
+        use incrementalmerkletree::frontier::{CommitmentTree, Frontier};
+        use orchard::tree::MerkleHashOrchard;
+        use pasta_curves::pallas;
+        use zcash_primitives::merkle_tree::write_commitment_tree;
+
+        const TREE_DEPTH: u8 = orchard::NOTE_COMMITMENT_TREE_DEPTH as u8;
+
+        fn merkle_hash(tag: u64) -> MerkleHashOrchard {
+            let repr = pallas::Base::from(tag).to_repr();
+            MerkleHashOrchard::from_bytes(&repr).expect("small field element is canonical")
+        }
+
+        fn frontier_with(tags: &[u64]) -> Frontier<MerkleHashOrchard, TREE_DEPTH> {
+            let mut frontier = Frontier::empty();
+            for tag in tags {
+                assert!(frontier.append(merkle_hash(*tag)));
+            }
+            frontier
+        }
+
+        fn tree_hex(frontier: &Frontier<MerkleHashOrchard, TREE_DEPTH>) -> String {
+            let commitment_tree = CommitmentTree::from_frontier(frontier);
+            let mut tree_bytes = Vec::new();
+            write_commitment_tree(&commitment_tree, &mut tree_bytes)
+                .expect("serialize note commitment tree state");
+            hex::encode(tree_bytes)
+        }
+
+        let orchard_frontier = frontier_with(&[1, 2, 3]);
+        let ironwood_frontier = frontier_with(&[7, 8]);
+        assert_ne!(
+            orchard_frontier.root().to_bytes(),
+            ironwood_frontier.root().to_bytes(),
+            "test needs distinguishable roots"
+        );
+        let tree_state = TreeState {
+            network: "test".to_string(),
+            height: 100,
+            hash: String::new(),
+            time: 0,
+            sapling_tree: String::new(),
+            orchard_tree: tree_hex(&orchard_frontier),
+            ironwood_tree: tree_hex(&ironwood_frontier),
+        };
+        let tree_state_bytes = tree_state.encode_to_vec();
+
+        let result = unsafe {
+            zcashlc_voting_extract_nc_root(tree_state_bytes.as_ptr(), tree_state_bytes.len())
+        };
+
+        let root = boxed_slice_to_vec(result);
+        assert_eq!(
+            root,
+            ironwood_frontier.root().to_bytes().to_vec(),
+            "nc_root must come from the Ironwood tree"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Restores coinholder voting (#1855) on `zcash_voting = "=2.0.0-rc.5"` with Ironwood support, consumed by the Zodl app's `chp-re-enable` branch (MOB-1678).

## What this is

- **rc.3 → rc.5 pin** with the crate-2.0 adaptations (`connect_pir_blocking` fail-closed PIR handshake, `PirLayout` threading).
- **De-mirrored wire layer**: the SDK stops re-typing the crate's wire structs; submission/recovery JSON passes through crate-owned `to_wire_json` / `recover_wire_json` (`rust/src/voting/`, `Sources/ZcashLightClientKit/Rust/Voting/`).
- **Confirm/recover passthroughs** (`confirm_vote_submission`, `recover_wire_json`) and the **software delegation-signing FFI** `zcashlc_voting_sign_delegation_request` (seed borrowed, never copied or logged).
- **Recoverable-share-indices FFI** `zcashlc_voting_recoverable_share_indices`: recovery consumers enumerate the crate's actual `enc_share` list (single-share slice respected) instead of guessing share counts from round parameters.
- **Ironwood tree-root fix** (`aec99172`): a voting round's `nc_root` is the Ironwood note-commitment-tree root; snapshot validation goes through the crate's `witness::generate_note_witnesses`, which reads the Ironwood tree. ⚠ Note for maintainers: this re-lands what `8a40d1f9` (Jul 17) fixed and the merge `eea6cde8` (Aug 6) silently reverted — **`main` carries that regression today**; this branch restores the fix plus the deleted regression tests, re-seeded on testnet/NU6.3 fixtures with a decoy Orchard tree.

## Evidence

- `cargo test --lib voting`: 84/84 (incl. 10 negative-path FFI tests from review round 1). `swift test --filter OfflineTests`: 873/0 (both re-measured on this head, 2026-08-13). FFI symbol surface additive only vs. pre-branch (+`zcashlc_voting_recoverable_share_indices`); review-round commit is symbol-identical (nm diff empty).
- Live: first complete end-to-end software vote on Valar stage (delegation + 2 cast votes confirmed on-chain + 32/32 tally shares accepted), 2026-08-12, via the Zodl branch that consumes this SDK.
- **2026-08-14: rebased onto `main` @ `785c7618`** — main merged #1971 (the escalated broadcast-readback fix) this morning; all 8 patches byte-equal by range-diff, sole conflict CHANGELOG (auto-merged, verified single `Unreleased` heading with both sides' entries). `cargo test --lib voting` re-run on this head: 84/84. Integrated-stack gates on the stacked #1972 head: OfflineTests 891/0 (main's 17 new broadcaster/readback tests included), zodl suite 1301/188.

## Where to look

- `rust/src/voting/` — the FFI voting layer (delegation.rs, util.rs, rounds.rs, helpers.rs).
- `Sources/ZcashLightClientKit/Rust/Voting/` — Swift wrappers + DTOs.
- The Zodl-side campaign record documents every finding with commit refs; it lives out-of-tree per the `.plans/` convention (available on request).

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes?
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

