### PR TITLE
[#1855] Bump zcash_voting to 3.0.0-rc.3: poly-aware PIR for the v1.3.0 chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,14 +76,24 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
-- Voting is pinned to `zcash_voting = "=2.0.0-rc.5"` (exactly; a non-`=` requirement resolves to
-  1.0.0). rc.4 made the PIR layout an explicit client/server handshake, so
-  `VotingRustBackend.precomputeDelegationPir(...)` and `buildAndProveDelegation(...)` take a new
+- Voting is pinned to `zcash_voting = "=3.0.0-rc.3"` (exactly; a non-`=` requirement resolves to
+  1.0.0). The 2.0 family made the PIR layout an explicit client/server handshake, so
+  `VotingRustBackend.precomputeDelegationPir(...)` and `buildAndProveDelegation(...)` take a
   `pirLayout: VotingPirLayout` — the `pir_depth`/`tier0_layers`/`tier1_layers` triple from the
   round's resolved dynamic voting config. It defaults to `VotingPirLayout.unknown`, the crate's own
   `PirLayout::UNKNOWN` sentinel, which `zcash_voting` rejects: a caller that does not pass a
   resolved layout fails closed before any private query rather than querying with a guessed
   geometry.
+
+  3.0 extends the handshake with the YPIR RLWE polynomial degree: `VotingPirLayout` gains a
+  required `polyLen` (2048 or 4096), sourced from the dynamic config's `pir_layout.poly_len` and
+  threaded through both wrappers, so PIR queries are built for the degree the server actually
+  serves. The 2.0 family hardcoded 2048 and fails against 4096 datasets with opaque tier-1 query
+  errors; 3.0 additionally verifies the advertised degree at connect and fails loudly on mismatch.
+  `VotingPirLayout.unknown` (`polyLen` 0) still fails closed. Separately, `VoteShareWire` now
+  carries `vote_round_id` (32 bytes, lowercase hex), so helper payloads from
+  `recoverWireJson(...)` include it — wallets that injected the field into the request body can
+  delete the injection.
 
 - The voting FFI no longer maintains its own copies of `zcash_voting`'s wire formats. Payloads bound
   for the vote chain and the helper servers are serialized by the crate and handed across the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
-- Voting is pinned to `zcash_voting = "=3.0.0-rc.3"` (exactly; a non-`=` requirement resolves to
+- Voting is pinned to `zcash_voting = "=3.0.0"` (exactly; a non-`=` requirement resolves to
   1.0.0). The 2.0 family made the PIR layout an explicit client/server handshake, so
   `VotingRustBackend.precomputeDelegationPir(...)` and `buildAndProveDelegation(...)` take a
   `pirLayout: VotingPirLayout` — the `pir_depth`/`tier0_layers`/`tier1_layers` triple from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,9 +3843,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.4.0-rc.4"
+version = "0.4.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d28b9974a13bdde2f90c614e3e399ec260165554fd1077b07290c73b075cc3"
+checksum = "cf6547ec35c8d4af154bc73d60fe2773be50f7c089e79414983d721d0dbc13db"
 dependencies = [
  "anyhow",
  "ff",
@@ -3862,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a363975b44d002bfa04c2003bdcd1b4564cd54bbd99bc0862140bc86865580"
+checksum = "24f3dd9f975f28591b07af57cca89804650c38fa66051cf12f34d664f7ea2ac6"
 dependencies = [
  "anyhow",
  "ff",
@@ -7017,9 +7017,9 @@ dependencies = [
 
 [[package]]
 name = "valar-ypir"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c3852d9476a0e3efd6c3bfbfc54d3a21a68d8818c4779824ace78aec84a042"
+checksum = "06a0e6155d97d9e2df44a7f552383a311fbcb5528dfc93e9b3236c98184eb840"
 dependencies = [
  "cc",
  "fastrand",
@@ -7069,9 +7069,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.4.0-rc.2"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3e4675e494f06faa7a5e571c69ec9e74142a2d222384696ba3d313a938b11e"
+checksum = "5fac7b20bee99168197ecdb760181d6d731ec7fb2428ff380a4772f2f1abfae9"
 dependencies = [
  "anyhow",
  "ff",
@@ -7086,9 +7086,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.6.0-rc.2"
+version = "0.7.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9bf6de4d2870aff92b3388df3572d186b1bf64fda3cee623e220d3874f7665"
+checksum = "32d3a7fd4c1a40672a2f13c625999b8fefeb44d517230b4db1d4947c473d4e4a"
 dependencies = [
  "base64",
  "ff",
@@ -7102,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.9.0-rc.3"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f116ea00a3fd0be51027a4d809953b88338020ac8f40ec9f5ec087b21a7a5c8"
+checksum = "416ad7678c8b74d03267410a49f509bb78346b5cc8d5aef04c18bd5184a193cb"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -8216,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "2.0.0-rc.5"
+version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb38f2178857e07f0d832c701ee0fb5b752660a12ccc89df3efcae6a5ee8c42"
+checksum = "30dd82b84145d042cf8019804217fb3255a01ecfe92820463b9c276da99185ba"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,9 +3843,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.4.0-rc.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6547ec35c8d4af154bc73d60fe2773be50f7c089e79414983d721d0dbc13db"
+checksum = "350efadb12ec2d11c8966cd376d9677c9e0038e3bb4aa2acfc69a8edc25700c9"
 dependencies = [
  "anyhow",
  "ff",
@@ -3862,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.3.0-rc.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f3dd9f975f28591b07af57cca89804650c38fa66051cf12f34d664f7ea2ac6"
+checksum = "635f27cfabeca929f821a0f1c934a15f27fd2922a61c487ecf1daa43b20dfd3e"
 dependencies = [
  "anyhow",
  "ff",
@@ -7069,9 +7069,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fac7b20bee99168197ecdb760181d6d731ec7fb2428ff380a4772f2f1abfae9"
+checksum = "22d1048977b2b16cd9ec141fd4521266565a970d41df67d446a6d2dbefe329bd"
 dependencies = [
  "anyhow",
  "ff",
@@ -7086,9 +7086,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3a7fd4c1a40672a2f13c625999b8fefeb44d517230b4db1d4947c473d4e4a"
+checksum = "e818193fc3f7755ccd8d4ea713804a12f9743804737a4ef50a69dc26150b49e8"
 dependencies = [
  "base64",
  "ff",
@@ -7102,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.10.0-rc.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416ad7678c8b74d03267410a49f509bb78346b5cc8d5aef04c18bd5184a193cb"
+checksum = "014def2d1738ecc42253d0cd0f6e74847bc51ccde55ad992abadede7fade76d5"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -8216,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.0.0-rc.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbea3bf21e9185e6e49ec7632a1f2a4ada26542197a6e7cf9d35114eb999a70"
+checksum = "1c184a75b485d9d9d2c37dbf098306de7a33b4705d82ad0ca2b57361443966ab"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8216,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30dd82b84145d042cf8019804217fb3255a01ecfe92820463b9c276da99185ba"
+checksum = "efbea3bf21e9185e6e49ec7632a1f2a4ada26542197a6e7cf9d35114eb999a70"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Zcash voting
-zcash_voting = { version = "=3.0.0-rc.2" }
+zcash_voting = { version = "=3.0.0-rc.3" }
 zeroize = "1"
 
 # Used by the pool-migration engine as well as by voting.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Zcash voting
-zcash_voting = { version = "=2.0.0-rc.5" }
+zcash_voting = { version = "=3.0.0-rc.2" }
 zeroize = "1"
 
 # Used by the pool-migration engine as well as by voting.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Zcash voting
-zcash_voting = { version = "=3.0.0-rc.3" }
+zcash_voting = { version = "=3.0.0" }
 zeroize = "1"
 
 # Used by the pool-migration engine as well as by voting.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,18 @@
 # Migrating from previous versions to _Unreleased_
 
+## Voting rides `zcash_voting` 3.0 — `VotingPirLayout` gains `polyLen`
+
+`VotingPirLayout`'s memberwise initializer gains a required `polyLen: UInt32` — the YPIR RLWE
+polynomial degree (2048 or 4096), taken from the dynamic voting config's `pir_layout.poly_len` —
+and `precomputeDelegationPir(...)` / `buildAndProveDelegation(...)` consume it through the layout.
+`VotingPirLayout.unknown` (`polyLen` 0) fails closed before any private query. Treat a config
+without `poly_len` as a configuration error rather than defaulting: the server's dataset geometry
+is bound to the value, and 3.0 clients verify the advertised degree at connect.
+
+Helper-server payloads returned by `recoverWireJson(...)` now include `vote_round_id`
+(lowercase hex). Remove any app-side injection of that field; the payload remains verbatim wire
+JSON — do not decode, re-shape or re-encode it.
+
 ## Voting wire payloads are produced by `zcash_voting`, not by the SDK
 
 `VotingSharePayload` is removed and `VotingVoteCommit.sharePayloads` is gone with it. Helper-server

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -178,7 +178,8 @@ extension VotingRustBackend {
                             UInt(urlBuf.count),
                             pirLayout.pirDepth,
                             pirLayout.tier0Layers,
-                            pirLayout.tier1Layers
+                            pirLayout.tier1Layers,
+                            pirLayout.polyLen
                         )
                     }
                 }
@@ -2073,6 +2074,7 @@ private extension VotingRustBackend {
                                             pirLayout.pirDepth,
                                             pirLayout.tier0Layers,
                                             pirLayout.tier1Layers,
+                                            pirLayout.polyLen,
                                             trampoline,
                                             progressContext
                                         )

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -584,6 +584,12 @@ public struct VotingPirLayout: Equatable, Sendable {
     public let tier0Layers: UInt32
     public let tier1Layers: UInt32
 
+    /// YPIR RLWE polynomial degree; the crate accepts only 2048 or 4096.
+    ///
+    /// Any other value — including the `0` of ``unknown`` — fails closed in
+    /// `zcash_voting` before any network I/O.
+    public let polyLen: UInt32
+
     /// The crate's `PirLayout::UNKNOWN` sentinel, and its `Default`.
     ///
     /// `zcash_voting` rejects it — "pir_layout is unknown; resolve a current
@@ -592,13 +598,15 @@ public struct VotingPirLayout: Equatable, Sendable {
     public static let unknown = VotingPirLayout(
         pirDepth: 0,
         tier0Layers: 0,
-        tier1Layers: 0
+        tier1Layers: 0,
+        polyLen: 0
     )
 
-    public init(pirDepth: UInt32, tier0Layers: UInt32, tier1Layers: UInt32) {
+    public init(pirDepth: UInt32, tier0Layers: UInt32, tier1Layers: UInt32, polyLen: UInt32) {
         self.pirDepth = pirDepth
         self.tier0Layers = tier0Layers
         self.tier1Layers = tier1Layers
+        self.polyLen = polyLen
     }
 }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -1327,6 +1327,43 @@ final class VotingRustBackendTests: XCTestCase {
         }
     }
 
+    // MARK: - precomputeDelegationPir layout gating
+
+    /// Pins that the `.unknown` sentinel layout (`polyLen` 0) fails closed
+    /// inside `zcash_voting` at the FFI boundary: the crate rejects the layout
+    /// locally, before issuing any network request. The probe stub satisfies
+    /// snapshot resolution offline, so the failure can only be the layout
+    /// rejection, not a resolver or transport error.
+    func test_precomputeDelegationPir_unknownLayout_failsClosedThroughFFI() async throws {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath(), networkId: roundTripNetworkId)
+        defer { backend.close() }
+
+        do {
+            _ = try await backend.precomputeDelegationPir(
+                roundId: hexRoundId(0x11),
+                bundleIndex: 0,
+                notes: [],
+                pirEndpoints: ["https://stub"],
+                expectedSnapshotHeight: 0,
+                pirLayout: .unknown,
+                pirResolver: PirSnapshotResolver(probe: MatchingProbe())
+            )
+            XCTFail("expected .rustError for the unknown PIR layout")
+        } catch let error as VotingRustBackendError {
+            guard case .rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error.localizedDescription)")
+                return
+            }
+            XCTAssertTrue(
+                message.contains("pir_layout is unknown"),
+                "expected the crate's unknown-layout rejection, got: \(message)"
+            )
+        } catch {
+            XCTFail("unexpected error: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeTempDbPath() -> String {
@@ -1523,5 +1560,13 @@ private struct FailingProbe: PirSnapshotProbing {
     func probe(url: String, expectedSnapshotHeight: BlockHeight) async -> PirSnapshotProbeOutcome {
         XCTFail("closed voting backend should fail before probing PIR endpoints")
         return PirSnapshotProbeOutcome(url: url, status: .matching(height: expectedSnapshotHeight))
+    }
+}
+
+/// Probe stub that reports every endpoint as serving the expected snapshot,
+/// letting resolution succeed offline so a test can reach the FFI itself.
+private struct MatchingProbe: PirSnapshotProbing {
+    func probe(url: String, expectedSnapshotHeight: BlockHeight) async -> PirSnapshotProbeOutcome {
+        PirSnapshotProbeOutcome(url: url, status: .matching(height: expectedSnapshotHeight))
     }
 }

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -343,6 +343,11 @@ fn connect_pir_client(
 
 /// Precompute and cache delegation PIR IMT proofs for the delegation ZKP.
 ///
+/// `pir_depth`, `tier0_layers`, `tier1_layers`, and `poly_len` describe the round's
+/// PIR layout from the resolved dynamic voting config. `poly_len` is the YPIR RLWE
+/// polynomial degree and must be 2048 or 4096; any other value (including the
+/// 0 sentinel of an unknown layout) fails closed before any network I/O.
+///
 /// Returns JSON-encoded `DelegationPirPrecomputeResult` as `*mut FfiBoxedSlice`,
 /// or null on error.
 ///
@@ -366,6 +371,7 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
     pir_depth: u32,
     tier0_layers: u32,
     tier1_layers: u32,
+    poly_len: u32,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
@@ -385,6 +391,7 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
             pir_depth,
             tier0_layers,
             tier1_layers,
+            poly_len,
         };
         let pir_client = connect_pir_client(&pir_url, pir_layout)?;
 
@@ -406,6 +413,11 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
 }
 
 /// Build and prove the real delegation ZKP. Long-running.
+///
+/// `pir_depth`, `tier0_layers`, `tier1_layers`, and `poly_len` describe the round's
+/// PIR layout from the resolved dynamic voting config. `poly_len` is the YPIR RLWE
+/// polynomial degree and must be 2048 or 4096; any other value (including the
+/// 0 sentinel of an unknown layout) fails closed before any network I/O.
 ///
 /// Returns JSON-encoded `DelegationProofResult` as `*mut FfiBoxedSlice`, or null on error.
 ///
@@ -444,6 +456,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
     pir_depth: u32,
     tier0_layers: u32,
     tier1_layers: u32,
+    poly_len: u32,
     progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
     progress_context: *mut std::ffi::c_void,
 ) -> *mut crate::ffi::BoxedSlice {
@@ -474,6 +487,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
             pir_depth,
             tier0_layers,
             tier1_layers,
+            poly_len,
         };
         let pir_client = connect_pir_client(&pir_url, pir_layout)?;
 
@@ -703,6 +717,7 @@ mod tests {
     const PIR_DEPTH: u32 = 19;
     const TIER0_LAYERS: u32 = 12;
     const TIER1_LAYERS: u32 = 7;
+    const POLY_LEN: u32 = 4096;
 
     use super::super::constants::HOTKEY_RAW_ADDRESS_LEN;
 
@@ -1189,6 +1204,7 @@ mod tests {
                     PIR_DEPTH,
                     TIER0_LAYERS,
                     TIER1_LAYERS,
+                    POLY_LEN,
                     None,
                     std::ptr::null_mut(),
                 )
@@ -1451,6 +1467,7 @@ mod tests {
                 PIR_DEPTH,
                 TIER0_LAYERS,
                 TIER1_LAYERS,
+                POLY_LEN,
             )
         };
 

--- a/rust/src/voting/recovery.rs
+++ b/rust/src/voting/recovery.rs
@@ -318,7 +318,14 @@ pub unsafe extern "C" fn zcashlc_voting_get_keystone_signatures(
     unwrap_exc_or_null(res)
 }
 
-/// Remove all recovery-state rows for a round.
+/// Clear retryable recovery state for a round without erasing recorded
+/// confirmations.
+///
+/// Share-delegation rows and Keystone signatures are always removed. Since
+/// `zcash_voting` 3.0 the clear is conservative about confirmed state:
+/// delegation tx hashes survive on bundles with a recorded VAN leaf position
+/// (and on capability-imported bundles), and votes with a recorded
+/// `vc_tree_position` keep their tx hash, commitment bundle, and position.
 ///
 /// # Safety
 ///
@@ -589,13 +596,9 @@ mod tests {
         unsafe { zcashlc_voting_db_free(db) };
     }
 
-    #[test]
-    fn clear_recovery_state_removes_stored_recovery_data() {
-        let db = open_memory_db();
-        let round_id = b"round";
-        insert_round_and_bundle(db, "round");
-        insert_vote(db, "round");
-
+    /// Stores the delegation tx hash, vote tx hash, and a Keystone signature
+    /// that the clear-recovery tests start from.
+    fn store_recovery_fixture(db: *mut VotingDatabaseHandle, round_id: &[u8]) {
         let delegation_tx = b"delegation-tx";
         assert_eq!(
             unsafe {
@@ -627,13 +630,6 @@ mod tests {
             0
         );
 
-        assert_eq!(
-            unsafe {
-                zcashlc_voting_record_vc_position(db, round_id.as_ptr(), round_id.len(), 0, 0, 42)
-            },
-            0
-        );
-
         let sig = [1u8; KEYSTONE_SIGNATURE_LEN];
         let sighash = [2u8; PCZT_SIGHASH_LEN];
         let rk = [3u8; RANDOMIZED_KEY_LEN];
@@ -660,6 +656,15 @@ mod tests {
         // nullifier from the persisted vote recovery bundle, which only a real
         // `vote::commit` can write. The clear is still asserted to leave no
         // share rows behind.
+    }
+
+    #[test]
+    fn clear_recovery_state_removes_unconfirmed_recovery_data() {
+        let db = open_memory_db();
+        let round_id = b"round";
+        insert_round_and_bundle(db, "round");
+        insert_vote(db, "round");
+        store_recovery_fixture(db, round_id);
 
         assert_eq!(
             unsafe { zcashlc_voting_clear_recovery_state(db, round_id.as_ptr(), round_id.len()) },
@@ -676,8 +681,8 @@ mod tests {
         });
         assert_eq!(vote_tx, None);
 
-        // A recorded vote-commitment-tree position is immutable while it is set,
-        // so accepting a different position proves the clear removed it.
+        // No position was recorded before the clear, so the vote row survives
+        // with its recovery columns reset and accepts a fresh recording.
         assert_eq!(
             unsafe {
                 zcashlc_voting_record_vc_position(db, round_id.as_ptr(), round_id.len(), 0, 0, 43)
@@ -694,6 +699,66 @@ mod tests {
             zcashlc_voting_get_share_delegations(db, round_id.as_ptr(), round_id.len())
         });
         assert!(share_delegations.is_empty());
+
+        unsafe { zcashlc_voting_db_free(db) };
+    }
+
+    /// Pins the conservative `zcash_voting` 3.0 clear semantics: a vote whose
+    /// on-chain `vc_tree_position` is recorded is confirmed state, and the
+    /// recovery clear must preserve it (rc.5 nulled it unconditionally).
+    #[test]
+    fn clear_recovery_state_preserves_recorded_vc_position() {
+        let db = open_memory_db();
+        let round_id = b"round";
+        insert_round_and_bundle(db, "round");
+        insert_vote(db, "round");
+        store_recovery_fixture(db, round_id);
+
+        assert_eq!(
+            unsafe {
+                zcashlc_voting_record_vc_position(db, round_id.as_ptr(), round_id.len(), 0, 0, 42)
+            },
+            0
+        );
+
+        assert_eq!(
+            unsafe { zcashlc_voting_clear_recovery_state(db, round_id.as_ptr(), round_id.len()) },
+            0
+        );
+
+        // The confirmed vote keeps its tx hash: the vote reset skips rows with
+        // a recorded position.
+        let vote_tx: Option<String> = decode_boxed_json(unsafe {
+            zcashlc_voting_get_vote_tx_hash(db, round_id.as_ptr(), round_id.len(), 0, 0)
+        });
+        assert_eq!(vote_tx.as_deref(), Some("vote-tx"));
+
+        // The recorded position survived: a conflicting recording is refused
+        // while re-recording the same position stays idempotent.
+        assert_eq!(
+            unsafe {
+                zcashlc_voting_record_vc_position(db, round_id.as_ptr(), round_id.len(), 0, 0, 43)
+            },
+            -1
+        );
+        assert_eq!(
+            unsafe {
+                zcashlc_voting_record_vc_position(db, round_id.as_ptr(), round_id.len(), 0, 0, 42)
+            },
+            0
+        );
+
+        // The unconfirmed delegation (no recorded VAN leaf position) is still
+        // cleared, and the unconditional lanes still empty out.
+        let delegation_tx: Option<String> = decode_boxed_json(unsafe {
+            zcashlc_voting_get_delegation_tx_hash(db, round_id.as_ptr(), round_id.len(), 0)
+        });
+        assert_eq!(delegation_tx, None);
+
+        let keystone_sigs: Vec<serde_json::Value> = decode_boxed_json(unsafe {
+            zcashlc_voting_get_keystone_signatures(db, round_id.as_ptr(), round_id.len())
+        });
+        assert!(keystone_sigs.is_empty());
 
         unsafe { zcashlc_voting_db_free(db) };
     }

--- a/rust/src/voting/rounds.rs
+++ b/rust/src/voting/rounds.rs
@@ -286,6 +286,11 @@ pub unsafe extern "C" fn zcashlc_voting_clear_round(
 
 /// Delete bundle rows with index >= `keep_count`, removing skipped bundles.
 ///
+/// Since `zcash_voting` 3.0 this fails for rounds holding capability-imported
+/// bundles: the imported batch is atomic, so it must be replaced via
+/// `zcashlc_voting_clear_round` and a complete re-import instead of partial
+/// deletion. Locally prepared rounds are unaffected.
+///
 /// Returns the number of deleted rows on success, or -1 on error.
 ///
 /// # Safety
@@ -461,6 +466,54 @@ mod tests {
 
         assert_eq!(code, 0);
         assert!(round_exists(db, round_id));
+
+        unsafe { zcashlc_voting_db_free(db) };
+    }
+
+    #[test]
+    fn delete_skipped_bundles_deletes_from_locally_prepared_rounds() {
+        use crate::voting::test_helpers::insert_round_and_bundle;
+
+        let db = open_memory_db();
+        let round_id = b"round";
+        insert_round_and_bundle(db, "round");
+
+        let deleted = unsafe {
+            zcashlc_voting_delete_skipped_bundles(db, round_id.as_ptr(), round_id.len(), 0)
+        };
+        assert_eq!(deleted, 1);
+
+        unsafe { zcashlc_voting_db_free(db) };
+    }
+
+    /// Pins the `zcash_voting` 3.0 atomicity guard: an imported-capability
+    /// batch cannot be partially deleted, only replaced via a round clear and
+    /// a complete re-import.
+    #[test]
+    fn delete_skipped_bundles_rejects_imported_capability_rounds() {
+        use crate::voting::test_helpers::insert_round_and_bundle;
+
+        let db = open_memory_db();
+        let round_id = b"round";
+        insert_round_and_bundle(db, "round");
+
+        // Simulate a capability-imported bundle through the storage
+        // discriminator the crate documents: imported bundles are exactly
+        // those persisted without note positions (local preparation always
+        // stores them; rc.5 databases therefore never trip this guard).
+        {
+            let handle = unsafe { db.as_ref() }.expect("voting db handle");
+            handle
+                .db
+                .conn()
+                .execute("UPDATE bundles SET note_positions_blob = NULL", [])
+                .expect("mark bundle as capability-imported");
+        }
+
+        let deleted = unsafe {
+            zcashlc_voting_delete_skipped_bundles(db, round_id.as_ptr(), round_id.len(), 0)
+        };
+        assert_eq!(deleted, -1);
 
         unsafe { zcashlc_voting_db_free(db) };
     }

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -458,8 +458,12 @@ mod tests {
             .map(|i| [0x51 + i as u8; 32])
             .collect();
 
+        // Canonical 64-char lowercase-hex round id, matching the crate's own
+        // `share.rs` fixture: since 3.0.0-rc.3, `serialize_recovery` and
+        // `parse_recovery` validate `vote_round_id` as a canonical Pallas
+        // field element, so a placeholder like "round1" no longer round-trips.
         voting::vote::VoteRecoveryBundle {
-            vote_round_id: "round1".to_string(),
+            vote_round_id: "01".repeat(32),
             bundle_index: 0,
             proposal_id: 1,
             vote_decision: 2,

--- a/rust/src/voting/tree.rs
+++ b/rust/src/voting/tree.rs
@@ -14,6 +14,13 @@ use super::helpers::{json_to_boxed_slice, str_from_ptr};
 
 /// Sync the vote commitment tree from a chain node.
 ///
+/// Since `zcash_voting` 3.0 the sync also validates confirmed VAN entries
+/// against the synced tree, so two new failure shapes surface here as error
+/// messages: a confirmed delegation bundle that does not match its synced
+/// vote-tree leaf (the crate resets the round's tree client; witnesses cannot
+/// be generated from unverified data), and a confirmed position still absent
+/// from the synced tree (incremental state is kept; the next sync resumes).
+///
 /// Returns the latest synced block height on success (>= 0), or -1 on error.
 ///
 /// # Safety


### PR DESCRIPTION
Stacked on #1962 (base `chp-re-enable`). Consumed by the Zodl app's `chp-30-bump` branch (zodl-inc/zodl-ios#1992, MOB-1678).

## Why this exists

Valar's v1.3.0 rollout intentionally broke the 2.0-family clients (their confirmation, Aug 13/14): the PIR dataset moved to `poly_len: 4096` — 2.0-family clients hardcode 2048 in query construction, so every tier1 query 502s — and **prod upgrades Friday with no dual-serving**. `zcash_voting 3.0.0-rc.3` is the intended wallet target for the scheduled session.

## What this is

- **Pin `=2.0.0-rc.5` → `=3.0.0-rc.3`**; the lock moves exactly the crate's own family (poly-aware `pir-client 0.4.0-rc.7` / `pir-types 0.3.0-rc.6` / `valar-ypir 0.2.0`, plus the VCT/circuits rcs) — nothing else.
- **`poly_len` threading**: `VotingPirLayout` gains a required `polyLen` (2048/4096) and both delegation FFI entry points (`zcashlc_voting_precompute_delegation_pir`, `zcashlc_voting_build_and_prove_delegation`) take it — the only two `PirLayout` construction sites. Queries are now built for the server's advertised degree, and 3.0 verifies it at connect (loud mismatch instead of opaque 502s). `.unknown` (`polyLen` 0) still fails closed. Symbol table unchanged (234 exports, nm diff empty — C symbols don't encode params; the ABI change is carried by the regenerated header).
- **`VoteShareWire.vote_round_id`** (new in rc.3): helper payloads from `recoverWireJson` now include the round id (32 bytes lowercase hex) — the app deletes its injection.
- FFI tests re-pinned to 3.0's safer storage semantics (recovery-clear now preserves confirmed state; imported-capability rounds refuse partial bundle deletion) + a fail-closed `.unknown`-layout test.
- MIGRATING/CHANGELOG entries for the source-breaking `VotingPirLayout` init.

## Evidence

- `cargo test --lib voting`: 87/87. `swift test --filter OfflineTests`: 874/0. FFI symbol surface identical (nm diff empty). All three local FFI slices rebuilt with the new signatures.
- Migrations are byte-identical to rc.5 — an existing `voting.sqlite3` opens in place; no reset.
- **Live on stage v1.3.0 (2026-08-14): full end-to-end vote** via the consuming Zodl branch — auth-v2 rounds authenticate, PIR tier1 answers 200 on the 4096 dataset, delegation + vote + all shares accepted.
- The finding-#10 resume guards (write-once `pczt_sighash`, deterministic re-prove) survive in 3.0 at the same points — verified in the campaign's crate-diff map.
- **2026-08-14: restacked onto post-#1971 `main`** (4/4 patches byte-equal by range-diff). Re-measured on this head: cargo voting 87/87, OfflineTests 891/0 (incl. main's 17 new broadcaster/readback tests), all three FFI slices rebuilt — the escalated-fix symbol (`zcashlc_free_transaction_data`) verified present in each alongside the voting surface.

## Where to look

- `Cargo.toml` / `Cargo.lock` — the pin and its exact family movement.
- `rust/src/voting/delegation.rs` — the two grown FFI signatures.
- `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift` — `VotingPirLayout.polyLen`.
- `MIGRATING.md` / `CHANGELOG.md` — the consumer-facing story.

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes?
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
