### PR TITLE
[MOB-1737] Read the engine's reconciliation views under their ext_ names

### DIFF
--- a/Sources/ZcashLightClientKit/DAO/TransactionDao.swift
+++ b/Sources/ZcashLightClientKit/DAO/TransactionDao.swift
@@ -116,16 +116,16 @@ class TransactionSQLDAO: TransactionRepository {
         return txids
     }
 
-    // DB-READ (audited 2026-08-03): SELECT over the slipstream_v_tx_reconciled VIEW — read-only
+    // DB-READ (audited 2026-08-03): SELECT over the ext_slipstream_v_tx_reconciled VIEW — read-only
     // by construction.
     func unreconciledTxids() async throws -> Set<Data> {
-        // [#1755] Reads the slipstream-owned `slipstream_v_tx_reconciled` view (a VIEW over upstream's
+        // [#1755] Reads the slipstream-owned `ext_slipstream_v_tx_reconciled` view (a VIEW over upstream's
         // nullifier_map / *_received_notes — see slipstream `reconcile.rs`). Returns the txids whose
         // delta is not yet final because a recent-first restore scanned the spend before its input's
         // origin block. Defensive: a DB the slipstream engine never opened has no such view, so the
         // query throws — we swallow it and return an empty set (nothing held back; legacy behavior).
         do {
-            let statement = try connection().prepare("SELECT txid FROM slipstream_v_tx_reconciled WHERE reconciled = 0")
+            let statement = try connection().prepare("SELECT txid FROM ext_slipstream_v_tx_reconciled WHERE reconciled = 0")
             var result: Set<Data> = []
             for row in statement {
                 if let blob = row[0] as? Blob {

--- a/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
@@ -30,7 +30,7 @@ protocol TransactionRepository {
     func debugDatabase(sql: String) -> String
 
     /// [#1755] Txids whose `account_balance_delta` is not yet final during a deep recovery — read from
-    /// the slipstream-owned `slipstream_v_tx_reconciled` view. A recent-first restore can scan a spend
+    /// the slipstream-owned `ext_slipstream_v_tx_reconciled` view. A recent-first restore can scan a spend
     /// before its input's origin block, so the spend is transiently unattributed and the tx reads as a
     /// phantom "+receive". Consumers hold these txs out of the Activity list until they reconcile. The
     /// default returns an empty set: a DB without the view (legacy / non-slipstream) holds nothing back.

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamEngine.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamEngine.swift
@@ -232,7 +232,7 @@ public actor SlipstreamEngine {
 
     /// [Engine API v2 §0.5 / v2.1 Phase 1] The unified, PHASE-RESOLVING wallet summary:
     /// one call that is correct at every phase — recovering ⇒ the upstream summary with
-    /// per-account balances REPLACED by `slipstream_v_recovery_balance` (Σ of final,
+    /// per-account balances REPLACED by `ext_slipstream_v_recovery_balance` (Σ of final,
     /// reconciled tx deltas — never over-shows); not recovering ⇒ the upstream summary
     /// passed through unchanged. No host ever re-implements restore balance math.
     ///

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -185,7 +185,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
     /// [#1755] Mirrors the wallet's deep-recovery state. Seeded from the persisted summary at
     /// prepare()/start(); ENGINE-OWNED during a run (tickPoll adopts `snap.isRecovering`, which embeds
     /// the terminal fail-safe latch — Done/Error force it 0). Drives the "Restoring"
-    /// LABEL and the Activity gate: the Activity is gated PER-TRANSACTION by the `slipstream_v_tx_reconciled`
+    /// LABEL and the Activity gate: the Activity is gated PER-TRANSACTION by the `ext_slipstream_v_tx_reconciled`
     /// view (not held wholesale), so reconciled txs surface immediately while only the provisional ones
     /// wait. (Balance is NOT special-cased — live is correct on a fresh restore; see tickPoll.) Tracks the
     /// LIVE signal, so it self-corrects across rewind / truncate / stop.
@@ -1000,7 +1000,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
 
     /// [#1755] During a recent-first RESTORE the scheduler scans a recent block that spends an older note
     /// before that note's origin block, so a self-send's change reads as a phantom "+receive" until the
-    /// spend links. `slipstream_v_tx_reconciled` flags those still-provisional txs, and we hold them out of
+    /// spend links. `ext_slipstream_v_tx_reconciled` flags those still-provisional txs, and we hold them out of
     /// the Activity list until their delta is final (genuine receives + already-linked sends still surface
     /// as soon as they appear).
     ///
@@ -1030,7 +1030,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
     }
 
     /// Pure: which txs the Activity list shows. Outside recovery (or with nothing flagged) every tx passes;
-    /// during recovery the unreconciled txids (a dangling shielded spend per `slipstream_v_tx_reconciled`)
+    /// during recovery the unreconciled txids (a dangling shielded spend per `ext_slipstream_v_tx_reconciled`)
     /// are held back until their delta is final. Static + pure so it is unit-testable.
     static func reconciledVisible(
         _ txs: [ZcashTransaction.Overview],

--- a/Tests/OfflineTests/SlipstreamOfflineTests.swift
+++ b/Tests/OfflineTests/SlipstreamOfflineTests.swift
@@ -528,7 +528,7 @@ class SlipstreamOfflineTests: ZcashTestCase {
 
     // MARK: - reconciledVisible pure-helper unit tests ([#1755] vanishing-tx fix)
     //
-    // The reconcile filter (`slipstream_v_tx_reconciled`) must hold provisional txs back ONLY during an
+    // The reconcile filter (`ext_slipstream_v_tx_reconciled`) must hold provisional txs back ONLY during an
     // active recovery. On a synced wallet a mined tx the view flags unreconciled (transiently OR, as seen
     // in the field with a Keystone send, persistently) must still show — dropping a confirmed tx is the
     // "vanishing transaction" bug.

--- a/Tests/OfflineTests/SlipstreamReconcileReadTests.swift
+++ b/Tests/OfflineTests/SlipstreamReconcileReadTests.swift
@@ -3,7 +3,7 @@
 //  ZcashLightClientKit-Unit-Tests
 //
 //  [#1755] Covers the SDK read side of the slipstream reconciliation gate:
-//  `TransactionSQLDAO.unreconciledTxids()` reads the `slipstream_v_tx_reconciled`
+//  `TransactionSQLDAO.unreconciledTxids()` reads the `ext_slipstream_v_tx_reconciled`
 //  view (the view's SQL logic itself is proven in the engine's `reconcile.rs`
 //  Rust tests). Here we verify the Swift blob-read returns the right txid set,
 //  and that a database WITHOUT the view (legacy / non-slipstream) degrades to an
@@ -24,16 +24,16 @@ final class SlipstreamReconcileReadTests: XCTestCase {
         // A view is just a SELECT; the DAO issues `SELECT txid ... WHERE reconciled = 0`, so a
         // same-shaped table exercises the exact read path without rebuilding upstream's schema.
         let setup = try Connection(path)
-        try setup.run("CREATE TABLE slipstream_v_tx_reconciled (txid BLOB, reconciled INTEGER)")
+        try setup.run("CREATE TABLE ext_slipstream_v_tx_reconciled (txid BLOB, reconciled INTEGER)")
 
         let unreconciled = Data(repeating: 0xAA, count: 32)
         let reconciled = Data(repeating: 0xBB, count: 32)
         try setup.run(
-            "INSERT INTO slipstream_v_tx_reconciled (txid, reconciled) VALUES (?, 0)",
+            "INSERT INTO ext_slipstream_v_tx_reconciled (txid, reconciled) VALUES (?, 0)",
             Blob(bytes: [UInt8](unreconciled))
         )
         try setup.run(
-            "INSERT INTO slipstream_v_tx_reconciled (txid, reconciled) VALUES (?, 1)",
+            "INSERT INTO ext_slipstream_v_tx_reconciled (txid, reconciled) VALUES (?, 1)",
             Blob(bytes: [UInt8](reconciled))
         )
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -400,7 +400,7 @@ impl AccountBalance {
     }
 
     /// [Slipstream API v2 §0-5] The account's UUID bytes, for matching against
-    /// `slipstream_v_recovery_balance.account_uuid`.
+    /// `ext_slipstream_v_recovery_balance.account_uuid`.
     pub(crate) fn uuid_bytes(&self) -> &[u8; 16] {
         &self.account_uuid
     }
@@ -1570,13 +1570,13 @@ mod recovery_hold_tests {
         let _ = std::fs::remove_file(&path);
         let conn = rusqlite::Connection::open(&path).unwrap();
         conn.execute_batch(
-            "CREATE TABLE slipstream_v_recovery_balance (account_uuid BLOB, balance_zat INTEGER);
+            "CREATE TABLE ext_slipstream_v_recovery_balance (account_uuid BLOB, balance_zat INTEGER);
              CREATE TABLE v_transactions (account_uuid BLOB, mined_height INTEGER, spent_note_count INTEGER, expired_unmined INTEGER);",
         )
         .unwrap();
         for (u, bal) in recovery {
             conn.execute(
-                "INSERT INTO slipstream_v_recovery_balance (account_uuid, balance_zat) VALUES (?1, ?2)",
+                "INSERT INTO ext_slipstream_v_recovery_balance (account_uuid, balance_zat) VALUES (?1, ?2)",
                 rusqlite::params![u.to_vec(), bal],
             )
             .unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4804,7 +4804,7 @@ pub struct SlipstreamHandle {
     summary_refresh_inflight: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// [#1806] Last successfully-read recovery-balance nets (account-uuid bytes → reconciled
     /// net zatoshi), used ONLY as a fallback when the bounded (250 ms) read of
-    /// `slipstream_v_recovery_balance` is contended — so a momentarily-locked view never
+    /// `ext_slipstream_v_recovery_balance` is contended — so a momentarily-locked view never
     /// nulls the whole summary. `None` until the first successful read; see
     /// [`zcashlc_slipstream_wallet_summary`].
     recovery_nets_cache: std::sync::Mutex<Option<std::collections::HashMap<[u8; 16], i64>>>,
@@ -5944,7 +5944,7 @@ fn decide_summary_serving(
 /// an outgoing spend is `spent_note_count > 0` (mirrors librustzcash's spent-notes clause),
 /// unmined is `mined_height IS NULL`, and the view's own `expired_unmined` flag supplies
 /// tx-expiry (mirrors `tx_unexpired_condition`). The returned UUIDs match the account keys of
-/// `slipstream_v_recovery_balance`.
+/// `ext_slipstream_v_recovery_balance`.
 fn read_unmined_spend_accounts_conn(
     conn: &rusqlite::Connection,
 ) -> anyhow::Result<std::collections::HashSet<[u8; 16]>> {
@@ -6082,7 +6082,7 @@ fn serve_wallet_summary(
             let mut nets: std::collections::HashMap<[u8; 16], i64> =
                 std::collections::HashMap::new();
             let mut stmt = conn
-                .prepare("SELECT account_uuid, balance_zat FROM slipstream_v_recovery_balance")
+                .prepare("SELECT account_uuid, balance_zat FROM ext_slipstream_v_recovery_balance")
                 .map_err(|e| anyhow!("recovery balance prepare: {}", e))?;
             let mut rows = stmt
                 .query([])
@@ -6170,7 +6170,7 @@ fn serve_wallet_summary(
 /// - **Recovering** (the recent-first restore backfill; `snapshot.is_recovering == 1`) →
 ///   the upstream summary's per-account balances are REPLACED, because upstream balances
 ///   "may overestimate" mid-restore by documented design (a receipt is counted before its
-///   spend is scanned). The replacement is the engine-owned `slipstream_v_recovery_balance`
+///   spend is scanned). The replacement is the engine-owned `ext_slipstream_v_recovery_balance`
 ///   (Σ of FINAL, reconciled tx deltas — never over-shows, converges to the true total),
 ///   surfaced per the SDK's field-validated Direction-B mapping: the whole clamped net as
 ///   orchard spendable, everything else zero. Progress/heights fields pass through.
@@ -6900,5 +6900,41 @@ mod slipstream_anchor_retention_tests {
             nu6_3: None,
         };
         assert_eq!(slipstream_anchor_retention_floor(&no_nu63), None);
+    }
+}
+
+/// Guards the engine-owned view names this crate and the Swift layer hard-code.
+///
+/// Both read paths fail SILENTLY by design — the recovery-balance read below falls back to
+/// an empty map ("zeroes every balance — safe") and Swift's reconcile read swallows a missing
+/// view as the legitimate non-engine case. So a view rename in the engine does not surface as
+/// an error; it surfaces as zeroed balances and phantom transactions. That is precisely how
+/// the pre-`ext_` names survived unnoticed once the engine's `ExtSchemaInit` migration renamed
+/// them. These assertions turn the next such rename into a failing test naming the file to fix.
+#[cfg(test)]
+mod engine_schema_names_tests {
+    /// The view `TransactionSQLDAO.unreconciledTxids()` reads from Swift. The engine exports
+    /// this name, so bind to it rather than trusting our copy of the string.
+    #[test]
+    fn reconcile_view_name_matches_the_swift_query() {
+        assert_eq!(
+            slipstream_core::reconcile::RECONCILE_VIEW_NAME,
+            "ext_slipstream_v_tx_reconciled",
+            "the engine renamed the reconciliation view; update the query in \
+             Sources/ZcashLightClientKit/DAO/TransactionDao.swift to match"
+        );
+    }
+
+    /// The view `serve_wallet_summary` reads for recovery nets. The engine exports no name
+    /// constant for it, so assert against the DDL it does export.
+    #[test]
+    fn recovery_balance_view_name_matches_our_query() {
+        assert!(
+            slipstream_core::reconcile::RECOVERY_BALANCE_VIEW_SQL
+                .contains("ext_slipstream_v_recovery_balance"),
+            "the engine renamed the recovery-balance view; update the query in \
+             resolve_recovery_nets to match. Engine DDL: {}",
+            slipstream_core::reconcile::RECOVERY_BALANCE_VIEW_SQL
+        );
     }
 }


### PR DESCRIPTION
## The bug

ZODL Slipstream's `ExtSchemaInit` migration renames both reconciliation views — its own comment reads *"The legacy views carry no state — drop and recreate under `ext_` names"* — so on engine 0.1.1 the schema at head is:

- `ext_slipstream_v_tx_reconciled`
- `ext_slipstream_v_recovery_balance`

Both of our readers still use the pre-rename names, so **neither has been reading anything**:

| Reader | Queries | Consequence |
|---|---|---|
| `resolve_recovery_nets` (`rust/src/lib.rs`) | `slipstream_v_recovery_balance` | Its contract is *"on ANY failure, fall back to … an empty map, which zeroes every balance — safe"*, so recovery balances read as **zero** for the whole restore window instead of surfacing the recovered nets. |
| `TransactionSQLDAO.unreconciledTxids()` (Swift) | `slipstream_v_tx_reconciled` | A missing view is swallowed as the legitimate "database the engine never opened" case → returns empty → the Activity hold-back never engages, and a recent-first restore shows exactly the phantom `+receive` entries the filter exists to suppress. |

**Neither failure is visible.** Both paths degrade quietly by design, so the rename produced wrong numbers rather than errors — which is why it went unnoticed.

## Why the tests didn't catch it

Both fixtures create tables under the same stale names, so they were self-consistent and wrong: `rust/src/ffi.rs` (`CREATE TABLE slipstream_v_recovery_balance`) and `Tests/OfflineTests/SlipstreamReconcileReadTests.swift`. Corrected here, so they now exercise the real schema.

## Not fixing it again

Two tests bind our hard-coded names to what the engine actually exports:

```rust
assert_eq!(slipstream_core::reconcile::RECONCILE_VIEW_NAME, "ext_slipstream_v_tx_reconciled", ...);
assert!(slipstream_core::reconcile::RECOVERY_BALANCE_VIEW_SQL.contains("ext_slipstream_v_recovery_balance"), ...);
```

Verified they bite: asserting the old name fails with *"the engine renamed the reconciliation view; update the query in `Sources/ZcashLightClientKit/DAO/TransactionDao.swift` to match"*. The next rename becomes a failing build naming the file to change, instead of silently zeroed balances.

## Scope

Deliberately isolated so wallet developers can review the behavioural change on its own: two query strings, the fixtures that masked them, doc comments naming the views, and the two guards. No refactoring, no moves. [#1964](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1964) will be rebased on top of this so it remains purely a code move.

## Verification

- `cargo test`: **236 passing** (234 + the 2 new guards).
- Swift offline suite: **893 passing**.
- Guard negative-tested by reverting a name — fails with the file-naming message.

🤖 Drafted and opened by [Claude Code](https://claude.com/claude-code) on @pacu's behalf.

https://claude.ai/code/session_01AkdBfgXpNvWmnNQXWjfA9G