### PR TITLE
[#1984] Fix final release review blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `proveMigrationTransactions(accountUUID:_:maxProofs:)` returns `MigrationProveOutcome` — the
   total proved plus THE TXIDS OF THE PREPARATIONS IT PROVED, and only those — and the new
   `takeMigrationPreparation(accountUUID:byTxid:)` hands each one back as a
-  `PreparedMigrationTransfer`. THE ACCESSOR IS THE SEAM: `txid -> row -> the store's atomic
+  `PreparedMigrationTransfer`. Transaction ids use `TxId` throughout this public handoff:
+  `MigrationProveOutcome.preparationTxids`, `PreparedMigrationTransfer.txid`,
+  `MigrationTransactionStatus.State.broadcast(txid:)`, `MigrationTransferResult.success(txId:)`,
+  and the accessor's `byTxid` parameter.
+  THE ACCESSOR IS THE SEAM: `txid -> row -> the store's atomic
   broadcast seam`, in one database transaction, so the wallet's record binds AT RETRIEVAL and a
   consumer that crashed before submitting re-retrieves the same bytes over the same record. It is
   PREPARATION-GATED — a transfer's txid is refused, because transfers are served by the drive's
@@ -408,7 +412,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process-lifetime plan-cache key no persisted copy could honor), so every decoded copy carries
   handle `0` — re-propose instead of committing a persisted schedule.
 - New `ZcashError` cases: `ZRUST0099`–`ZRUST0106`, `ZRUST0108`, `ZRUST0111`–`ZRUST0113`,
-  `ZRUST0115`–`ZRUST0122`, `ZRUST0124`–`ZRUST0138`, `ZRUST0140`–`ZRUST0147`, and `ZRUST0149`
+  `ZRUST0115`–`ZRUST0121`, `ZRUST0124`–`ZRUST0138`, `ZRUST0140`–`ZRUST0147`, and `ZRUST0149`
   (`rustMigrationTakePreparation`, the preparation accessor). Ten codes were
   retired pre-release with the members they served, and none is reused; the ranges' other gaps
   are accounted for elsewhere (`ZRUST0107` is the enhancement-path case above, and

--- a/Example/ZcashLightClientSample/README.md
+++ b/Example/ZcashLightClientSample/README.md
@@ -1,7 +1,7 @@
-# iOS demo app 
-This is a demo app that exercises code in https://github.com/zcash/ZcashLightClientKit, which has all the iOS-related functionalities necessary to build a mobile Zcash shielded wallet. 
+# iOS demo app
+This is a demo app that exercises code in https://github.com/zcash/ZcashLightClientKit, which has all the iOS-related functionalities necessary to build a mobile Zcash shielded wallet.
 
-It relies on [Lightwalletd](https://github.com/zcash/lightwalletd), a backend service that provides a bandwidth-efficient interface to the Zcash blockchain. There is an equivalent [Android demo app](https://github.com/zcash/zcash-android-wallet-sdk/). 
+It relies on [Lightwalletd](https://github.com/zcash/lightwalletd), a backend service that provides a bandwidth-efficient interface to the Zcash blockchain. There is an equivalent [Android demo app](https://github.com/zcash/zcash-android-wallet-sdk/).
 
 
 ## Contents
@@ -13,13 +13,13 @@ It relies on [Lightwalletd](https://github.com/zcash/lightwalletd), a backend se
 - [Resources](#resources)
 
 ## Requirements
-Demo app requires a target device running iOS 12+. 
+Demo app requires a target device running iOS 12+.
 
 [Back to contents](#contents)
 
 ## Exploring the demo app
-After building the app, the emulator should launch with a basic app that exercises the SDK (see picture below). 
-To explore the app, click on each menu item, in order, and also look at the associated code. 
+After building the app, the emulator should launch with a basic app that exercises the SDK (see picture below).
+To explore the app, click on each menu item, in order, and also look at the associated code.
 
 ![The android demo app, running in Android Studio](assets/ios-demo-app.png?raw=true "Demo app built with Xcode")
 
@@ -31,33 +31,33 @@ Menu Item|Related Code|Description
 :-----|:-----|:-----
 Get address | [GetAddressViewController.swift]() | Given a seed, display its z-addr
 Latest block height | [LatestHeightViewController.swift]() | Given a lightwalletd server, retrieve the latest block height
-Sync blocks | [SyncBlocksViewController.swift]() | Download compact blocks from the lightwalletd server. 
+Sync blocks | [SyncBlocksViewController.swift]() | Download compact blocks from the lightwalletd server.
 Get balance | [GetBalanceViewController.swift]() | Calculates the balance of the current wallet address.
-Send funds | [SendViewController.swift]()| Send a transaction, the most complex demo. 
-Transaction details | [TransactionDetailViewController.swift]() | See status of a transaction: pending or confirmed, sent or received. 
-All transactions |  [TransactionsTableViewController.swift](), [TransactionsDataSource.swift]() | Displays as much available transaction information  on the wallet. 
-Paginated transactions |  [PaginatedTransactionsViewController.swift]() | Demonstrates how to paginate transactions. 
+Send funds | [SendViewController.swift]()| Send a transaction, the most complex demo.
+Transaction details | [TransactionDetailViewController.swift]() | See status of a transaction: pending or confirmed, sent or received.
+All transactions |  [TransactionsTableViewController.swift](), [TransactionsDataSource.swift]() | Displays as much available transaction information  on the wallet.
+Paginated transactions |  [PaginatedTransactionsViewController.swift]() | Demonstrates how to paginate transactions.
 
 [Back to contents](#contents)
 
 ## Getting started
-We’re assuming you already have a brilliant app idea, a vision for the app’s UI, and know the ins and outs of the Android lifecycle. We’ll just stick to the Zcash app part of “getting started.” 
+We’re assuming you already have a brilliant app idea, a vision for the app’s UI, and know the ins and outs of the Android lifecycle. We’ll just stick to the Zcash app part of “getting started.”
 
-Similarly, the best way to build a functioning Zcash shielded app is to implement the functionalities that are listed in the demo app, in roughly that order: 
+Similarly, the best way to build a functioning Zcash shielded app is to implement the functionalities that are listed in the demo app, in roughly that order:
 
-1. Generate and safely store your private key. 
-1. Get the associated address, and display it to the user on a receive screen. You may also want to generate a QR code from this address. 
-1. Make sure your app can talk to the lightwalletd server and check by asking for the latest height, and verify that it’s current with the Zcash network. 
-1. Try interacting with lightwalletd by fetching a block and processing it. Then try fetching a range of blocks, which is much more efficient. 
-1. Now that you have the blocks process them and list transactions that send to or are from that wallet, to calculate your balance. 
-1. With a current balance (and funds, of course), send a transaction and monitor its transaction status and update the UI with the results. 
+1. Generate and safely store your private key.
+1. Get the associated address, and display it to the user on a receive screen. You may also want to generate a QR code from this address.
+1. Make sure your app can talk to the lightwalletd server and check by asking for the latest height, and verify that it’s current with the Zcash network.
+1. Try interacting with lightwalletd by fetching a block and processing it. Then try fetching a range of blocks, which is much more efficient.
+1. Now that you have the blocks process them and list transactions that send to or are from that wallet, to calculate your balance.
+1. With a current balance (and funds, of course), send a transaction and monitor its transaction status and update the UI with the results.
 
 [Back to contents](#contents)
 
 ## Resources
-You don’t need to do it all on your own. 
+You don’t need to do it all on your own.
 * Chat with the team who built the kit: [Zcash discord community channel, wallet](https://discord.gg/efFG7UJ)
-* Discuss ideas with other community members: [Zcash forum](https://forum.zcashcommunity.com/) 
+* Discuss ideas with other community members: [Zcash forum](https://forum.zcashcommunity.com/)
 * Get funded to build a Zcash app: [Zcash foundation grants program](https://grants.zfnd.org/)
 * Follow Zcash-specific best practices: [Zcash wallet developer checklist](https://zcash.readthedocs.io/en/latest/rtd_pages/ux_wallet_checklist.html)
 * Get more information and see FAQs about the wallet: [Shielded resources documentation](https://zcash.readthedocs.io/en/latest/rtd_pages/shielded_support.html)

--- a/Example/ZcashLightClientSample/README.md
+++ b/Example/ZcashLightClientSample/README.md
@@ -1,5 +1,5 @@
 # iOS demo app
-This is a demo app that exercises code in https://github.com/zcash/ZcashLightClientKit, which has all the iOS-related functionalities necessary to build a mobile Zcash shielded wallet.
+This is a demo app that exercises code in https://github.com/zcash/zcash-swift-wallet-sdk, which has all the iOS-related functionalities necessary to build a mobile Zcash shielded wallet.
 
 It relies on [Lightwalletd](https://github.com/zcash/lightwalletd), a backend service that provides a bandwidth-efficient interface to the Zcash blockchain. There is an equivalent [Android demo app](https://github.com/zcash/zcash-android-wallet-sdk/).
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -154,7 +154,9 @@ or one whose anchor the wallet cannot resolve yet) do not spend the budget.
 `proveMigrationTransactions(accountUUID:_:maxProofs:)` no longer returns a bare `Int`. It returns
 `MigrationProveOutcome` — `totalProved` plus `preparationTxids`. **Breaking, with no deprecation
 period** (nothing here has shipped in a release): a caller that used the count reads
-`outcome.totalProved`.
+`outcome.totalProved`. The transaction-id handoff is semantically typed: `preparationTxids` is
+`[TxId]`, `takeMigrationPreparation(accountUUID:byTxid:)` takes `TxId`, and the returned
+`PreparedMigrationTransfer.txid` and `MigrationTransferResult.success(txId:)` both carry `TxId`.
 
 The ruling behind the new shape, verbatim in substance:
 
@@ -497,8 +499,9 @@ the app executes through the normal transaction pipeline, with one new call to r
   no engine plan cache behind it: nothing about the returned proposal can go stale the way a
   `MigrationSchedule` preview can, and `signAndStoreMigrationSchedule` is not part of this lane (it
   remains for `proposeMigrationTransfers`'s gradual path).
-- **New: `recordImmediateMigration(accountUUID:txid:) async throws`.** Call it after a successful
-  broadcast (software or Keystone lane) so the platform migration state machine reports the sweep:
+- **New: `recordImmediateMigration(accountUUID:txid:) async throws`.** Pass the broadcast
+  transaction's `TxId` after a successful broadcast (software or Keystone lane) so the platform
+  migration state machine reports the sweep:
   `InProgress(0 of 1)` while unmined, then a quiet `NotStarted` once it mines. A MINED immediate
   sweep is CONSUMED — it is NOT surfaced as `Complete`, so there is nothing for the user to
   acknowledge and no per-run completion screen (the sweep zeroes the spendable Orchard balance, so
@@ -575,7 +578,7 @@ behavior (`SDKSynchronizer` does):
 - **New: `migrationTransactionStatuses(accountUUID:) async throws -> [MigrationTransactionStatus]`.**
   The live per-transaction detail view behind `migrationProgress(accountUUID:)`'s aggregate
   summary: every committed migration transaction's kind (preparation layer/index or transfer
-  crossing), lifecycle state (`broadcast`/`mined` fold the engine's txid/mined-height payload into
+  crossing), lifecycle state (`broadcast(txid:)` carries `TxId`, while `mined` folds the engine's height into
   the matching case, so illegal combinations are unrepresentable — a MINED row's txid is NOT
   carried by the engine's own state model), scheduled/expiry heights, readiness, and next
   action/blocker, keyed by a stable id. A verbatim marshal of the engine's own

--- a/Sources/ZcashLightClientKit/Error/ZcashError.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashError.swift
@@ -582,9 +582,6 @@ public enum ZcashError: Equatable, Error {
     /// Thrown by MigrationBroadcaster when the dedicated migration Tor runtime or an isolated connection cannot be established before the submit attempt; the transaction was not broadcast.
     /// ZRUST0121
     case migrationTorUnavailable
-    /// The `txId` hex string carried by `MigrationTransferResult.success` did not decode to a 32-byte transaction id when calling ZcashRustBackend.migrationRecordTransferResult.
-    /// ZRUST0122
-    case migrationInvalidTxId(_ txId: String)
     /// The migration engine failed to record a successfully submitted broadcast. The broadcast DID land; the engine reconciles the transfer on a later execution attempt (a duplicate re-submission records as success) or when the mined transaction is scanned. The sync gate's in-flight marker is deliberately left set on this path and self-expires.
     /// - `error` is the underlying failure from ZcashRustBackend.migrationRecordTransferResult.
     /// ZRUST0124
@@ -1120,7 +1117,6 @@ public enum ZcashError: Equatable, Error {
         case .rustMigrationCreateUnsignedTransferPczts: return "Error from rust layer when calling ZcashRustBackend.migrationCreateUnsignedTransferPczts"
         case .rustMigrationStoreSignedSchedulePczts: return "Error from rust layer when calling ZcashRustBackend.migrationStoreSignedSchedulePczts"
         case .migrationTorUnavailable: return "Tor was requested for a migration broadcast but could not be established."
-        case .migrationInvalidTxId: return "The `txId` hex string carried by `MigrationTransferResult.success` did not decode to a 32-byte transaction id when calling ZcashRustBackend.migrationRecordTransferResult."
         case .migrationRecordFailedAfterBroadcast: return "The migration engine failed to record a successfully submitted broadcast. The broadcast DID land; the engine reconciles the transfer on a later execution attempt (a duplicate re-submission records as success) or when the mined transaction is scanned. The sync gate's in-flight marker is deliberately left set on this path and self-expires."
         case .migrationSyncBlocked: return "Synchronizer.start() was refused because the migration privacy gate is active."
         case .migrationBroadcastDuringSync: return "A broadcast-performing migration method was called while the synchronizer is actively syncing."
@@ -1391,7 +1387,6 @@ public enum ZcashError: Equatable, Error {
         case .rustMigrationCreateUnsignedTransferPczts: return .rustMigrationCreateUnsignedTransferPczts
         case .rustMigrationStoreSignedSchedulePczts: return .rustMigrationStoreSignedSchedulePczts
         case .migrationTorUnavailable: return .migrationTorUnavailable
-        case .migrationInvalidTxId: return .migrationInvalidTxId
         case .migrationRecordFailedAfterBroadcast: return .migrationRecordFailedAfterBroadcast
         case .migrationSyncBlocked: return .migrationSyncBlocked
         case .migrationBroadcastDuringSync: return .migrationBroadcastDuringSync

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
@@ -307,8 +307,6 @@ public enum ZcashErrorCode: String {
     case rustMigrationStoreSignedSchedulePczts = "ZRUST0120"
     /// Tor was requested for a migration broadcast but could not be established.
     case migrationTorUnavailable = "ZRUST0121"
-    /// The `txId` hex string carried by `MigrationTransferResult.success` did not decode to a 32-byte transaction id when calling ZcashRustBackend.migrationRecordTransferResult.
-    case migrationInvalidTxId = "ZRUST0122"
     /// The migration engine failed to record a successfully submitted broadcast. The broadcast DID land; the engine reconciles the transfer on a later execution attempt (a duplicate re-submission records as success) or when the mined transaction is scanned. The sync gate's in-flight marker is deliberately left set on this path and self-expires.
     case migrationRecordFailedAfterBroadcast = "ZRUST0124"
     /// Synchronizer.start() was refused because the migration privacy gate is active.

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
@@ -631,9 +631,6 @@ enum ZcashErrorDefinition {
     /// Thrown by MigrationBroadcaster when the dedicated migration Tor runtime or an isolated connection cannot be established before the submit attempt; the transaction was not broadcast.
     // sourcery: code="ZRUST0121"
     case migrationTorUnavailable
-    /// The `txId` hex string carried by `MigrationTransferResult.success` did not decode to a 32-byte transaction id when calling ZcashRustBackend.migrationRecordTransferResult.
-    // sourcery: code="ZRUST0122"
-    case migrationInvalidTxId(_ txId: String)
     /// The migration engine failed to record a successfully submitted broadcast. The broadcast DID land; the engine reconciles the transfer on a later execution attempt (a duplicate re-submission records as success) or when the mined transaction is scanned. The sync gate's in-flight marker is deliberately left set on this path and self-expires.
     /// - `error` is the underlying failure from ZcashRustBackend.migrationRecordTransferResult.
     // sourcery: code="ZRUST0124"

--- a/Sources/ZcashLightClientKit/Migration/MigrationBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Migration/MigrationBroadcaster.swift
@@ -138,7 +138,7 @@ actor MigrationBroadcaster: MigrationBroadcasting {
     /// 3. Anything else maps to ``MigrationTransferResult/invalidNote``. This InvalidNote/Expired
     ///    split is best-effort (the lightwalletd rejection reasons do not cleanly distinguish the
     ///    two); it mirrors the Android SDK's known ambiguity and is kept for parity.
-    static func map(outcome: MigrationBroadcastOutcome, successTxId: String) -> MigrationTransferResult {
+    static func map(outcome: MigrationBroadcastOutcome, successTxId: TxId) -> MigrationTransferResult {
         switch outcome {
         case .submitted:
             return MigrationTransferResult.success(txId: successTxId)
@@ -233,7 +233,7 @@ actor MigrationBroadcaster: MigrationBroadcasting {
         do {
             runtime = try await dedicatedTorClient()
         } catch {
-            logger.error("MigrationBroadcaster: dedicated Tor runtime unavailable: \(error)")
+            logger.error("MigrationBroadcaster: dedicated Tor runtime unavailable: \(error.localizedDescription)")
             throw ZcashError.migrationTorUnavailable
         }
 
@@ -242,7 +242,7 @@ actor MigrationBroadcaster: MigrationBroadcasting {
             let isolated = try await runtime.isolatedClient()
             connection = try await isolated.connectToLightwalletd(endpoint: endpoint.urlString)
         } catch {
-            logger.error("MigrationBroadcaster: could not open isolated Tor connection to \(endpoint.host):\(endpoint.port): \(error)")
+            logger.error("MigrationBroadcaster: Tor connection to \(endpoint.host):\(endpoint.port) failed: \(error.localizedDescription)")
             throw ZcashError.migrationTorUnavailable
         }
 
@@ -255,7 +255,7 @@ actor MigrationBroadcaster: MigrationBroadcasting {
             let response = try connection.submit(spendTransaction: rawTransaction)
             return outcome(from: response)
         } catch {
-            logger.error("MigrationBroadcaster: Tor submit transport failure: \(error)")
+            logger.error("MigrationBroadcaster: Tor submit transport failure: \(error.localizedDescription)")
             return MigrationBroadcastOutcome.transportError
         }
     }
@@ -277,7 +277,7 @@ actor MigrationBroadcaster: MigrationBroadcasting {
             return outcome(from: response)
         } catch {
             await service.closeConnections()
-            logger.error("MigrationBroadcaster: direct submit transport failure: \(error)")
+            logger.error("MigrationBroadcaster: direct submit transport failure: \(error.localizedDescription)")
             return MigrationBroadcastOutcome.transportError
         }
     }

--- a/Sources/ZcashLightClientKit/Migration/MigrationSyncGate.swift
+++ b/Sources/ZcashLightClientKit/Migration/MigrationSyncGate.swift
@@ -180,7 +180,7 @@ final class MigrationSyncGate: @unchecked Sendable {
         do {
             try BackupExcludedStorage.provision(directory: directory)
         } catch {
-            logger.warn("MigrationSyncGate: failed to provision the storage directory (backup exclusion may be missing): \(error)")
+            logger.warn("MigrationSyncGate: storage provisioning failed; backup exclusion may be missing: \(error.localizedDescription)")
         }
 
         // Load the in-memory `inFlightUntil` cache from the file exactly once, here -- every
@@ -518,7 +518,7 @@ final class MigrationSyncGate: @unchecked Sendable {
             let data = try JSONEncoder().encode(state)
             try data.write(to: fileURL, options: .atomic)
         } catch {
-            logger.warn("MigrationSyncGate: failed to persist sync-gate state: \(error)")
+            logger.warn("MigrationSyncGate: failed to persist sync-gate state: \(error.localizedDescription)")
         }
     }
 
@@ -536,7 +536,7 @@ final class MigrationSyncGate: @unchecked Sendable {
             }
             return state.inFlightUntilEpochSeconds.map { Date(timeIntervalSince1970: $0) }
         } catch {
-            logger.warn("MigrationSyncGate: ignoring corrupt sync-gate file: \(error)")
+            logger.warn("MigrationSyncGate: ignoring corrupt sync-gate file: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
@@ -404,15 +404,14 @@ actor OrchardMigration {
     /// Unlike ``performBroadcast(_:options:)`` this does NOT broadcast, so it is not serialized
     /// against the broadcast flows and carries no privacy options of its own: what the host does
     /// with the bytes, and over what transport, is the host's ordinary submission policy.
-    /// - Parameter txid: a txid ``MigrationProveOutcome/preparationTxids`` named, in the SDK's
-    ///   raw/internal byte order.
+    /// - Parameter txid: a txid ``MigrationProveOutcome/preparationTxids`` named.
     /// - Throws: ``ZcashError/migrationProvingUnavailable(_:)`` when the stored artifact cannot be
     ///   turned into servable bytes; ``ZcashError/rustMigrationTakePreparation(_:)`` for a
     ///   transfer's txid, for a txid the stored run does not carry, and for the readiness refusal
     ///   of a preparation that is not proved — which a host discharges by proving again rather
     ///   than retrying this.
-    func takePreparation(byTxid txid: Data) async throws -> PreparedMigrationTransfer {
-        try await welding.migrationTakePreparation(txid: txid, for: accountUUID)
+    func takePreparation(byTxid txid: TxId) async throws -> PreparedMigrationTransfer {
+        try await welding.migrationTakePreparation(txid: Data(txid.id), for: accountUUID)
     }
 
     /// Records the engine-side outcome of a preparation the host retrieved and submitted ITSELF —
@@ -619,8 +618,8 @@ actor OrchardMigration {
     /// the ordinary `createProposedTransactions`/`createTransactionFromPCZT` pipeline, already
     /// guarded there) -- this only records the outcome, so it is not gated by
     /// ``serializedBroadcastFlow(_:)``.
-    func recordImmediateMigration(txid: Data) async throws {
-        try await welding.migrationRecordImmediateRun(txid: txid, for: accountUUID)
+    func recordImmediateMigration(txid: TxId) async throws {
+        try await welding.migrationRecordImmediateRun(txid: Data(txid.id), for: accountUUID)
     }
 
     /// The leftover Orchard balance a migration would not cross, when large enough to be worth
@@ -900,7 +899,7 @@ actor OrchardMigration {
             throw error
         }
 
-        let result = MigrationBroadcaster.map(outcome: outcome, successTxId: prepared.txid.toHexStringTxId())
+        let result = MigrationBroadcaster.map(outcome: outcome, successTxId: prepared.txid)
         if case MigrationTransferResult.success = result {
             // The broadcast landed (or a duplicate rejection proved an earlier one did). Nothing
             // is armed here: the gate is behavior-based, so a completed broadcast leaves behind
@@ -912,7 +911,7 @@ actor OrchardMigration {
             } catch {
                 // Deliberately NOT clearing the in-flight marker: the result was never recorded,
                 // which is exactly the submit-to-record gap the marker guards; it self-expires.
-                logger.error("OrchardMigration: failed to record a successfully submitted broadcast: \(error)")
+                logger.error("OrchardMigration: failed to record a successfully submitted broadcast: \(error.localizedDescription)")
                 throw ZcashError.migrationRecordFailedAfterBroadcast(error)
             }
         } else {

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigrationHost.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigrationHost.swift
@@ -243,7 +243,7 @@ actor OrchardMigrationHost {
         do {
             accounts = try await welding.listAccounts()
         } catch {
-            logger.error("OrchardMigrationHost: failed to enumerate wallet accounts for the sync-blocked check; degrading to unblocked: \(error)")
+            logger.error("OrchardMigrationHost: account enumeration failed; treating sync as unblocked: \(error.localizedDescription)")
             return false
         }
 

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -413,9 +413,8 @@ public struct MigrationTransactionStatus: Equatable, Sendable {
         case signed
         /// Proven and ready to broadcast.
         case proved
-        /// Broadcast to the network as `txid` (the SDK's raw/internal byte order), not yet
-        /// observed mined.
-        case broadcast(txid: Data)
+        /// Broadcast to the network as `txid`, not yet observed mined.
+        case broadcast(txid: TxId)
         /// Mined at `height`.
         case mined(height: BlockHeight)
         /// Dead according to the engine's satisfiability oracle after a funding input became
@@ -838,17 +837,16 @@ public struct ImmediateMigrationProposal: Equatable {
 public struct PreparedMigrationTransfer: Equatable, Sendable {
     /// The transfer's engine-issued id.
     public let id: UInt32
-    /// The finalized transaction's id, in the SDK's raw/internal byte order (matching `TxId.id`,
-    /// not the reversed display-hex order produced by `Data.toHexStringTxId()`). Zeroed when the
+    /// The finalized transaction's id. Its bytes use the SDK's raw/internal byte order. Zeroed when the
     /// value is a STORAGE RECEIPT (`migrationStoreSignedNoteSplitPczts`) whose transaction has not
     /// been proven yet — the broadcastable value is served by the delivery lane.
-    public let txid: Data
+    public let txid: TxId
     /// The artifact: a finalized consensus transaction or a serialized PCZT per the producer, as
     /// the type doc above spells out. The property keeps its historical name.
     public let pczt: Data
 
     /// Creates a `PreparedMigrationTransfer`.
-    public init(id: UInt32, txid: Data, pczt: Data) {
+    public init(id: UInt32, txid: TxId, pczt: Data) {
         self.id = id
         self.txid = txid
         self.pczt = pczt
@@ -872,13 +870,12 @@ public struct PreparedMigrationTransfer: Equatable, Sendable {
 public struct MigrationProveOutcome: Equatable, Sendable {
     /// How many transactions this pass proved — preparations AND transfers.
     public let totalProved: Int
-    /// The proved preparations' txids, in the order they were proved, in the SDK's raw/internal
-    /// byte order (matching ``PreparedMigrationTransfer/txid``, not the reversed display-hex order
-    /// produced by `Data.toHexStringTxId()`). Empty when the pass proved no preparation.
-    public let preparationTxids: [Data]
+    /// The proved preparations' txids, in the order they were proved. Empty when the pass proved
+    /// no preparation.
+    public let preparationTxids: [TxId]
 
     /// Creates a `MigrationProveOutcome`.
-    public init(totalProved: Int, preparationTxids: [Data]) {
+    public init(totalProved: Int, preparationTxids: [TxId]) {
         self.totalProved = totalProved
         self.preparationTxids = preparationTxids
     }
@@ -889,11 +886,7 @@ public struct MigrationProveOutcome: Equatable, Sendable {
 /// `ZcashRustBackendWelding.migrationRecordTransferResult(transferId:result:for:)`.
 public enum MigrationTransferResult: Equatable, Sendable {
     /// The transfer was accepted by the network as `txId`.
-    ///
-    /// `txId` is the display-form hex-encoded transaction id: the same byte order produced by
-    /// `Data.toHexStringTxId()` and consumed by `TxId.init(_ id: String)` (reversed relative to
-    /// the transaction's raw/internal byte order), matching how the SDK renders txids elsewhere.
-    case success(txId: String)
+    case success(txId: TxId)
     /// The broadcast failed for a network-level reason; `retryable` indicates whether the
     /// platform should retry the same prepared transfer later.
     case networkError(retryable: Bool)

--- a/Sources/ZcashLightClientKit/Model/TxId.swift
+++ b/Sources/ZcashLightClientKit/Model/TxId.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TxId: Equatable, Hashable, Identifiable {
+public struct TxId: Equatable, Hashable, Identifiable, Sendable {
     static let byteLength = 32
 
     public var id: [UInt8]

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -2085,7 +2085,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         // The chunks' PREPARATION TXIDS accumulate across the whole pass, in prove order, so the
         // caller sees one handoff list for the pass rather than one per chunk.
         var totalProved = 0
-        var preparationTxids: [Data] = []
+        var preparationTxids: [TxId] = []
         while totalProved < maxProofs {
             // The last-error is cleared first so the message read on failure cannot be a
             // leftover from an earlier call on this thread.
@@ -2212,15 +2212,8 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
 
         switch result {
         case .success(let txId):
-            // `txId` is the display-form hex string (see `MigrationTransferResult.success`); the
-            // FFI wants the raw 32-byte internal-order id, so round-trip it through `TxId`, which
-            // both validates the length and undoes the display byte-reversal.
-            guard let parsedTxId = try? TxId(txId), parsedTxId.id.count == TxId.byteLength else {
-                throw ZcashError.migrationInvalidTxId(txId)
-            }
-
             resultTag = 0
-            txidBytes = parsedTxId.id
+            txidBytes = txId.id
         case .networkError:
             // `retryable` is a Swift-level signal for the caller's own retry policy; the rust
             // layer's behavior for a network error never depended on it (tag 1 alone drives it).
@@ -2962,7 +2955,7 @@ extension FfiMigrationTransactionStatus {
             decodedState = .proved
         case 3:
             guard has_txid else { return nil }
-            decodedState = .broadcast(txid: Data(FfiTxId(tuple: txid).array))
+            decodedState = .broadcast(txid: TxId(FfiTxId(tuple: txid).array))
         case 4:
             guard mined_height >= 0 else { return nil }
             decodedState = .mined(height: BlockHeight(mined_height))
@@ -3174,7 +3167,7 @@ extension FfiPreparedTransfer {
 
         return PreparedMigrationTransfer(
             id: id,
-            txid: Data(FfiTxId(tuple: txid).array),
+            txid: TxId(FfiTxId(tuple: txid).array),
             pczt: Data(bytes: pcztPtr, count: Int(pczt_len))
         )
     }
@@ -3187,12 +3180,12 @@ extension FfiMigrationProveOutcome {
     /// Total-only is a valid shape: a pass that proved transfers alone reports its count with no
     /// txids, because only preparations are retrievable.
     func unsafeToMigrationProveOutcome() -> MigrationProveOutcome {
-        var txids: [Data] = []
+        var txids: [TxId] = []
         txids.reserveCapacity(Int(preparation_txids_len))
 
         if let txidsPtr = preparation_txids {
             for index in 0 ..< Int(preparation_txids_len) {
-                txids.append(Data(FfiTxId(tuple: txidsPtr.advanced(by: index).pointee).array))
+                txids.append(TxId(FfiTxId(tuple: txidsPtr.advanced(by: index).pointee).array))
             }
         }
 

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -717,9 +717,7 @@ protocol ZcashRustBackendWelding {
     func migrationTakeBroadcastTransaction(id: UInt32, for account: AccountUUID) async throws -> PreparedMigrationTransfer
 
     /// Records the platform's broadcast outcome for `transferId`, advancing the engine's state.
-    /// - Throws: `rustMigrationRecordTransferResult` if the rust layer returns an error;
-    ///           `migrationInvalidTxId` if `result` is `.success` and its `txId` does not decode
-    ///           to a 32-byte transaction id.
+    /// - Throws: `rustMigrationRecordTransferResult` if the rust layer returns an error.
     func migrationRecordTransferResult(
         transferId: UInt32,
         result: MigrationTransferResult,

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -737,14 +737,13 @@ public protocol Synchronizer: AnyObject {
     /// against sync.
     /// - Parameters:
     ///   - accountUUID: the account whose preparation is being retrieved.
-    ///   - txid: a txid ``MigrationProveOutcome/preparationTxids`` named, in the SDK's
-    ///     raw/internal byte order.
+    ///   - txid: a txid ``MigrationProveOutcome/preparationTxids`` named.
     /// - Throws: ``ZcashError/migrationProvingUnavailable(_:)`` when the stored artifact cannot be
     ///   turned into servable bytes; ``ZcashError/rustMigrationTakePreparation(_:)`` for a
     ///   transfer's txid, for a txid the stored run does not carry, and for the readiness refusal
     ///   of a preparation that is not proved — which an app discharges by proving again rather
     ///   than retrying this.
-    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: Data) async throws -> PreparedMigrationTransfer
+    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: TxId) async throws -> PreparedMigrationTransfer
 
     /// Closes the seam: records the engine-side outcome of a preparation the app retrieved with
     /// ``takeMigrationPreparation(accountUUID:byTxid:)`` and submitted itself — the same per-row
@@ -924,9 +923,8 @@ public protocol Synchronizer: AnyObject {
     /// pipeline, so this call carries no ``ZcashError/migrationBroadcastDuringSync`` guard of its own.
     /// - Parameters:
     ///   - accountUUID: the account the immediate migration belongs to.
-    ///   - txid: the broadcast transaction's id, in the SDK's raw/internal byte order (32 bytes;
-    ///     matches `TxId.id`, not the reversed display-hex order produced by `Data.toHexStringTxId()`).
-    func recordImmediateMigration(accountUUID: AccountUUID, txid: Data) async throws
+    ///   - txid: the broadcast transaction's id.
+    func recordImmediateMigration(accountUUID: AccountUUID, txid: TxId) async throws
 
     /// The leftover Orchard balance a migration of `accountUUID` would not cross, when large enough
     /// to be worth offering the user a choice about; `nil` when there is no such residual.
@@ -1426,7 +1424,7 @@ public extension Synchronizer {
         throw MigrationUnimplemented(member: #function)
     }
 
-    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: Data) async throws -> PreparedMigrationTransfer {
+    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: TxId) async throws -> PreparedMigrationTransfer {
         throw MigrationUnimplemented(member: #function)
     }
 
@@ -1485,7 +1483,7 @@ public extension Synchronizer {
         throw MigrationUnimplemented(member: #function)
     }
 
-    func recordImmediateMigration(accountUUID: AccountUUID, txid: Data) async throws {
+    func recordImmediateMigration(accountUUID: AccountUUID, txid: TxId) async throws {
         throw MigrationUnimplemented(member: #function)
     }
 

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1227,7 +1227,7 @@ public class SDKSynchronizer: Synchronizer {
         try await migrationHost.migration(for: accountUUID).proveTransactions(instruction, maxProofs: maxProofs)
     }
 
-    public func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: Data) async throws -> PreparedMigrationTransfer {
+    public func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: TxId) async throws -> PreparedMigrationTransfer {
         try await migrationHost.migration(for: accountUUID).takePreparation(byTxid: txid)
     }
 
@@ -1287,7 +1287,7 @@ public class SDKSynchronizer: Synchronizer {
         try await migrationHost.migration(for: accountUUID).proposeImmediateMigration()
     }
 
-    public func recordImmediateMigration(accountUUID: AccountUUID, txid: Data) async throws {
+    public func recordImmediateMigration(accountUUID: AccountUUID, txid: TxId) async throws {
         try await migrationHost.migration(for: accountUUID).recordImmediateMigration(txid: txid)
     }
 

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -13,7 +13,7 @@
 //  Ported from the michal/MOB-1455-ironwood-migration-prototype-ffi branch (commit 86450d54) to the
 //  committed API, then updated again when the SDK-side `MigrationState`/`migrationState(for:)` state
 //  machine was replaced by the verbatim `migrationAdvanceStep(for:)` conduit:
-//  `MigrationTransferResult.success` takes `txId:` (display-hex) rather than `txid:`, and there is no
+//  `MigrationTransferResult.success` takes a semantic `TxId`, and there is no
 //  `migrationInitializePostUpgrade` in the committed surface -- account creation goes through the
 //  standard `createAccount` fixture pattern instead.
 //
@@ -275,7 +275,7 @@ final class MigrationFFITests: XCTestCase {
         do {
             try await rustBackend.migrationRecordTransferResult(
                 transferId: 4_294_967_295,
-                result: MigrationTransferResult.success(txId: String(repeating: "ab", count: 32)),
+                result: MigrationTransferResult.success(txId: TxId([UInt8](repeating: 0xAB, count: 32))),
                 for: account
             )
             XCTFail("Expected recording a success with no active migration run to throw")
@@ -502,7 +502,7 @@ final class MigrationFFITests: XCTestCase {
         do {
             try await rustBackend.migrationRecordTransferResult(
                 transferId: 4_294_967_295,
-                result: MigrationTransferResult.success(txId: String(repeating: "ab", count: 32)),
+                result: MigrationTransferResult.success(txId: TxId([UInt8](repeating: 0xAB, count: 32))),
                 for: account
             )
             XCTFail("Expected recording a result with no active migration run to throw")
@@ -570,7 +570,7 @@ final class MigrationFFITests: XCTestCase {
         let bytes = (0 ..< 32).map { UInt8($0) }
         let ffi = makeStatus(state: 3, txid: Self.tuple32(bytes), hasTxid: true)
         let decoded = try XCTUnwrap(ffi.unsafeToMigrationTransactionStatus())
-        XCTAssertEqual(decoded.state, .broadcast(txid: Data(bytes)))
+        XCTAssertEqual(decoded.state, .broadcast(txid: TxId(bytes)))
     }
 
     /// A mined row's txid is NOT carried by the engine's state model (`has_txid` drops back to
@@ -901,7 +901,7 @@ final class MigrationFFITests: XCTestCase {
 
         XCTAssertEqual(
             outcome.unsafeToMigrationProveOutcome(),
-            MigrationProveOutcome(totalProved: 3, preparationTxids: [Data(first), Data(second)]),
+            MigrationProveOutcome(totalProved: 3, preparationTxids: [TxId(first), TxId(second)]),
             "the total counts every kind; the txids marshal element-by-element, in buffer order"
         )
     }

--- a/Tests/OfflineTests/MigrationInstructionOpacityTests.swift
+++ b/Tests/OfflineTests/MigrationInstructionOpacityTests.swift
@@ -135,7 +135,7 @@ private func performDictate(
     on synchronizer: Synchronizer,
     options: MigrationNetworkPrivacyOptions,
     maxProofs: Int,
-    submitRawTransaction: (Data) async -> String?
+    submitRawTransaction: (Data) async -> TxId?
 ) async throws {
     switch advance?.step {
     case .prove(let instruction):

--- a/Tests/OfflineTests/MigrationLogicTests.swift
+++ b/Tests/OfflineTests/MigrationLogicTests.swift
@@ -14,6 +14,7 @@ import XCTest
 final class MigrationLogicTests: ZcashTestCase {
     private let accountA = AccountUUID(id: [UInt8](repeating: 0x11, count: 16))
     private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private let mappedTxId = TxId([UInt8](repeating: 0xAB, count: 32))
     private static let uaString = """
     u1l9f0l4348negsncgr9pxd9d3qaxagmqv3lnexcplmufpq7muffvfaue6ksevfvd7wrz7xrvn95rc5zjtn7ugkmgh5rnxswmcj30y0pw52pn0zjvy38rn2esfgve64rj5pcmazxgpyuj
     """
@@ -768,36 +769,36 @@ final class MigrationLogicTests: ZcashTestCase {
 
     func testMapTransportErrorIsRetryableNetworkError() {
         XCTAssertEqual(
-            MigrationBroadcaster.map(outcome: .transportError, successTxId: "unused"),
+            MigrationBroadcaster.map(outcome: .transportError, successTxId: mappedTxId),
             MigrationTransferResult.networkError(retryable: true)
         )
     }
 
     func testMapGenericRejectionIsInvalidNote() {
         XCTAssertEqual(
-            MigrationBroadcaster.map(outcome: .rejected(errorCode: -25, message: "missing inputs"), successTxId: "unused"),
+            MigrationBroadcaster.map(outcome: .rejected(errorCode: -25, message: "missing inputs"), successTxId: mappedTxId),
             MigrationTransferResult.invalidNote
         )
     }
 
     func testMapExpiringSoonRejectionIsExpired() {
         XCTAssertEqual(
-            MigrationBroadcaster.map(outcome: .rejected(errorCode: -26, message: "tx-expiring-soon"), successTxId: "unused"),
+            MigrationBroadcaster.map(outcome: .rejected(errorCode: -26, message: "tx-expiring-soon"), successTxId: mappedTxId),
             MigrationTransferResult.expired
         )
     }
 
     func testMapExpiredRejectionIsCaseInsensitive() {
         XCTAssertEqual(
-            MigrationBroadcaster.map(outcome: .rejected(errorCode: -1, message: "Transaction has EXPIRED"), successTxId: "unused"),
+            MigrationBroadcaster.map(outcome: .rejected(errorCode: -1, message: "Transaction has EXPIRED"), successTxId: mappedTxId),
             MigrationTransferResult.expired
         )
     }
 
     func testMapSuccessCarriesProvidedTxId() {
         XCTAssertEqual(
-            MigrationBroadcaster.map(outcome: .submitted, successTxId: "aabbccdd"),
-            MigrationTransferResult.success(txId: "aabbccdd")
+            MigrationBroadcaster.map(outcome: .submitted, successTxId: mappedTxId),
+            MigrationTransferResult.success(txId: mappedTxId)
         )
     }
 
@@ -810,9 +811,9 @@ final class MigrationLogicTests: ZcashTestCase {
         XCTAssertEqual(
             MigrationBroadcaster.map(
                 outcome: .rejected(errorCode: -27, message: "transaction verification failed"),
-                successTxId: "feedface"
+                successTxId: mappedTxId
             ),
-            MigrationTransferResult.success(txId: "feedface")
+            MigrationTransferResult.success(txId: mappedTxId)
         )
     }
 
@@ -829,8 +830,8 @@ final class MigrationLogicTests: ZcashTestCase {
 
         for message in duplicateMessages {
             XCTAssertEqual(
-                MigrationBroadcaster.map(outcome: .rejected(errorCode: -26, message: message), successTxId: "aabbccdd"),
-                MigrationTransferResult.success(txId: "aabbccdd"),
+                MigrationBroadcaster.map(outcome: .rejected(errorCode: -26, message: message), successTxId: mappedTxId),
+                MigrationTransferResult.success(txId: mappedTxId),
                 "expected duplicate message \"\(message)\" to map to success"
             )
         }
@@ -840,9 +841,9 @@ final class MigrationLogicTests: ZcashTestCase {
         XCTAssertEqual(
             MigrationBroadcaster.map(
                 outcome: .rejected(errorCode: -26, message: "Transaction ALREADY In Block Chain"),
-                successTxId: "aabbccdd"
+                successTxId: mappedTxId
             ),
-            MigrationTransferResult.success(txId: "aabbccdd")
+            MigrationTransferResult.success(txId: mappedTxId)
         )
     }
 
@@ -852,9 +853,9 @@ final class MigrationLogicTests: ZcashTestCase {
         XCTAssertEqual(
             MigrationBroadcaster.map(
                 outcome: .rejected(errorCode: -27, message: "transaction has expired"),
-                successTxId: "aabbccdd"
+                successTxId: mappedTxId
             ),
-            MigrationTransferResult.success(txId: "aabbccdd")
+            MigrationTransferResult.success(txId: mappedTxId)
         )
     }
 
@@ -864,7 +865,7 @@ final class MigrationLogicTests: ZcashTestCase {
         XCTAssertEqual(
             MigrationBroadcaster.map(
                 outcome: .rejected(errorCode: -25, message: "input already spent"),
-                successTxId: "unused"
+                successTxId: mappedTxId
             ),
             MigrationTransferResult.invalidNote
         )
@@ -980,11 +981,11 @@ final class MigrationLogicTests: ZcashTestCase {
             receivedAccount = account
         }
         let migration = makeMigration(welding: welding, account: accountA)
-        let txid = Data(repeating: 0xCD, count: 32)
+        let txid = TxId([UInt8](repeating: 0xCD, count: 32))
 
         try await migration.recordImmediateMigration(txid: txid)
 
-        XCTAssertEqual(receivedTxid, txid)
+        XCTAssertEqual(receivedTxid, Data(txid.id))
         XCTAssertEqual(receivedAccount, accountA)
     }
 
@@ -1102,7 +1103,7 @@ final class MigrationLogicTests: ZcashTestCase {
     func testPerformBroadcastFailsClosedOnTorUnavailableWithoutRecordingOrGating() async throws {
         let prepared = PreparedMigrationTransfer(
             id: 0,
-            txid: Data(repeating: 0xAB, count: 32),
+            txid: TxId([UInt8](repeating: 0xAB, count: 32)),
             pczt: Data([0x01, 0x02])
         )
         let welding = ZcashRustBackendWeldingMock()

--- a/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
@@ -63,7 +63,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         welding.migrationRecordTransferResultTransferIdResultForClosure = { transferId, result, _ in
             recorder.record("record")
             XCTAssertEqual(transferId, prepared.id)
-            XCTAssertEqual(result, MigrationTransferResult.success(txId: prepared.txid.toHexStringTxId()))
+            XCTAssertEqual(result, MigrationTransferResult.success(txId: prepared.txid))
             // Ordering proof: the submit-to-record window must still be open when record runs.
             XCTAssertNotNil(self.gate.currentInFlightUntil())
         }
@@ -78,7 +78,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             options: MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: defaultEndpoint)
         )
 
-        XCTAssertEqual(result, MigrationTransferResult.success(txId: prepared.txid.toHexStringTxId()))
+        XCTAssertEqual(result, MigrationTransferResult.success(txId: prepared.txid))
         XCTAssertEqual(recorder.events, ["sign", "broadcast", "record"])
         XCTAssertEqual(broadcaster.receivedCalls.count, 1)
         XCTAssertEqual(
@@ -213,10 +213,10 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             options: MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: defaultEndpoint)
         )
 
-        XCTAssertEqual(result, .success(txId: prepared.txid.toHexStringTxId()))
+        XCTAssertEqual(result, .success(txId: prepared.txid))
         XCTAssertEqual(
             welding.migrationRecordTransferResultTransferIdResultForReceivedArguments?.result,
-            MigrationTransferResult.success(txId: prepared.txid.toHexStringTxId())
+            MigrationTransferResult.success(txId: prepared.txid)
         )
         XCTAssertNil(gate.currentInFlightUntil(), "the recorded outcome closes the submit-to-record window")
         XCTAssertFalse(gate.currentlyBlocked(), "a completed broadcast leaves no timed hold behind")
@@ -363,15 +363,11 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     /// identical bytes is a no-op; those tests would stay green even if the byte-order reversal
     /// silently dropped out of `OrchardMigration.broadcastAndRecord`).
     ///
-    /// `expectedDisplayTxId` is hand-derived from the documented convention (reverse `prepared.txid`'s
-    /// byte order, then hex-encode -- see `PreparedMigrationTransfer.txid` and
-    /// `MigrationTransferResult.success`'s doc comments) independently of `Data.toHexStringTxId()`,
-    /// not produced by running it and pasting the output. See `TxIdTests` for the same convention
-    /// pinned directly against the conversion helpers themselves, off the actor.
+    /// The raw bytes are asymmetric, so the welding assertion below detects any accidental byte
+    /// reversal between the public semantic type and the FFI.
     func testPerformBroadcastRecordsTheDocumentedByteOrderForAnAsymmetricTxId() async throws {
         let rawTxId: [UInt8] = (0..<32).map { UInt8($0) }
-        let expectedDisplayTxId = "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100"
-        let prepared = PreparedMigrationTransfer(id: 1, txid: Data(rawTxId), pczt: Data([0x01, 0x02]))
+        let prepared = PreparedMigrationTransfer(id: 1, txid: TxId(rawTxId), pczt: Data([0x01, 0x02]))
         welding.migrationTakeBroadcastTransactionIdForReturnValue = prepared
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let broadcaster = ScriptedBroadcaster(script: .outcome(.submitted))
@@ -382,10 +378,10 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
             options: MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: defaultEndpoint)
         )
 
-        XCTAssertEqual(result, .success(txId: expectedDisplayTxId))
+        XCTAssertEqual(result, .success(txId: prepared.txid))
         XCTAssertEqual(
             welding.migrationRecordTransferResultTransferIdResultForReceivedArguments?.result,
-            MigrationTransferResult.success(txId: expectedDisplayTxId)
+            MigrationTransferResult.success(txId: prepared.txid)
         )
     }
 
@@ -605,7 +601,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     /// the OUTCOME the engine reports — count and preparation txids alike, passed through
     /// untouched (no kind judgment of its own: the engine's return already carries it).
     func testProveTransactionsNamesTheInstructionsIdsWithoutCrankingTheDrive() async throws {
-        let preparationTxid = Data(repeating: 8, count: 32)
+        let preparationTxid = TxId([UInt8](repeating: 8, count: 32))
         welding.migrationProveTransactionsIdsMaxProofsForReturnValue =
             MigrationProveOutcome(totalProved: 2, preparationTxids: [preparationTxid])
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
@@ -701,7 +697,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         ]
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
-        let landed = MigrationTransferResult.success(txId: prepared.txid.toHexStringTxId())
+        let landed = MigrationTransferResult.success(txId: prepared.txid)
 
         try await migration.recordPreparationBroadcast(prepared, result: landed)
 
@@ -723,7 +719,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
         do {
-            try await migration.recordPreparationBroadcast(prepared, result: .success(txId: "landed"))
+            try await migration.recordPreparationBroadcast(prepared, result: .success(txId: prepared.txid))
             XCTFail("a transfer's id must be refused")
         } catch let ZcashError.rustMigrationRecordTransferResult(message) {
             XCTAssertTrue(
@@ -749,7 +745,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
         do {
-            try await migration.recordPreparationBroadcast(prepared, result: .success(txId: "landed"))
+            try await migration.recordPreparationBroadcast(prepared, result: .success(txId: prepared.txid))
             XCTFail("an id the run does not carry must be refused")
         } catch let ZcashError.rustMigrationRecordTransferResult(message) {
             XCTAssertTrue(message.contains("no migration transaction with id 99"), "got: \(message)")
@@ -814,7 +810,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
 
         let broadcastsStarted = await broadcaster.startedCount
         XCTAssertEqual(broadcastsStarted, 1, "the same due transfer must be broadcast exactly once")
-        XCTAssertEqual(firstResult, .success(txId: prepared.txid.toHexStringTxId()))
+        XCTAssertEqual(firstResult, .success(txId: prepared.txid))
         XCTAssertFalse(
             welding.migrationAdvanceStepForEstimatedTipCalled,
             "neither caller advances: the executor is not a lane with a mind of its own"
@@ -870,8 +866,8 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         let transferResult = try await transferCall.value
         let splitResult = try await splitCall.value
 
-        XCTAssertEqual(transferResult, .success(txId: dueTransfer.txid.toHexStringTxId()))
-        XCTAssertEqual(splitResult, MigrationTransferResult.success(txId: splitTransfer.txid.toHexStringTxId()))
+        XCTAssertEqual(transferResult, .success(txId: dueTransfer.txid))
+        XCTAssertEqual(splitResult, MigrationTransferResult.success(txId: splitTransfer.txid))
         let broadcastsStarted = await broadcaster.startedCount
         XCTAssertEqual(broadcastsStarted, 2, "each flow broadcasts its own transaction, strictly serialized")
         XCTAssertEqual(
@@ -915,7 +911,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         )
 
         XCTAssertEqual(instruction.id, prepTransfer.id)
-        XCTAssertEqual(result, .success(txId: prepTransfer.txid.toHexStringTxId()))
+        XCTAssertEqual(result, .success(txId: prepTransfer.txid))
         XCTAssertEqual(welding.migrationRecordTransferResultTransferIdResultForReceivedArguments?.transferId, prepTransfer.id)
     }
 
@@ -1052,7 +1048,7 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     }
 
     private func makePreparedTransfer(id: UInt32) -> PreparedMigrationTransfer {
-        PreparedMigrationTransfer(id: id, txid: Data(repeating: 0xAB, count: 32), pczt: Data([0x01, 0x02]))
+        PreparedMigrationTransfer(id: id, txid: TxId([UInt8](repeating: 0xAB, count: 32)), pczt: Data([0x01, 0x02]))
     }
 }
 

--- a/Tests/OfflineTests/OrchardMigrationHostTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationHostTests.swift
@@ -75,7 +75,7 @@ final class OrchardMigrationHostTests: ZcashTestCase {
 
         let prepared = PreparedMigrationTransfer(
             id: 0,
-            txid: Data(repeating: 0xAB, count: 32),
+            txid: TxId([UInt8](repeating: 0xAB, count: 32)),
             pczt: Data([0x01, 0x02])
         )
         // Fulfilled from account B's own actor, right before it hands off to the shared broadcaster
@@ -301,7 +301,7 @@ final class OrchardMigrationHostTests: ZcashTestCase {
         welding.listAccountsReturnValue = [makeAccount(accountA)]
         welding.migrationTakeBroadcastTransactionIdForReturnValue = PreparedMigrationTransfer(
             id: 0,
-            txid: Data(repeating: 0xAB, count: 32),
+            txid: TxId([UInt8](repeating: 0xAB, count: 32)),
             pczt: Data([0x01, 0x02])
         )
         welding.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -304,11 +304,11 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
             receivedAccount = account
         }
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
-        let txid = Data(repeating: 0xEF, count: 32)
+        let txid = TxId([UInt8](repeating: 0xEF, count: 32))
 
         try await synchronizer.recordImmediateMigration(accountUUID: accountUUID, txid: txid)
 
-        XCTAssertEqual(receivedTxid, txid)
+        XCTAssertEqual(receivedTxid, Data(txid.id))
         XCTAssertEqual(receivedAccount, accountUUID)
     }
 
@@ -746,7 +746,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         do {
             _ = try await synchronizer.takeMigrationPreparation(
                 accountUUID: accountUUID,
-                byTxid: Data(repeating: 7, count: 32)
+                byTxid: TxId([UInt8](repeating: 7, count: 32))
             )
             XCTFail("expected the stubbed take-preparation failure to propagate")
         } catch let error as StubTakePreparationFailure {
@@ -764,7 +764,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
     /// included, which is what lets a host record the submission's outcome with no identity of
     /// its own.
     func testTakeMigrationPreparationPassesTheTxidThroughAndReturnsTheEngineId() async throws {
-        let txid = Data(repeating: 0x5A, count: 32)
+        let txid = TxId([UInt8](repeating: 0x5A, count: 32))
         let welding = ZcashRustBackendWeldingMock()
         welding.migrationTakePreparationTxidForReturnValue = PreparedMigrationTransfer(
             id: 11,
@@ -778,7 +778,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         XCTAssertEqual(prepared.id, 11, "the engine transfer id crosses the surface")
         XCTAssertEqual(prepared.txid, txid)
         XCTAssertEqual(prepared.pczt, Data([0xDE, 0xAD, 0xBE, 0xEF]), "the finalized transaction is submittable as-is")
-        XCTAssertEqual(welding.migrationTakePreparationTxidForReceivedArguments?.txid, txid)
+        XCTAssertEqual(welding.migrationTakePreparationTxidForReceivedArguments?.txid, Data(txid.id))
         XCTAssertEqual(welding.migrationTakePreparationTxidForReceivedArguments?.account, accountUUID)
     }
 
@@ -806,11 +806,11 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
         await synchronizer.updateStatus(.syncing(0.5, false))
 
-        let prepared = PreparedMigrationTransfer(id: 5, txid: Data(repeating: 0x5A, count: 32), pczt: Data([0x01]))
+        let prepared = PreparedMigrationTransfer(id: 5, txid: TxId([UInt8](repeating: 0x5A, count: 32)), pczt: Data([0x01]))
         try await synchronizer.recordMigrationPreparationBroadcast(
             accountUUID: accountUUID,
             prepared,
-            result: .success(txId: prepared.txid.toHexStringTxId())
+            result: .success(txId: prepared.txid)
         )
 
         let received = try XCTUnwrap(welding.migrationRecordTransferResultTransferIdResultForReceivedArguments)

--- a/Tests/OfflineTests/SynchronizerMigrationDefaultsTests.swift
+++ b/Tests/OfflineTests/SynchronizerMigrationDefaultsTests.swift
@@ -101,7 +101,10 @@ final class SynchronizerMigrationDefaultsTests: XCTestCase {
 
     func testRecordImmediateMigrationDefaultThrowsUnimplemented() async {
         await assertThrowsMigrationUnimplemented {
-            try await self.synchronizer.recordImmediateMigration(accountUUID: self.accountUUID, txid: Data(repeating: 0x01, count: 32))
+            try await self.synchronizer.recordImmediateMigration(
+                accountUUID: self.accountUUID,
+                txid: TxId([UInt8](repeating: 0x01, count: 32))
+            )
         }
     }
 

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2776,11 +2776,11 @@ class SynchronizerMock: Synchronizer {
     var takeMigrationPreparationAccountUUIDByTxidCalled: Bool {
         return takeMigrationPreparationAccountUUIDByTxidCallsCount > 0
     }
-    var takeMigrationPreparationAccountUUIDByTxidReceivedArguments: (accountUUID: AccountUUID, txid: Data)?
+    var takeMigrationPreparationAccountUUIDByTxidReceivedArguments: (accountUUID: AccountUUID, txid: TxId)?
     var takeMigrationPreparationAccountUUIDByTxidReturnValue: PreparedMigrationTransfer!
-    var takeMigrationPreparationAccountUUIDByTxidClosure: ((AccountUUID, Data) async throws -> PreparedMigrationTransfer)?
+    var takeMigrationPreparationAccountUUIDByTxidClosure: ((AccountUUID, TxId) async throws -> PreparedMigrationTransfer)?
 
-    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: Data) async throws -> PreparedMigrationTransfer {
+    func takeMigrationPreparation(accountUUID: AccountUUID, byTxid txid: TxId) async throws -> PreparedMigrationTransfer {
         if let error = takeMigrationPreparationAccountUUIDByTxidThrowableError {
             throw error
         }
@@ -3051,10 +3051,10 @@ class SynchronizerMock: Synchronizer {
     var recordImmediateMigrationAccountUUIDTxidCalled: Bool {
         return recordImmediateMigrationAccountUUIDTxidCallsCount > 0
     }
-    var recordImmediateMigrationAccountUUIDTxidReceivedArguments: (accountUUID: AccountUUID, txid: Data)?
-    var recordImmediateMigrationAccountUUIDTxidClosure: ((AccountUUID, Data) async throws -> Void)?
+    var recordImmediateMigrationAccountUUIDTxidReceivedArguments: (accountUUID: AccountUUID, txid: TxId)?
+    var recordImmediateMigrationAccountUUIDTxidClosure: ((AccountUUID, TxId) async throws -> Void)?
 
-    func recordImmediateMigration(accountUUID: AccountUUID, txid: Data) async throws {
+    func recordImmediateMigration(accountUUID: AccountUUID, txid: TxId) async throws {
         if let error = recordImmediateMigrationAccountUUIDTxidThrowableError {
             throw error
         }


### PR DESCRIPTION
Addresses the blockers identified in the final review comment on #1984.

Changes:
- log migration errors through `localizedDescription` so sensitive FFI-associated values are not reflected into logs
- use `TxId` across the new public migration transaction-id surface, converting to raw bytes only at the welding/FFI boundary
- remove the now-unreachable raw-string migration txid validation error and regenerate generated errors/mocks
- remove trailing whitespace from the sample README
- update the 3.0 migration documentation and changelog to describe the final semantic API shape

The review also referenced `Scripts/tests/test-workflow.sh` and `make test-scripts`. Neither exists in the live `review/3.0.0` target (GitHub returns 404 for that path at target SHA `d2935976`), so there is no workflow-test change to apply in this PR. The corrected run-block-only scanner exists on the separate `ci/run-script-interpolation-test` line.

Test plan:
- [x] `make ffi-all`
- [x] `make check`
- [x] `make lint` (passes with pre-existing warnings)
- [x] `./Scripts/update-proposal-proto.sh --check`
- [x] `git diff --check`
- [x] audit `Sources/ZcashLightClientKit/Migration/` for direct `\(error)` interpolation
- [x] audit the new public migration surface for primitive transaction-id types
- [ ] Manual testnet verification: not applicable; these changes alter type safety and log rendering without changing migration behavior or the FFI contract.