### PR TITLE
Merge `feature/ironwood-slipstream` changes back to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,15 @@ Changes are relative to `2.8.0-rc.3`.
   file") that previously only `SDKSynchronizer.wipe()` honored: a wallet wiped through the
   Slipstream synchronizer left `submit_plans_<networkId>.db` behind, together with any retry
   plans it held for transactions the wipe had just erased. [#1976]
+- Background transaction resubmission now runs under `SlipstreamSynchronizer` too: unmined,
+  unexpired transactions are periodically re-broadcast through their recorded submit plans, and
+  plans whose transactions have expired are pruned — matching `SDKSynchronizer`. A transaction
+  that never reached the network (submitted while the server was unreachable, or dropped from
+  every mempool it was sent to) previously got a second chance only on the old sync pipeline,
+  which ran the resubmission step once per sync pass; the Slipstream synchronizer has no action
+  list and so did nothing at all. It now drives the same resubmission core from its poll loop —
+  a check at most once a minute while the engine is syncing or synced, with the re-broadcast
+  itself throttled exactly as it always was. [#1975]
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,11 @@ Changes are relative to `2.8.0-rc.3`.
   and so absent from `getTransactionOutputs(for:)`, until the transaction was
   mined and scanned. Shielded outputs stored by this path are also now tagged with
   their note commitment tree, as the ordinary send path already did.
+- `SlipstreamSynchronizer.wipe()` now deletes the submit-plan database file, restoring the
+  documented `Synchronizer.wipe()` contract ("`Synchronizer.wipe()` deletes the plan database
+  file") that previously only `SDKSynchronizer.wipe()` honored: a wallet wiped through the
+  Slipstream synchronizer left `submit_plans_<networkId>.db` behind, together with any retry
+  plans it held for transactions the wipe had just erased. [#1976]
 
 ## Added
 

--- a/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
@@ -8,23 +8,23 @@
 import Foundation
 
 final class TxResubmissionAction {
-    private enum Constants {
-        static let thresholdToTrigger = TimeInterval(300.0)
+    let resubmitter: TxResubmitter
+
+    var latestResolvedTime: TimeInterval {
+        get { resubmitter.latestResolvedTime }
+        set { resubmitter.latestResolvedTime = newValue }
     }
 
-    var latestResolvedTime: TimeInterval = Date().timeIntervalSince1970
-    let transactionRepository: TransactionRepository
-    var transactionEncoder: TransactionEncoder
-    let submitPlanStore: SubmitPlanStoring
-    let submitPlanExecutor: SubmitPlanExecutor
-    let logger: Logger
+    // `CompactBlockProcessor.updateService(_:)` re-wires this with a freshly
+    // resolved encoder after a server switch; forward to the resubmitter so
+    // that update keeps reaching the instance actually used for resubmission.
+    var transactionEncoder: TransactionEncoder {
+        get { resubmitter.transactionEncoder }
+        set { resubmitter.transactionEncoder = newValue }
+    }
 
     init(container: DIContainer) {
-        transactionRepository = container.resolve(TransactionRepository.self)
-        transactionEncoder = container.resolve(TransactionEncoder.self)
-        submitPlanStore = container.resolve(SubmitPlanStoring.self)
-        submitPlanExecutor = container.resolve(SubmitPlanExecutor.self)
-        logger = container.resolve(Logger.self)
+        resubmitter = TxResubmitter(container: container)
     }
 }
 
@@ -34,48 +34,7 @@ extension TxResubmissionAction: Action {
     func run(with context: ActionContext, didUpdate: @escaping (CompactBlockProcessor.Event) async -> Void) async throws -> ActionContext {
         let latestBlockHeight = await context.syncControlData.latestBlockHeight
 
-        // Plans whose transactions are expired or gone are no longer retry
-        // candidates; drop them. Mined transactions keep their plans until
-        // expiry so a reorg that un-mines one still retries through its
-        // recorded endpoints — findForResubmission excludes mined transactions,
-        // so a retained plan costs nothing meanwhile. Decisions are made per
-        // transaction from current repository state, so a transaction created
-        // mid-pass can never be wrongly pruned.
-        await pruneStalePlans(latestBlockHeight: latestBlockHeight)
-
-        // find all candidates for the resubmission
-        do {
-            logger.info("TxResubmissionAction check started at \(latestBlockHeight) height.")
-            let transactions = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
-            logger.debug("TxResubmissionAction found \(transactions.count) resubmission candidate(s).")
-
-            // no candidates, update the time and continue with the next action
-            if transactions.isEmpty {
-                latestResolvedTime = Date().timeIntervalSince1970
-            } else {
-                let now = Date().timeIntervalSince1970
-                let diff = now - latestResolvedTime
-
-                // the last time resubmission was triggered is more than 5 minutes ago so try again
-                if diff > Constants.thresholdToTrigger {
-                    // resubmission; per-transaction error handling so one
-                    // transaction's dead endpoints can't starve the others
-                    for transaction in transactions {
-                        do {
-                            try await resubmit(transaction: transaction)
-                        } catch {
-                            logger.error(
-                                "TxResubmissionAction failed to resubmit transaction \(transaction.rawID.toHexStringTxId()): \(error)"
-                            )
-                        }
-                    }
-
-                    latestResolvedTime = Date().timeIntervalSince1970
-                }
-            }
-        } catch {
-            logger.error("TxResubmissionAction failed to find candidates.")
-        }
+        await resubmitter.checkAndResubmit(latestBlockHeight: latestBlockHeight)
 
         if await context.prevState == .enhance {
             await context.update(state: .updateChainTip)
@@ -86,91 +45,4 @@ extension TxResubmissionAction: Action {
     }
 
     func stop() async { }
-}
-
-private extension TxResubmissionAction {
-    func resubmit(transaction: ZcashTransaction.Overview) async throws {
-        let plan = await submitPlanStore.plan(for: transaction.rawID)
-
-        switch plan {
-        case .awaiting:
-            // Created through Broadcaster but never submitted by the app —
-            // resubmitting would broadcast something the user may have cancelled.
-            logger.info(
-                "TxResubmissionAction skipping transaction \(transaction.rawID.toHexStringTxId()) until it is submitted by the app."
-            )
-
-        case .ready(let endpoints):
-            logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()) via its submit plan.")
-            let createdTransaction = try CreatedTransaction(overview: transaction)
-            try await submitPlanExecutor.submit(transaction: createdTransaction, endpoints: endpoints)
-
-        case .storeUnavailable:
-            // Whether the app ever submitted this transaction is unknown.
-            // Skip rather than risk broadcasting something the user never
-            // released or using an endpoint the user didn't choose.
-            logger.warn(
-                "TxResubmissionAction skipping transaction \(transaction.rawID.toHexStringTxId()): the submit plan store is unavailable."
-            )
-
-        case nil:
-            logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()).")
-            let encodedTransaction = try transaction.encodedTransaction()
-            try await transactionEncoder.submit(transaction: encodedTransaction)
-        }
-    }
-
-    func pruneStalePlans(latestBlockHeight: BlockHeight) async {
-        let plannedTxIds = await submitPlanStore.allPlannedTransactionIds()
-        guard !plannedTxIds.isEmpty else { return }
-
-        var staleTxIds: [Data] = []
-        for txId in plannedTxIds {
-            do {
-                let transaction = try await transactionRepository.find(rawID: txId)
-                // Stale only once expired: pruning at "mined" would lose the
-                // plan if a reorg un-mines the transaction inside its expiry
-                // window. Transactions without an expiry height are never
-                // resubmission candidates, so their plans are stale right away.
-                let isStale = (transaction.expiryHeight ?? 0) <= latestBlockHeight
-                if isStale {
-                    staleTxIds.append(txId)
-                }
-            } catch ZcashError.transactionRepositoryEntityNotFound {
-                do {
-                    guard let created = try await transactionEncoder.createdTransactions(forTxIds: [txId]).first,
-                          let expiryHeight = created.expiryHeight,
-                          expiryHeight > latestBlockHeight
-                    else {
-                        staleTxIds.append(txId)
-                        continue
-                    }
-                    logger.warn(
-                        "TxResubmissionAction keeping plan for view-invisible wallet-store transaction \(txId.toHexStringTxId())."
-                    )
-                } catch {
-                    // An unreadable wallet store is inconclusive. Keep the plan and retry later.
-                    logger.warn(
-                        """
-                        TxResubmissionAction could not verify view-invisible transaction \(txId.toHexStringTxId()): \
-                        \(error.localizedDescription)
-                        """
-                    )
-                }
-            } catch {
-                // Unknown repository error — keep the plan, try again next pass.
-                logger.warn(
-                    """
-                    TxResubmissionAction could not check plan staleness for \(txId.toHexStringTxId()): \
-                    \(error.localizedDescription)
-                    """
-                )
-            }
-        }
-
-        if !staleTxIds.isEmpty {
-            logger.info("TxResubmissionAction pruning \(staleTxIds.count) stale submit plan(s).")
-            await submitPlanStore.deletePlans(txIds: staleTxIds)
-        }
-    }
 }

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -49,6 +49,10 @@ public actor SlipstreamSynchronizer: Synchronizer {
     private let transactionRepository: TransactionRepository
     private let transactionEncoder: TransactionEncoder
     private let broadcasterStorage: Broadcaster
+    /// [#1976] Resolved once in `init` from the container (same singleton `broadcasterStorage`'s
+    /// `SDKBroadcaster` uses) so `wipe()` can delete the plan database directly — mirrors
+    /// `SDKSynchronizer`'s `submitPlanStore` property exactly.
+    private let submitPlanStore: SubmitPlanStoring
 
     /// The one migration host this synchronizer owns (see `OrchardMigrationHost`'s type doc: each
     /// synchronizer holds exactly one). Registered on `initializer.container` and resolved
@@ -203,6 +207,9 @@ public actor SlipstreamSynchronizer: Synchronizer {
         self.migrationHost = initializer.container.resolve(OrchardMigrationHost.self)
 
         let transactionEncoderRef = WalletTransactionEncoder(initializer: initializer)
+        // [#1976] Resolved once here (it's a singleton) and stored on `self` so `wipeImpl(_:)`
+        // can wipe it directly; the same instance is handed to `SDKBroadcaster` below.
+        self.submitPlanStore = initializer.container.resolve(SubmitPlanStoring.self)
         // [#1755] zcash #1757 (multiserver submission) reworked SDKBroadcaster's init: it now
         // takes submitPlanStore + multiEndpointSubmitter (resolved from the container, same as
         // SDKSynchronizer) and no longer takes sdkFlags. Mirror SDKSynchronizer exactly.
@@ -211,7 +218,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
             initializer: initializer,
             logger: logger,
             eventSubject: eventSubjectRef,
-            submitPlanStore: initializer.container.resolve(SubmitPlanStoring.self),
+            submitPlanStore: submitPlanStore,
             multiEndpointSubmitter: initializer.container.resolve(MultiEndpointSubmitter.self),
             statusCheck: {}
         )
@@ -1069,8 +1076,11 @@ public actor SlipstreamSynchronizer: Synchronizer {
     /// 4. Delete `data.db` + its WAL (`-wal`) and shared-memory (`-shm`) siblings.
     /// 5. Delete the `fsBlockDbRoot` directory (parity with old SDK's `storage.clear()` +
     ///    FS-cache directory removal; Slipstream does not use it but the app may have created it).
-    /// 6. Reset the state subject to `.zero` (status `.unprepared`).
-    /// 7. Complete the returned publisher — or fail it if any file-removal throws.
+    /// 6. Delete the submit-plan-store database file (`submitPlanStore.wipe()`) — restores the
+    ///    documented `Synchronizer.wipe()` contract ("`Synchronizer.wipe()` deletes the plan
+    ///    database file", MIGRATING.md) that only `SDKSynchronizer` used to honor ([#1976]).
+    /// 7. Reset the state subject to `.zero` (status `.unprepared`).
+    /// 8. Complete the returned publisher — or fail it if any file-removal throws.
     ///
     /// The publisher uses a `PassthroughSubject` driven from a `Task(priority: .high)`,
     /// mirroring the `SDKSynchronizer.wipe()` idiom.
@@ -1131,10 +1141,15 @@ public actor SlipstreamSynchronizer: Synchronizer {
                 try fileManager.removeItem(at: fsRoot)
             }
 
-            // 6. Reset state to unprepared/zero.
+            // 6. Delete the submit-plan-store database file — mirrors SDKSynchronizer.wipe()
+            //    (SDKSynchronizer.swift:815-818), which wipes the plan store only when the
+            //    wallet wipe succeeded (this `do` block only reaches here on success).
+            await submitPlanStore.wipe()
+
+            // 7. Reset state to unprepared/zero.
             stateSubject.send(.zero)
 
-            // 7. Signal completion.
+            // 8. Signal completion.
             subject.send(completion: .finished)
         } catch {
             subject.send(completion: .failure(error))

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -53,6 +53,9 @@ public actor SlipstreamSynchronizer: Synchronizer {
     /// `SDKBroadcaster` uses) so `wipe()` can delete the plan database directly — mirrors
     /// `SDKSynchronizer`'s `submitPlanStore` property exactly.
     private let submitPlanStore: SubmitPlanStoring
+    /// [#1975] The resubmission core shared with the old pipeline's `TxResubmissionAction`
+    /// (same type, same retry policy, same 300 s throttle) — see the driver block below.
+    private let txResubmitter: TxResubmitter
 
     /// The one migration host this synchronizer owns (see `OrchardMigrationHost`'s type doc: each
     /// synchronizer holds exactly one). Registered on `initializer.container` and resolved
@@ -131,6 +134,46 @@ public actor SlipstreamSynchronizer: Synchronizer {
     /// healthy sync. `internal` so tests can reference the constant.
     static let stallWatchdogThresholdSeconds: TimeInterval = 120
 
+    // ── [#1975] Background transaction resubmission ────────────────────────────
+    // Parity with the old pipeline's `TxResubmissionAction`, which ran once per sync pass:
+    // unmined, unexpired transactions are re-broadcast through their recorded submit plans,
+    // and plans whose transactions expired are pruned. `SlipstreamSynchronizer` has no action
+    // list, so the poll loop drives it — `tickPoll` asks `maybeRunTxResubmission` on every
+    // 2 s tick and the guards below decide.
+    //
+    // Two cadences, deliberately: the CHECK runs at most every
+    // `resubmissionCheckInterval` (60 s — it walks the transaction table and the plan store),
+    // while the actual re-broadcast is throttled to 300 s INSIDE `TxResubmitter`
+    // (`Constants.thresholdToTrigger`, shared with the old pipeline). The prune runs on every
+    // check. This host duplicates neither number.
+    //
+    // Teardown (`stopImpl`, `wipeImpl`) only CANCELS `resubmissionTask`; it never nils the
+    // handle. The fired task clears it itself, as its last step, through the actor-isolated
+    // `finishResubmissionCheck()` — a single writer. If teardown also nil'd the handle, a fast
+    // stop→start could let a stale task's finish clear a NEWER task's handle and re-open the
+    // spawn guard while that new task still runs (double-spawn). Cancel-only teardown keeps
+    // the guard closed until the cancelled task's own finish clears it, which is benign and
+    // self-healing. Note the LIMIT of that cancellation: only the SUBMIT stage observes it
+    // (`SubmitPlanExecutor.submit` checks `Task.checkCancellation`, and `TxResubmitter` catches
+    // per transaction). The prune stage has no cancellation checks at all and runs to
+    // completion — which is why `wipeImpl` cancels AND joins (below), rather than trusting
+    // cancellation to stop a check that would otherwise write to files it is deleting.
+    //
+    // The driver is also gated on the CALLER's cancellation (`isCancelled`, defaulted to
+    // `Task.isCancelled` so it is evaluated in the caller's task context). `stopPolling()`
+    // cancels `pollTask` without awaiting it, and teardown then suspends (`engine.stop()`,
+    // `engine.close()`), so a `tickPoll` that was suspended mid-tick can RESUME inside the
+    // teardown and walk on to this driver. Without that gate a wipe could spawn a fresh,
+    // uncancelled check that reads `data.db` and re-creates the submit-plan database SQLite
+    // just deleted (a connect resurrects the file), undoing [#1976] a few milliseconds later.
+    /// Wall-clock stamp (`timeIntervalSince1970`) of the last check the driver FIRED; 0 = never.
+    private var lastResubmissionCheckTime: TimeInterval = 0
+    /// The in-flight check, if any. Doubles as the "one at a time" guard: a slow submit round
+    /// must never be joined by a second concurrent pass over the same transactions.
+    private var resubmissionTask: Task<Void, Never>?
+    /// How often the poll loop may run a resubmission check: 60 s (the poll tick is 2 s).
+    /// `internal` so tests can reference the constant, like `stallWatchdogThresholdSeconds`.
+    static let resubmissionCheckInterval: TimeInterval = 60
 
     // [v2.1 E-3] The host-side summary cache is GONE: the engine caches the summary itself
     // (E-1) and the warm-start emissions it fed read the truthful-from-open snapshot instead.
@@ -210,6 +253,9 @@ public actor SlipstreamSynchronizer: Synchronizer {
         // [#1976] Resolved once here (it's a singleton) and stored on `self` so `wipeImpl(_:)`
         // can wipe it directly; the same instance is handed to `SDKBroadcaster` below.
         self.submitPlanStore = initializer.container.resolve(SubmitPlanStoring.self)
+        // [#1975] Same container, same singletons the old pipeline's `TxResubmissionAction`
+        // resolves — so both synchronizers resubmit through one implementation.
+        self.txResubmitter = TxResubmitter(container: initializer.container)
         // [#1755] zcash #1757 (multiserver submission) reworked SDKBroadcaster's init: it now
         // takes submitPlanStore + multiEndpointSubmitter (resolved from the container, same as
         // SDKSynchronizer) and no longer takes sdkFlags. Mirror SDKSynchronizer exactly.
@@ -365,6 +411,10 @@ public actor SlipstreamSynchronizer: Synchronizer {
     private func stopImpl() async {
         isRunning = false
         stopPolling()
+        // [#1975] Cancel, don't join: nothing is being deleted here, so a check that runs a
+        //   moment longer is harmless, and `stop()` must stay prompt. Cancel ONLY — the fired
+        //   task clears the handle itself (see the driver block).
+        resubmissionTask?.cancel()
         // T8.3 (T5.5 wart fix): only emit .stopped if we were prepared. stop() on an
         // unprepared synchronizer (Zodl calls it unconditionally on didEnterBackground,
         // RootInitialization.swift:75-76) must NOT forge isPrepared by moving
@@ -542,6 +592,11 @@ public actor SlipstreamSynchronizer: Synchronizer {
             ))
         }
 
+        // ── [#1975] Background resubmission ───────────────────────────────────
+        // Non-blocking: the guards are evaluated inline and the work (if any) runs in its own
+        // task, so a slow submit round can never stretch a poll tick.
+        maybeRunTxResubmission(state: snap.state, chainTip: snap.chainTip)
+
         // ── foundTransactions: the E-4 one-line rule ──────────────────────────
         // The ENGINE versions the stored tx set (`snap.txSetVersion`: enhancement writes,
         // mempool hits, boundary reconcile-linkage transitions, post-submit pokes — a
@@ -557,6 +612,106 @@ public actor SlipstreamSynchronizer: Synchronizer {
             let txs = await droppingUnreconciled(await enhanceWithState((try? await transactionRepository.find(offset: 0, limit: 50, kind: .all)) ?? []))
             eventSubject.send(.foundTransactions(txs, nil))
         }
+    }
+
+    /// [#1975] The poll loop's background-resubmission driver: decides (via the pure
+    /// `resubmissionCheckDue` gate) whether this tick runs a resubmission check, and if so fires
+    /// it in `resubmissionTask`. Synchronous and non-blocking — the caller's tick never waits on
+    /// the check. See the driver block at the top of the type for the two cadences and the
+    /// cancel-only teardown rule.
+    ///
+    /// `internal` (not `private`) so `@testable` tests can drive the gate directly, mirroring
+    /// `setInternalSyncStatusForTesting`; production's only caller is `tickPoll`.
+    ///
+    /// - Parameters:
+    ///   - state: `snap.state` (0 = disconnected, 1 = syncing, 2 = error, 3 = done).
+    ///   - chainTip: `snap.chainTip` — the resubmission candidates are selected `upTo:` it.
+    ///   - isCancelled: whether the CALLING task is cancelled. Defaulted to `Task.isCancelled`,
+    ///     which — because default arguments are evaluated at the call site — reads the poll
+    ///     task's own flag when `tickPoll` calls this. A tick that resumes after teardown
+    ///     cancelled `pollTask` therefore fires nothing; see the driver block above for the
+    ///     wipe-resurrects-the-plan-database failure this closes. Tests pass it explicitly.
+    func maybeRunTxResubmission(state: UInt8, chainTip: UInt64, isCancelled: Bool = Task.isCancelled) {
+        let now = Date().timeIntervalSince1970
+        guard SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: isCancelled,
+            state: state,
+            chainTip: chainTip,
+            secondsSinceLastCheck: now - lastResubmissionCheckTime,
+            inFlight: resubmissionTask != nil
+        ) else { return }
+
+        // Stamped at FIRE time, not at completion: the cadence is "a check every 60 s", and a
+        // check that takes a while must not push the next one further out.
+        lastResubmissionCheckTime = now
+        let latestBlockHeight = BlockHeight(chainTip)
+        resubmissionTask = Task { [weak self] in
+            guard let self else { return }
+            await self.runResubmissionCheck(latestBlockHeight: latestBlockHeight)
+        }
+    }
+
+    /// The actor-isolated body of one resubmission check: hops back onto the actor so
+    /// `txResubmitter` never leaves it, and clears the in-flight handle on every exit path.
+    private func runResubmissionCheck(latestBlockHeight: BlockHeight) async {
+        defer { finishResubmissionCheck() }
+        // Non-throwing: `TxResubmitter` logs and swallows both the candidate lookup and every
+        // per-transaction submit failure (a cancelled submit included), so one dead endpoint —
+        // or a teardown mid-check — can never escape as an unhandled error here.
+        await txResubmitter.checkAndResubmit(latestBlockHeight: latestBlockHeight)
+    }
+
+    /// Clears the in-flight handle. THE single writer that nils `resubmissionTask` (teardown only
+    /// cancels) — see the driver block for why that ordering is what keeps the spawn guard sound.
+    private func finishResubmissionCheck() {
+        resubmissionTask = nil
+    }
+
+    /// Test-only seam: awaits the in-flight resubmission check (if any) and returns the stamp of
+    /// the last check the driver FIRED (0 = never). Lets `@testable` tests observe the interval
+    /// gate deterministically instead of sleeping, and guarantees a follow-up call is gated by
+    /// the interval rather than merely by "in flight". `internal`, never called by production.
+    func awaitResubmissionCheckForTesting() async -> TimeInterval {
+        await resubmissionTask?.value
+        return lastResubmissionCheckTime
+    }
+
+    /// Test-only seam: whether a check is in flight. Pins the single-writer invariant — after a
+    /// completed check this must read false (the task's own `finishResubmissionCheck()` cleared
+    /// the handle), and it must NOT be false merely because teardown nil'd it. `internal`.
+    var resubmissionCheckInFlightForTesting: Bool { resubmissionTask != nil }
+
+    /// Pure gate for the background-resubmission driver. Static + pure so the truth table is
+    /// unit-testable without an engine, mirroring `isSyncStalled`.
+    ///
+    /// - Parameters:
+    ///   - isCancelled: whether the calling task is cancelled. Checked FIRST: a cancelled poll
+    ///     task means teardown is in progress (possibly a `wipe()` deleting the very databases a
+    ///     check would touch), so nothing else about the tick can make a check legitimate.
+    ///   - state: `snap.state`. Only Syncing (1) and Done (3) check — those are the states with
+    ///     a live server connection, and they mirror the old pipeline, which ran
+    ///     `TxResubmissionAction` once per sync pass. Disconnected (0) / Error (2) have no
+    ///     network, so a check there could only burn a database walk and log failures.
+    ///   - chainTip: `snap.chainTip`; 0 means the server tip is not known yet, and candidates
+    ///     are selected `upTo:` that height, so there is nothing to resolve.
+    ///   - secondsSinceLastCheck: elapsed wall time since the last check FIRED (an elapsed span
+    ///     rather than two timestamps, mirroring `isSyncStalled`). Enormous before the first
+    ///     check (the stamp starts at 0), so the first eligible tick always fires; a backwards
+    ///     clock adjustment can make it negative, which merely defers the next check.
+    ///   - inFlight: whether a check is already running.
+    /// - Returns: true when this tick should run a resubmission check.
+    static func resubmissionCheckDue(
+        isCancelled: Bool,
+        state: UInt8,
+        chainTip: UInt64,
+        secondsSinceLastCheck: TimeInterval,
+        inFlight: Bool
+    ) -> Bool {
+        guard !isCancelled else { return false }
+        guard state == 1 || state == 3 else { return false }
+        guard chainTip > 0 else { return false }
+        guard !inFlight else { return false }
+        return secondsSinceLastCheck >= resubmissionCheckInterval
     }
 
     /// [v2.1 Phase 2] THE summary source for the slipstream path: the engine's unified
@@ -1070,7 +1225,8 @@ public actor SlipstreamSynchronizer: Synchronizer {
     /// Wipes all wallet data managed by this synchronizer.
     ///
     /// Mirrors `SDKSynchronizer.wipe()` + `CompactBlockProcessor.doWipe()`:
-    /// 1. Stop the poll loop.
+    /// 1. Stop the poll loop, then cancel AND await any in-flight background resubmission
+    ///    check ([#1975]) — it must not still be reading or writing the files step 4 deletes.
     /// 2. `engine.stop()` — cancel any in-flight sync task.
     /// 3. `engine.close()` — free the Rust handle so no Rust-side state survives file deletion.
     /// 4. Delete `data.db` + its WAL (`-wal`) and shared-memory (`-shm`) siblings.
@@ -1100,6 +1256,18 @@ public actor SlipstreamSynchronizer: Synchronizer {
     private func wipeImpl(_ subject: PassthroughSubject<Void, Error>) async {
         // 1. Stop polling.
         stopPolling()
+        // 1a. [#1975] Cancel AND JOIN any in-flight resubmission check — it reads and writes the
+        //     very database files about to be deleted. Cancel alone is not enough: only the
+        //     SUBMIT stage observes cancellation (`SubmitPlanExecutor.submit`), while the prune
+        //     stage has no cancellation checks and would run on to `deletePlans` after the plan
+        //     file was removed. Joining does not violate the single-writer rule (that forbids
+        //     nil'ing the handle here, not awaiting it): the task's own `finishResubmissionCheck()`
+        //     clears it, and has done so by the time `.value` returns. No deadlock — awaiting
+        //     suspends `wipeImpl` and frees the actor for that finish hop. A tick that resumes
+        //     during this wipe cannot start a new check: `pollTask` is cancelled, and the driver
+        //     is gated on the caller's cancellation.
+        resubmissionTask?.cancel()
+        await resubmissionTask?.value
 
         // 2. Stop the in-flight sync (non-blocking cancel in Rust).
         await engine.stop()

--- a/Sources/ZcashLightClientKit/Transaction/TxResubmitter.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TxResubmitter.swift
@@ -1,0 +1,163 @@
+//
+//  TxResubmitter.swift
+//  ZcashLightClientKit
+//
+
+import Foundation
+
+/// Engine-independent resubmission core: prunes stale submit plans and
+/// resubmits the transactions that qualify, throttled to at most once per
+/// 300-second window. Shared by the old sync pipeline's `TxResubmissionAction`
+/// and `SlipstreamSynchronizer`, so the retry policy lives in exactly one place.
+final class TxResubmitter {
+    private enum Constants {
+        static let thresholdToTrigger = TimeInterval(300.0)
+    }
+
+    var latestResolvedTime: TimeInterval = Date().timeIntervalSince1970
+    let transactionRepository: TransactionRepository
+    var transactionEncoder: TransactionEncoder
+    let submitPlanStore: SubmitPlanStoring
+    let submitPlanExecutor: SubmitPlanExecutor
+    let logger: Logger
+
+    init(container: DIContainer) {
+        transactionRepository = container.resolve(TransactionRepository.self)
+        transactionEncoder = container.resolve(TransactionEncoder.self)
+        submitPlanStore = container.resolve(SubmitPlanStoring.self)
+        submitPlanExecutor = container.resolve(SubmitPlanExecutor.self)
+        logger = container.resolve(Logger.self)
+    }
+
+    func checkAndResubmit(latestBlockHeight: BlockHeight) async {
+        // Plans whose transactions are expired or gone are no longer retry
+        // candidates; drop them. Mined transactions keep their plans until
+        // expiry so a reorg that un-mines one still retries through its
+        // recorded endpoints — findForResubmission excludes mined transactions,
+        // so a retained plan costs nothing meanwhile. Decisions are made per
+        // transaction from current repository state, so a transaction created
+        // mid-pass can never be wrongly pruned.
+        await pruneStalePlans(latestBlockHeight: latestBlockHeight)
+
+        // find all candidates for the resubmission
+        do {
+            logger.info("TxResubmissionAction check started at \(latestBlockHeight) height.")
+            let transactions = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
+            logger.debug("TxResubmissionAction found \(transactions.count) resubmission candidate(s).")
+
+            // no candidates, update the time and continue with the next action
+            if transactions.isEmpty {
+                latestResolvedTime = Date().timeIntervalSince1970
+            } else {
+                let now = Date().timeIntervalSince1970
+                let diff = now - latestResolvedTime
+
+                // the last time resubmission was triggered is more than 5 minutes ago so try again
+                if diff > Constants.thresholdToTrigger {
+                    // resubmission; per-transaction error handling so one
+                    // transaction's dead endpoints can't starve the others
+                    for transaction in transactions {
+                        do {
+                            try await resubmit(transaction: transaction)
+                        } catch {
+                            logger.error(
+                                "TxResubmissionAction failed to resubmit transaction \(transaction.rawID.toHexStringTxId()): \(error)"
+                            )
+                        }
+                    }
+
+                    latestResolvedTime = Date().timeIntervalSince1970
+                }
+            }
+        } catch {
+            logger.error("TxResubmissionAction failed to find candidates.")
+        }
+    }
+}
+
+private extension TxResubmitter {
+    func resubmit(transaction: ZcashTransaction.Overview) async throws {
+        let plan = await submitPlanStore.plan(for: transaction.rawID)
+
+        switch plan {
+        case .awaiting:
+            // Created through Broadcaster but never submitted by the app —
+            // resubmitting would broadcast something the user may have cancelled.
+            logger.info(
+                "TxResubmissionAction skipping transaction \(transaction.rawID.toHexStringTxId()) until it is submitted by the app."
+            )
+
+        case .ready(let endpoints):
+            logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()) via its submit plan.")
+            let createdTransaction = try CreatedTransaction(overview: transaction)
+            try await submitPlanExecutor.submit(transaction: createdTransaction, endpoints: endpoints)
+
+        case .storeUnavailable:
+            // Whether the app ever submitted this transaction is unknown.
+            // Skip rather than risk broadcasting something the user never
+            // released or using an endpoint the user didn't choose.
+            logger.warn(
+                "TxResubmissionAction skipping transaction \(transaction.rawID.toHexStringTxId()): the submit plan store is unavailable."
+            )
+
+        case nil:
+            logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()).")
+            let encodedTransaction = try transaction.encodedTransaction()
+            try await transactionEncoder.submit(transaction: encodedTransaction)
+        }
+    }
+
+    func pruneStalePlans(latestBlockHeight: BlockHeight) async {
+        let plannedTxIds = await submitPlanStore.allPlannedTransactionIds()
+        guard !plannedTxIds.isEmpty else { return }
+
+        var staleTxIds: [Data] = []
+        for txId in plannedTxIds {
+            do {
+                let transaction = try await transactionRepository.find(rawID: txId)
+                // Stale only once expired: pruning at "mined" would lose the
+                // plan if a reorg un-mines the transaction inside its expiry
+                // window. Transactions without an expiry height are never
+                // resubmission candidates, so their plans are stale right away.
+                let isStale = (transaction.expiryHeight ?? 0) <= latestBlockHeight
+                if isStale {
+                    staleTxIds.append(txId)
+                }
+            } catch ZcashError.transactionRepositoryEntityNotFound {
+                do {
+                    guard let created = try await transactionEncoder.createdTransactions(forTxIds: [txId]).first,
+                          let expiryHeight = created.expiryHeight,
+                          expiryHeight > latestBlockHeight
+                    else {
+                        staleTxIds.append(txId)
+                        continue
+                    }
+                    logger.warn(
+                        "TxResubmissionAction keeping plan for view-invisible wallet-store transaction \(txId.toHexStringTxId())."
+                    )
+                } catch {
+                    // An unreadable wallet store is inconclusive. Keep the plan and retry later.
+                    logger.warn(
+                        """
+                        TxResubmissionAction could not verify view-invisible transaction \(txId.toHexStringTxId()): \
+                        \(error.localizedDescription)
+                        """
+                    )
+                }
+            } catch {
+                // Unknown repository error — keep the plan, try again next pass.
+                logger.warn(
+                    """
+                    TxResubmissionAction could not check plan staleness for \(txId.toHexStringTxId()): \
+                    \(error.localizedDescription)
+                    """
+                )
+            }
+        }
+
+        if !staleTxIds.isEmpty {
+            logger.info("TxResubmissionAction pruning \(staleTxIds.count) stale submit plan(s).")
+            await submitPlanStore.deletePlans(txIds: staleTxIds)
+        }
+    }
+}

--- a/Tests/OfflineTests/SlipstreamOfflineTests.swift
+++ b/Tests/OfflineTests/SlipstreamOfflineTests.swift
@@ -7,8 +7,8 @@
 //  Tests:
 //    1. Progress mapping: chainTip == 0 → syncStatus .syncing(0.0) without crash.
 //    2. Dealloc-without-stop: create + release SlipstreamSynchronizer without stop() → no crash.
-//    3. wipe() removes database files + resets state; switchTo() when-never-started
-//       succeeds (endpoint swapped, no crash).
+//    3. wipe() removes database files (incl. the submit-plan store, [#1976]) + resets state;
+//       switchTo() when-never-started succeeds (endpoint swapped, no crash).
 //    4. Engine FFI smoke (Offline-safe):
 //       - zcashlc_slipstream_open with invalid path → throws rustSlipstreamOpen.
 //       - start before open → throws rustSlipstreamNotOpen.
@@ -301,6 +301,56 @@ class SlipstreamOfflineTests: ZcashTestCase {
         // State must be reset.
         XCTAssertEqual(sync.latestState.syncSessionID, SynchronizerState.zero.syncSessionID,
                        "state must be reset to .zero after wipe")
+    }
+
+    /// [#1976] wipe() must also delete the submit-plan-store database file — mirroring
+    /// `SDKSynchronizer.wipe()` (SDKSynchronizer.swift:815-818), which wipes the plan store
+    /// only when the wallet wipe itself succeeds. Regression test: `SlipstreamSynchronizer.wipe()`
+    /// used to leave `submit_plans_*.db` behind after a wipe.
+    func testWipeDeletesSubmitPlanStoreDatabase() async throws {
+        let initializer = try makeInitializer()
+        let store = initializer.container.resolve(SubmitPlanStoring.self)
+
+        await store.recordPlan(
+            txId: Data(repeating: 0x01, count: 32),
+            endpoints: [LightWalletEndpoint(address: "example.com", port: 443, secure: true)]
+        )
+
+        // Same construction as Dependencies.swift:58-64.
+        let submitPlansDbURL = initializer.generalStorageURL
+            .appendingPathComponent("submit_plans_\(initializer.network.networkType.networkId).db")
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: submitPlansDbURL.path),
+                      "submit-plan database must exist after recordPlan")
+
+        let sync = SlipstreamSynchronizer(initializer: initializer)
+
+        let wipeExpectation = XCTestExpectation(description: "wipe completes")
+        var receivedError: Error?
+
+        sync.wipe()
+            .sink(
+                receiveCompletion: { completion in
+                    if case let .failure(error) = completion {
+                        receivedError = error
+                    }
+                    wipeExpectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        await fulfillment(of: [wipeExpectation], timeout: 5)
+        XCTAssertNil(receivedError,
+                     "wipe() must not error when a submit plan exists, got \(String(describing: receivedError))")
+
+        // Check file absence BEFORE any store call that would lazily recreate it.
+        XCTAssertFalse(fm.fileExists(atPath: submitPlansDbURL.path),
+                       "submit-plan database must be removed after wipe")
+
+        let plan = await store.plan(for: Data(repeating: 0x01, count: 32))
+        XCTAssertNil(plan, "plan lookup after wipe must find no row, got \(String(describing: plan))")
     }
 
     /// `switchTo(endpoint:)` on a synchronizer that was never started must complete

--- a/Tests/OfflineTests/SlipstreamOfflineTests.swift
+++ b/Tests/OfflineTests/SlipstreamOfflineTests.swift
@@ -990,4 +990,128 @@ class SlipstreamOfflineTests: ZcashTestCase {
             0
         )
     }
+
+    // MARK: - 15. [#1975] Background transaction-resubmission driver
+    //
+    // Parity with the old pipeline's `TxResubmissionAction`, which ran once per sync pass.
+    // The poll loop asks `resubmissionCheckDue` on every 2 s tick; the answer gates a
+    // `TxResubmitter.checkAndResubmit` call (prune every check, actual re-broadcast throttled
+    // to 300 s INSIDE the resubmitter — the cadence tested here is only the CHECK cadence).
+
+    /// Syncing (1) and Done (3) both check: the old pipeline ran the action once per sync pass,
+    /// and a Done engine still holds unmined transactions worth re-broadcasting.
+    func testResubmissionCheckDueWhileSyncingOrDone() {
+        for state: UInt8 in [1, 3] {
+            XCTAssertTrue(SlipstreamSynchronizer.resubmissionCheckDue(
+                isCancelled: false, state: state, chainTip: 2_400_000, secondsSinceLastCheck: 1_000, inFlight: false
+            ), "state \(state) must run the resubmission check")
+        }
+    }
+
+    /// Disconnected (0) and Error (2) never check: there is no network to submit through,
+    /// so a check could only burn a database walk and log failures.
+    func testResubmissionCheckNotDueWhileDisconnectedOrError() {
+        for state: UInt8 in [0, 2] {
+            XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+                isCancelled: false, state: state, chainTip: 2_400_000, secondsSinceLastCheck: 1_000, inFlight: false
+            ), "state \(state) must never run the resubmission check")
+        }
+    }
+
+    /// A cancelled caller never checks, however perfect the rest of the tick looks. This is the
+    /// teardown guard: `stopPolling()` cancels `pollTask` without awaiting it, and `wipeImpl`
+    /// then suspends (`engine.stop()`/`engine.close()`), so a `tickPoll` suspended mid-tick can
+    /// resume INSIDE the wipe. Firing there would read `data.db` and re-create the submit-plan
+    /// database the wipe had just deleted (SQLite recreates the file on connect), undoing
+    /// [#1976] milliseconds later.
+    func testResubmissionCheckNotDueWhenTheCallerIsCancelled() {
+        for state: UInt8 in [1, 3] {
+            XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+                isCancelled: true, state: state, chainTip: 2_400_000, secondsSinceLastCheck: 100_000, inFlight: false
+            ), "state \(state) must not check while the calling task is cancelled")
+        }
+    }
+
+    /// A zero chain tip means the server tip is not yet known; resubmission candidates are
+    /// selected `upTo:` that height, so checking with 0 would resolve nothing.
+    func testResubmissionCheckNotDueWithoutAChainTip() {
+        XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 1, chainTip: 0, secondsSinceLastCheck: 1_000, inFlight: false
+        ))
+        XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 3, chainTip: 0, secondsSinceLastCheck: 1_000, inFlight: false
+        ))
+    }
+
+    /// A check already in flight blocks the next one however long ago the last one started:
+    /// a slow submit round must never be joined by a second concurrent pass over the same
+    /// transactions.
+    func testResubmissionCheckNotDueWhileAnotherCheckIsInFlight() {
+        XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 1, chainTip: 2_400_000, secondsSinceLastCheck: 100_000, inFlight: true
+        ))
+    }
+
+    /// The 60 s check cadence, at the tick granularity that actually asks (2 s) and at the
+    /// boundary itself (`>=` semantics, mirroring the stall watchdog).
+    func testResubmissionCheckHonorsTheCheckInterval() {
+        XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 1, chainTip: 2_400_000, secondsSinceLastCheck: 2, inFlight: false
+        ), "the next poll tick is inside the window")
+        XCTAssertFalse(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 1, chainTip: 2_400_000, secondsSinceLastCheck: 59.9, inFlight: false
+        ))
+        XCTAssertTrue(SlipstreamSynchronizer.resubmissionCheckDue(
+            isCancelled: false, state: 1, chainTip: 2_400_000, secondsSinceLastCheck: 60, inFlight: false
+        ), "exactly at the interval must fire (>= semantics)")
+    }
+
+    /// The shipped check cadence is 60 s.
+    func testResubmissionCheckIntervalConstant() {
+        XCTAssertEqual(SlipstreamSynchronizer.resubmissionCheckInterval, 60)
+    }
+
+    /// Actor-level: the driver fires the first eligible tick and then holds the line for the
+    /// rest of the interval — the poll loop calls it every 2 s, so without the gate a wallet
+    /// would walk its transaction table 30× a minute.
+    ///
+    /// Also pins the single-writer invariant: a COMPLETED check leaves no in-flight handle,
+    /// because the task's own `finishResubmissionCheck()` cleared it. A regression that re-adds
+    /// `resubmissionTask = nil` to teardown, or that leaks the handle, fails here rather than
+    /// hiding behind the interval-vs-in-flight ambiguity.
+    ///
+    /// Offline caveat: the temp `data.db` has no wallet tables, so the fired check's
+    /// `findForResubmission` throws and `TxResubmitter` swallows it — the task completes with
+    /// zero work, which is exactly what this test needs (it asserts the GATE, not the work).
+    /// `awaitResubmissionCheckForTesting()` awaits that task instead of sleeping, so the
+    /// second call is guaranteed to be gated by the interval and not merely by "in flight".
+    func testResubmissionDriverFiresOncePerInterval() async throws {
+        let sync = SlipstreamSynchronizer(initializer: try makeInitializer())
+
+        await sync.maybeRunTxResubmission(state: 1, chainTip: 2_400_000, isCancelled: false)
+        let firstCheck = await sync.awaitResubmissionCheckForTesting()
+        XCTAssertGreaterThan(firstCheck, 0, "a Syncing tick with a known chain tip must fire the first check")
+        var inFlight = await sync.resubmissionCheckInFlightForTesting
+        XCTAssertFalse(inFlight, "the finished check must have cleared its own handle")
+
+        await sync.maybeRunTxResubmission(state: 3, chainTip: 2_400_002, isCancelled: false)
+        let secondCheck = await sync.awaitResubmissionCheckForTesting()
+        XCTAssertEqual(secondCheck, firstCheck, "a tick inside the 60 s window must not fire a second check")
+        inFlight = await sync.resubmissionCheckInFlightForTesting
+        XCTAssertFalse(inFlight, "a gated tick must not leave a check in flight")
+    }
+
+    /// Actor-level counterpart of the cancellation row: the driver must PLUMB the caller's
+    /// cancellation, not just accept it. A tick resuming inside a teardown fires nothing —
+    /// no stamp, no task — so a `wipe()` in progress cannot be raced by a fresh check.
+    func testResubmissionDriverSkipsWhenTheCallingTaskIsCancelled() async throws {
+        let sync = SlipstreamSynchronizer(initializer: try makeInitializer())
+
+        await sync.maybeRunTxResubmission(state: 1, chainTip: 2_400_000, isCancelled: true)
+
+        let stamp = await sync.awaitResubmissionCheckForTesting()
+        XCTAssertEqual(stamp, 0, "a cancelled caller must not fire a check")
+        let inFlight = await sync.resubmissionCheckInFlightForTesting
+        XCTAssertFalse(inFlight, "a cancelled caller must not spawn a check task")
+    }
 }


### PR DESCRIPTION
This PR brings `main` up to date with the `feature/ironwood-slipstream` work. Note that work for the 3.0.0 SDK release will continue to be based on and merge to `feature/ironwood-slipstream`; the purpose of this is to integrate all outstanding work so that we can begin working on coinholder polling on `main` without duplicating or conflicting with ongoing work on the feature branch.