### PR TITLE
Accept options after the positional arguments

### DIFF
--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -199,6 +199,8 @@ cmd_start() {
     local previous="" issue="" remote version revision rev_sha prev_tag
     local release_branch candidate_branch b today pr_body_file
 
+    local -a positional=()
+
     while [ $# -gt 0 ]; do
         case "$1" in
             --issue)    issue="${2:?--issue needs an issue number}"; shift 2 ;;
@@ -206,9 +208,11 @@ cmd_start() {
             --dry-run)  DRY_RUN=true; shift ;;
             -h|--help)  usage_start; return 0 ;;
             --*)        usage_start >&2; die "unknown option '$1'" ;;
-            *)          break ;;
+            *)          positional+=("$1"); shift ;;
         esac
     done
+    # Options may appear anywhere, including after the positionals.
+    set -- ${positional[@]+"${positional[@]}"}
 
     if [ $# -lt 2 ]; then
         usage_start >&2
@@ -515,6 +519,8 @@ EOF
 cmd_artifacts() {
     local force=false verify=true version
 
+    local -a positional=()
+
     while [ $# -gt 0 ]; do
         case "$1" in
             --force-overwrite-existing-release) force=true; shift ;;
@@ -522,9 +528,11 @@ cmd_artifacts() {
             --dry-run) DRY_RUN=true; shift ;;
             -h|--help) usage_artifacts; return 0 ;;
             --*)       usage_artifacts >&2; die "unknown option '$1'" ;;
-            *)         break ;;
+            *)         positional+=("$1"); shift ;;
         esac
     done
+    # Options may appear anywhere, including after the positionals.
+    set -- ${positional[@]+"${positional[@]}"}
 
     if [ $# -lt 1 ]; then
         usage_artifacts >&2
@@ -660,6 +668,8 @@ cmd_build() {
     local artifacts="local" rebuild=false verify=true remote version
     local candidate_branch pr_number checksum is_draft behind current_branch
 
+    local -a positional=()
+
     while [ $# -gt 0 ]; do
         case "$1" in
             --artifacts) artifacts="${2:?--artifacts needs local or ci}"; shift 2 ;;
@@ -668,9 +678,11 @@ cmd_build() {
             --dry-run)   DRY_RUN=true; shift ;;
             -h|--help)   usage_build; return 0 ;;
             --*)         usage_build >&2; die "unknown option '$1'" ;;
-            *)           break ;;
+            *)           positional+=("$1"); shift ;;
         esac
     done
+    # Options may appear anywhere, including after the positionals.
+    set -- ${positional[@]+"${positional[@]}"}
 
     case "$artifacts" in
         local|ci) ;;


### PR DESCRIPTION
Each subcommand's option loop ended at the first non-option, so an option written after <remote>/<version> was never seen:

    prepare-release.sh start zodl 4.0.0 --previous 3.0.0-rc.3 --issue 5

parsed as remote=zodl, version=4.0.0, revision=--previous, with both --previous and --issue discarded. It failed with "--issue <N> is required" naming an option the invocation had in fact supplied, and had the issue check not fired first it would have gone on to resolve a revision literally named --previous. The same loop shape governs build and artifacts, so --artifacts, --rebuild, --skip-verify and --dry-run were all positional-order-sensitive in the same way.

The three loops now accumulate positionals and restore them afterwards, so options are recognized wherever they appear. The array is expanded as ${positional[@]+"${positional[@]}"} to stay safe under `set -u` when a subcommand is called with no positionals at all, which bash 3.2 on the macOS runners would otherwise treat as an unbound variable.
